### PR TITLE
chore: automated patch release v4.15.13

### DIFF
--- a/version-compatibility-matrix.json
+++ b/version-compatibility-matrix.json
@@ -1,5 +1,5 @@
 {
-  "last_updated": "2026-03-29T22:08:15Z",
+  "last_updated": "2026-03-29T22:08:44Z",
   "base_images": [
     {
       "name": "debian:11-slim",
@@ -73,7 +73,7 @@
       "base_image": "debian:13-slim",
       "versions": {},
       "status": "passing",
-      "tested_at": "2026-03-29T22:08:15Z",
+      "tested_at": "2026-03-29T22:08:44Z",
       "notes": "Base system only, no language runtimes"
     },
     {
@@ -83,7 +83,7 @@
         "python": "3.14.3"
       },
       "status": "passing",
-      "tested_at": "2026-03-29T22:08:15Z"
+      "tested_at": "2026-03-29T22:08:44Z"
     },
     {
       "variant": "node-dev",
@@ -92,7 +92,7 @@
         "node": "22"
       },
       "status": "passing",
-      "tested_at": "2026-03-29T22:08:15Z"
+      "tested_at": "2026-03-29T22:08:44Z"
     },
     {
       "variant": "rust-golang",
@@ -102,14 +102,14 @@
         "go": "1.26.1"
       },
       "status": "passing",
-      "tested_at": "2026-03-29T22:08:15Z"
+      "tested_at": "2026-03-29T22:08:44Z"
     },
     {
       "variant": "cloud-ops",
       "base_image": "debian:13-slim",
       "versions": {},
       "status": "passing",
-      "tested_at": "2026-03-29T22:08:15Z",
+      "tested_at": "2026-03-29T22:08:44Z",
       "notes": "Docker, Kubernetes, Terraform, AWS CLI"
     },
     {
@@ -122,7 +122,7 @@
         "go": "1.26.1"
       },
       "status": "passing",
-      "tested_at": "2026-03-29T22:08:15Z"
+      "tested_at": "2026-03-29T22:08:44Z"
     }
   ]
 }


### PR DESCRIPTION
## Automated Patch Release v4.15.13

chore: Update compatibility matrix with passing test results

---
All CI tests have passed. This PR was created by the automated patch release system.