### PR TITLE
fix(dev-tools): gunzip install path produced gzipped binaries; add nmap

### DIFF
--- a/lib/features/dev-tools.sh
+++ b/lib/features/dev-tools.sh
@@ -160,9 +160,11 @@ else
 fi
 
 # Network debugging tools
+# nmap package also provides ncat (feature-rich netcat) and nping
 log_message "Installing network debugging tools..."
 apt_install \
     netcat-openbsd \
+    nmap \
     dnsutils \
     iputils-ping \
     traceroute

--- a/lib/features/lib/install-github-release.sh
+++ b/lib/features/lib/install-github-release.sh
@@ -221,18 +221,23 @@ install_github_release() {
                 dpkg -i "$local_file"
             ;;
         gunzip)
+            # gunzip refuses in-place decompression unless the source file
+            # carries a recognized suffix (.gz/.tgz/-gz/.Z/-Z/.z/_z). Our
+            # download is saved as "${tool_name}-download" (no extension),
+            # so rename first, then gunzip produces $local_file.
+            command mv "$local_file" "${local_file}.gz"
             log_command "Extracting ${tool_name}" \
-                gunzip "$local_file"
-            # After gunzip, the file loses the extension — find the decompressed file
-            local decompressed
-            decompressed=$(command find . -maxdepth 1 -type f ! -name "*.gz" | command head -1)
-            if [ -z "$decompressed" ]; then
-                log_error "Decompressed file not found for ${tool_name}"
+                gunzip "${local_file}.gz"
+            # If the decompressed file isn't present, gunzip failed even
+            # though log_command's pipeline may have swallowed its exit
+            # status (tee's success masks upstream non-zero).
+            if [ ! -f "$local_file" ]; then
+                log_error "Decompressed file not found for ${tool_name} (gunzip failed)"
                 cd /
                 return 1
             fi
             log_command "Installing ${tool_name} binary" \
-                command mv "$decompressed" "/usr/local/bin/${tool_name}"
+                command mv "$local_file" "/usr/local/bin/${tool_name}"
             log_command "Setting ${tool_name} permissions" \
                 chmod +x "/usr/local/bin/${tool_name}"
             ;;

--- a/tests/unit/features/lib/install-github-release.sh
+++ b/tests/unit/features/lib/install-github-release.sh
@@ -580,10 +580,18 @@ $(_mock_preamble)
 dpkg() { echo 'amd64'; }
 export -f dpkg
 
-# Mock gunzip to simulate decompression (remove the file, create uncompressed)
+# Mock gunzip matching real semantics: requires a .gz suffix, produces
+# the .gz-stripped filename. Without the suffix it errors out (matching
+# real gunzip) — this catches the regression where the script forgets
+# to rename the download before decompressing.
 gunzip() {
-    rm -f \"\$1\"
-    echo 'decompressed-content' > ./mytool-decompressed
+    local input=\"\$1\"
+    if [[ \"\$input\" != *.gz ]]; then
+        echo \"gzip: \$input: unknown suffix -- ignored\" >&2
+        return 2
+    fi
+    rm -f \"\$input\"
+    echo 'decompressed-content' > \"\${input%.gz}\"
 }
 export -f gunzip
 


### PR DESCRIPTION
## Summary
Two related dev-tools fixes:

1. **gunzip install type was shipping gzipped files as "binaries"**
   `install_github_release` downloads to `${tool_name}-download` (no suffix) and then called `gunzip "$local_file"`. Real gunzip refuses in-place decompression without a recognized suffix (`gzip: …: unknown suffix -- ignored`, exit 2). `log_command`'s pipeline (`"$@" 2>&1 | tee`) returns tee's status and masked the failure. The fallback `find ! -name "*.gz"` then picked up the still-compressed download and `mv`'d it to `/usr/local/bin/${tool_name}`, reporting success.

   On-host check before the fix:
   ```
   $ head -c 4 /usr/local/bin/lefthook | od -An -tx1
    1f 8b 08 08
   $ /usr/local/bin/lefthook version
   bash: /usr/local/bin/lefthook: cannot execute binary file: Exec format error
   ```

   Affected tools: `lefthook` (broken on recent builds) and `taplo` (broken when `rust-dev` is absent — with `rust-dev`, cargo's taplo wins via PATH and masks it). Every other `install_github_release` caller uses `extract:*`, `extract_flat:*`, `zip_to:*`, `dpkg`, or genuine-bare-binary `binary` paths — all confirmed clean via magic-byte audit.

   **Fix**: rename to `.gz` before calling gunzip, then verify the expected decompressed path exists before moving it into place. Dropped the fragile find-fallback (which was what let the bad state masquerade as success).

   **Test change**: the existing `test_install_gunzip` mocked gunzip to unconditionally produce `./mytool-decompressed`, which hid the bug. Updated to match real gunzip semantics (reject non-`.gz` input, strip suffix on success) so this regression can't slip past tests again.

2. **Add `nmap` to dev-tools network tools**
   `ncat`/`nping` have come up repeatedly when debugging container networking. The `nmap` package ships all three. Installed alongside the existing `netcat-openbsd`.

## Test plan
- [x] `./tests/run_unit_tests.sh` — 2922 passed, 0 failed (3 skipped)
- [x] `shellcheck --severity=warning` on all changed files — clean
- [x] Magic-byte audit on a running container — surveyed `direnv`, `mkcert`, `biome`, `osv-scanner`, `yq`, `lefthook`, `taplo`, `just`, `lazygit`, `delta`, `git-cliff` — only `lefthook`/`taplo` affected
- [ ] Fresh `INCLUDE_DEV_TOOLS=true` container: `file /usr/local/bin/lefthook` reports ELF, `lefthook version` runs, `ncat --version` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)