### PR TITLE
chore: scoped just lint/test recipes + use them in lefthook hooks

### DIFF
--- a/justfile
+++ b/justfile
@@ -13,8 +13,32 @@ default:
 # Tests
 # ============================================================================
 
-# Full test suite (Rust + shell unit + Rust lint). For integration tests run `just test-integration`.
-test: test-rust lint-rust test-shell
+# Test suite. Default: rust tests + clippy + fmt --check + shell unit. Scopes: v5, v4, stibbons, containers-common (integration stays in `just test-integration`).
+test SCOPE="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    case "{{ SCOPE }}" in
+      "")
+          cargo test --workspace
+          cargo clippy --workspace -- -D warnings
+          cargo fmt --all -- --check
+          ./tests/run_unit_tests.sh
+          ;;
+      v5)
+          cargo test --workspace
+          ;;
+      v4)
+          ./tests/run_unit_tests.sh
+          ;;
+      stibbons|containers-common)
+          cargo test -p "{{ SCOPE }}"
+          ;;
+      *)
+          echo "Unknown scope: {{ SCOPE }}" >&2
+          echo "Valid scopes: v5, v4, stibbons, containers-common" >&2
+          exit 2
+          ;;
+    esac
 
 # Rust workspace tests (stibbons + containers-common)
 test-rust:
@@ -47,9 +71,35 @@ test-all: test test-integration
 # Lint & format
 # ============================================================================
 
-# Run every linter lefthook would run on a full pass.
-lint:
-    lefthook run pre-commit --all-files
+# Lint. Default: full lefthook pre-commit sweep. Scopes: v5 (rust workspace), v4 (shellcheck+shfmt), stibbons, containers-common.
+lint SCOPE="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    case "{{ SCOPE }}" in
+      "")
+          lefthook run pre-commit --all-files
+          ;;
+      v5)
+          cargo clippy --workspace -- -D warnings
+          cargo fmt --all -- --check
+          ;;
+      v4)
+          files=$(git ls-files '*.sh' | /usr/bin/grep -v '^tests/results/' || true)
+          if [ -n "$files" ]; then
+              echo "$files" | xargs -r shellcheck --severity=warning
+              echo "$files" | xargs -r shfmt -d -i 4 -ci
+          fi
+          ;;
+      stibbons|containers-common)
+          cargo clippy -p "{{ SCOPE }}" --all-targets -- -D warnings
+          cargo fmt -p "{{ SCOPE }}" -- --check
+          ;;
+      *)
+          echo "Unknown scope: {{ SCOPE }}" >&2
+          echo "Valid scopes: v5, v4, stibbons, containers-common" >&2
+          exit 2
+          ;;
+    esac
 
 # Rust lint: clippy (pedantic + nursery, warnings as errors) and fmt --check
 lint-rust:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -131,14 +131,25 @@ pre-commit:
       run: gitleaks protect --staged --verbose --redact
 
     # --- Rust linting (stibbons) ---
+    #
+    # Single hook delegating to `just lint <scope>` (fmt --check + clippy).
+    # Derives scope from staged file paths: each distinct `crates/<name>/…`
+    # becomes one `just lint <name>` call. Falls back to `just lint v5`
+    # (workspace) if no crate path is detectable — e.g., root `Cargo.toml`
+    # or `.rustfmt.toml` changes.
 
-    cargo-fmt:
+    cargo-lint:
       glob: "{crates/**/*.rs,.rustfmt.toml,Cargo.toml}"
-      run: cargo fmt --check
-
-    cargo-clippy:
-      glob: "{crates/**/*.rs,Cargo.toml}"
-      run: cargo clippy --workspace -- -D warnings
+      run: |
+        crates=$(/usr/bin/printf '%s\n' {staged_files} \
+          | /usr/bin/grep '^crates/' \
+          | /usr/bin/cut -d/ -f2 \
+          | /usr/bin/sort -u)
+        if [ -z "$crates" ]; then
+          just lint v5
+        else
+          for c in $crates; do just lint "$c"; done
+        fi
 
     # --- Custom hooks ---
 
@@ -192,12 +203,28 @@ pre-push:
 
     cargo-test:
       glob: "{crates/**/*.rs,Cargo.toml}"
-      run: cargo test --workspace
+      run: |
+        crates=$(/usr/bin/printf '%s\n' {push_files} \
+          | /usr/bin/grep '^crates/' \
+          | /usr/bin/cut -d/ -f2 \
+          | /usr/bin/sort -u)
+        if [ -z "$crates" ]; then
+          just test v5
+        else
+          for c in $crates; do just test "$c"; done
+        fi
 
-    # Spell-check (crate-ci/typos) — scans the working tree, respects
-    # _typos.toml excludes. Fast enough to skip a staged-files filter.
+    # Spell-check (crate-ci/typos) — scoped to pushed files when possible,
+    # falls back to a full-tree scan when there's no push file list (e.g.
+    # first push of a branch, or when only non-tracked paths changed).
     typos:
-      run: typos
+      run: |
+        files="{push_files}"
+        if [ -n "$files" ]; then
+          typos $files
+        else
+          typos
+        fi
 
     docker-compose-validate:
       run: |


### PR DESCRIPTION
## Summary

Two-commit PR that (1) adds scoped variants of `just lint` and `just test`, and (2) immediately uses them to make lefthook hooks scale with what you changed rather than with workspace size.

### Commit 1 — scoped recipes (closes #388)

- `just lint <scope>` and `just test <scope>` accept an optional `SCOPE` argument. Unknown scopes exit 2 with the valid list.
- Scopes:
  - `v5` — full rust workspace (clippy + fmt --check; or cargo test --workspace)
  - `v4` — shellcheck + shfmt -d over tracked `*.sh` (minus `tests/results/`); for test: `./tests/run_unit_tests.sh`
  - `stibbons` — that crate only
  - `containers-common` — that crate only
- Default (no arg) `just lint` / `just test` behavior is unchanged. `test-all: (test) test-integration` still resolves via just's zero-arg dep invocation.
- CI is unaffected — workflows already call the underlying commands directly, not the `just` recipes.

### Commit 2 — lefthook uses the new recipes

**Pre-commit**
- Collapse `cargo-fmt` + `cargo-clippy` into a single `cargo-lint` hook.
- Derive crate scope from `{staged_files}` paths (`crates/<name>/…`); call `just lint <name>` per crate.
- Fall back to `just lint v5` when only root `Cargo.toml` or `.rustfmt.toml` is staged.
- Tradeoff called out in the commit body: loses intra-hook fmt/clippy parallelism (both sub-second), gains a single source of truth.

**Pre-push**
- `cargo-test` derives crate scope from `{push_files}`, calls `just test <name>` per crate, falls back to `just test v5`.
- `typos` now takes `{push_files}` as explicit args when non-empty; falls back to a full-tree scan otherwise.

## Test plan

- [x] `just --list` shows `test SCOPE=""` and `lint SCOPE=""` with one-line summaries naming valid scopes
- [x] `just lint containers-common` — ~2s
- [x] `just test containers-common` — ~2.7s (54 tests pass)
- [x] `just lint stibbons` — ~1.7s
- [x] `just lint v5` — ~0.3s (cached workspace clippy + fmt)
- [x] `just lint v4` — ~35s clean (shellcheck + shfmt -d over all tracked `*.sh`)
- [x] `just lint bogus` / `just test bogus` — exit 2 with `Valid scopes: …`
- [x] `just --show test-all` resolves `test-all: (test) test-integration`
- [x] `cargo test --workspace` — all binaries pass
- [x] `lefthook run pre-commit --file crates/stibbons/src/main.rs --command cargo-lint` — 0.5s, stibbons-only
- [x] `lefthook run pre-commit --file Cargo.toml --command cargo-lint` — falls back to `just lint v5` cleanly
- [x] `lefthook run pre-push --file crates/containers-common/src/lib.rs --command cargo-test` — 0.3s, 54 tests, containers-common-only
- [x] Real push dogfooded the new pre-push hooks: typos 0.15s on scoped files, cargo-test correctly skipped (no crate files changed)
- [x] Lefthook pre-commit + commit-msg hooks pass on every commit in this branch

Closes #388