### PR TITLE
fix(ci): make release uploads idempotent and security scan submodule-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -977,7 +977,30 @@ jobs:
           \`\`\`
           EOF
 
+      # Skip release-asset upload when the release is already immutable.
+      # Why: GitHub returns 422 ("Cannot delete asset from an immutable
+      # release") if action-gh-release tries to overwrite assets, and any
+      # rerun of this job on an immutable release would otherwise fail.
+      # Cosign signing/attestation above is idempotent against ghcr, so the
+      # rerun's other side effects are still correct.
+      - name: Check release immutability
+        id: release_state
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.VERSION }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          IMMUTABLE=$(gh api "repos/${GH_REPO}/releases/tags/${VERSION}" \
+            --jq '.immutable // false' 2>/dev/null || echo "false")
+          if [ "${IMMUTABLE}" = "true" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Release ${VERSION} is immutable — skipping asset upload."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create GitHub Release
+        if: steps.release_state.outputs.skip != 'true'
         uses: softprops/action-gh-release@v2
         with:
           body_path: release-notes.md

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -18,6 +18,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # Force HTTPS for any cargo git fetches that recurse into submodules
+      # declared with ssh:// URLs (e.g. octarine's `containers` submodule).
+      # The runner has no SSH key for github.com, so without this rewrite
+      # `cargo metadata` (used by cargo-deny / cargo-audit) fails to walk
+      # transitive git deps.
+      - name: Rewrite SSH GitHub URLs to HTTPS
+        run: |
+          git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
+
       - name: Install just (task runner)
         uses: extractions/setup-just@v2
 


### PR DESCRIPTION
## Summary

Two independent CI failures observed on 2026-04-27, fixed together since both are tiny workflow tweaks:

### 1. Create Release — `Cannot delete asset from an immutable release`

The v4.18.1 tag was repointed (one-off correction for an earlier auto-patch bug), so CI reran on the new tag target after GitHub had already marked the release immutable. `softprops/action-gh-release@v2` always deletes-then-reuploads its `files:`, which 422s on immutable releases.

Fix: precheck the release's `.immutable` flag and skip the upload step when true. Cosign signing/attestation above is already idempotent against ghcr, so a rerun's other side effects remain correct.

Failure run: https://github.com/joshjhall/containers/actions/runs/24977086245

### 2. Scheduled security scan — `Permission denied (publickey)`

`cargo metadata` (used by cargo-deny / cargo-audit) walks transitive git deps, including octarine's `containers` submodule, which is declared with an `ssh://git@github.com/` URL. Runners have no SSH key, so the fetch fails.

Fix: configure `git url.insteadOf` at workflow start so cargo's git fetcher rewrites SSH GitHub URLs to HTTPS (anonymous-readable for public repos).

Failure run: https://github.com/joshjhall/containers/actions/runs/24976231190
Auto-filed tracking issue: #412

## Follow-ups (not in this PR)

- Octarine's `.gitmodules` shouldn't reference containers via SSH (or arguably at all — submodule isn't needed by library consumers). Discuss separately.
- Investigate why the v4.18.1 tag was force-moved; harden Create Release to be idempotent against future tag movement (already partially addressed here).

## Test plan

- [ ] actionlint passes (`just lint-workflows`) — done locally
- [ ] Trigger `Scheduled Dependency Security Scan` via `workflow_dispatch` after merge to confirm the rewrite resolves cargo metadata
- [ ] Next release tag exercises the immutability precheck path on first run (`skip=false`); manually re-running the job should now `skip=true` instead of failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)