### PR TITLE
chore(deps): bump octarine to v0.3.0-beta.3 and drop SSH-rewrite workaround

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,3 +1,5 @@
 - [v5 Architecture](v5-architecture.md) — Three executables (stibbons/igor/luggage), manifest-driven installs, multi-distro support
 - [Octarine Windows](octarine-windows.md) — Octarine doesn't compile on Windows yet, blocks stibbons Windows CI
 - [Luggage Tooldb Design](luggage-tooldb-design.md) — Tool catalog: separate containers-tooldb repo, 7-tier activity, luggage crate
+- [Minimal build philosophy](minimal-build-philosophy.md) — Install minimal package sets; clean up build artifacts
+- [Use file-issue skill](use-file-issue-skill.md) — Always file new issues via `/file-issue`, not raw `gh issue create`

--- a/.claude/memory/minimal-build-philosophy.md
+++ b/.claude/memory/minimal-build-philosophy.md
@@ -1,0 +1,45 @@
+---
+name: Minimal build philosophy
+description: Container images and tooldb entries declare only the packages strictly required, dedupe across tools, and clean up build artifacts to keep image size down
+type: feedback
+originSessionId: f3bdee37-b9b4-4808-a0f5-8265562211bc
+---
+
+Builds — image generation, tooldb `system_packages`, feature scripts — must
+install only what is strictly necessary, not "convenience" supersets.
+
+**Why:** Image size is a first-order cost in this project. The user has
+called this out repeatedly when reviewing tooldb data and feature scripts.
+A `build-essential` install pulls in g++, make, dpkg-dev, etc. — most rust
+toolchain installs only need `gcc` + `libc6-dev`. Bloat compounds across
+features.
+
+**How to apply:**
+
+1. **Pick the smallest package set that satisfies the immediate need.**
+   - Need a C linker for cargo? `gcc` + `libc6-dev`, not `build-essential`.
+   - Need a TLS-trust store for an `https://` download? `ca-certificates`,
+     not the full TLS dev stack.
+   - When in doubt, name the specific subpackage and skip the meta-package.
+2. **Push transitive needs to the consumer.**
+   - If a downstream tool (e.g., a cargo crate that wants `pkg-config`)
+     adds the dependency, that downstream tool's `system_packages` declares
+     it. The base tool's `system_packages` should not pre-install in case
+     someone might want it.
+3. **Idempotency by composition.**
+   - apt/apk/yum installs are themselves idempotent (re-installing a
+     present package is a no-op), but the *list* declared per tool should
+     overlap intentionally with other tools — luggage's resolver dedupes
+     `system_packages` across the tools it installs in one run, so a
+     well-factored catalog never installs `gcc` twice.
+4. **Clean up after install.**
+   - Feature scripts (and luggage's install engine, when it lands) must
+     remove apt cache, yum metadata, build temp dirs, downloaded tarballs
+     after use. Cargo / rustup caches under `/cache` are deliberately
+     persisted; everything else is ephemeral.
+5. **Prefer pre-built binaries over source builds** when the upstream
+   publishes signed/checksummed binaries. Source builds drag in compilers
+   that can't be removed without breaking debug.
+
+Applies to: `lib/features/*.sh`, `tools/<id>/*.json` `system_packages` /
+`post_install` arrays in `containers-db`, future luggage `install` recipes.

--- a/.claude/memory/use-file-issue-skill.md
+++ b/.claude/memory/use-file-issue-skill.md
@@ -1,0 +1,34 @@
+---
+name: Use file-issue skill for issue creation
+description: When filing GitHub/GitLab issues, always invoke the file-issue skill rather than calling gh/glab directly
+type: feedback
+originSessionId: f3bdee37-b9b4-4808-a0f5-8265562211bc
+---
+
+When this project's workflow needs to file a new issue (follow-up item,
+deferred acceptance criterion, scope creep that belongs separate, etc.),
+**invoke the `/file-issue` skill** rather than crafting an issue body inline
+or calling `gh issue create` directly.
+
+**Why:** The skill enforces structured fields, auto-labeling
+(severity/effort/component/type), scope boundaries, and the project's
+issue body conventions. Hand-rolled issues drift from those conventions
+and become noisier to triage. The user has flagged this directly when
+plans referenced raw `gh issue create` invocations.
+
+**How to apply:**
+
+- In planning documents that say "file follow-up issue X" — the next step
+  is `Skill(skill="file-issue", args="<short prompt describing the issue>")`,
+  not bash + `gh`.
+- The skill takes care of platform detection (gh vs glab), labels, and
+  duplicate-checking.
+- Cross-repo follow-ups (e.g., issues filed in `joshjhall/containers-db`
+  while working in `joshjhall/containers`) still go through the skill;
+  pass the repo as part of the prompt.
+- This includes both deferred acceptance criteria and scope-creep items
+  surfaced during planning.
+
+Equivalent verbal cues to watch for: "file an issue", "file a follow-up",
+"open an issue", "track this separately" — all should funnel through the
+skill.

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -18,16 +18,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Force HTTPS for any cargo git fetches that recurse into submodules
-      # declared with ssh:// URLs (e.g. octarine's `containers` submodule).
-      # The runner has no SSH key for github.com, so without this rewrite
-      # `cargo metadata` (used by cargo-deny / cargo-audit) fails to walk
-      # transitive git deps.
-      - name: Rewrite SSH GitHub URLs to HTTPS
-        run: |
-          git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
-          git config --global url."https://github.com/".insteadOf "git@github.com:"
-
       - name: Install just (task runner)
         uses: extractions/setup-just@v2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84790c55b5704b0d35130bf16a4ce22a8e70eb0ea773522557524d9a4852663d"
 dependencies = [
  "nix 0.30.1",
- "rand",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -310,13 +310,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chacha20poly1305"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -445,7 +456,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
 ]
 
@@ -1050,7 +1061,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand",
+ "rand 0.9.4",
  "smallvec",
  "spinning_top",
  "web-time",
@@ -1758,8 +1769,8 @@ dependencies = [
 
 [[package]]
 name = "octarine"
-version = "0.3.0-beta.1"
-source = "git+https://github.com/joshjhall/octarine.git?tag=v0.3.0-beta.1#56225ca4e812e785a55ad66e6c705af3979c1381"
+version = "0.3.0-beta.3"
+source = "git+https://github.com/joshjhall/octarine.git?tag=v0.3.0-beta.3#0e0fb29edb3b01fa3e110ee5128000bff38e821d"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -1789,14 +1800,14 @@ dependencies = [
  "octarine-derive",
  "once_cell",
  "parking_lot",
- "rand",
+ "rand 0.10.1",
  "rand_core 0.10.1",
  "regex",
  "reqwest",
  "secrecy",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "sha3",
  "tempfile",
  "thiserror 2.0.18",
@@ -1817,7 +1828,7 @@ dependencies = [
 [[package]]
 name = "octarine-derive"
 version = "0.1.0"
-source = "git+https://github.com/joshjhall/octarine.git?tag=v0.3.0-beta.1#56225ca4e812e785a55ad66e6c705af3979c1381"
+source = "git+https://github.com/joshjhall/octarine.git?tag=v0.3.0-beta.3#0e0fb29edb3b01fa3e110ee5128000bff38e821d"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -2064,7 +2075,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2119,6 +2130,17 @@ checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2507,6 +2529,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
+]
+
+[[package]]
 name = "sha3"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2615,7 +2648,7 @@ dependencies = [
  "octarine",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/joshjhall/containers"
 containers-common = { path = "crates/containers-common" }
 
 # Octarine foundation
-octarine = { git = "https://github.com/joshjhall/octarine.git", tag = "v0.3.0-beta.1", features = [
+octarine = { git = "https://github.com/joshjhall/octarine.git", tag = "v0.3.0-beta.3", features = [
   "full",
 ] }
 


### PR DESCRIPTION
## Summary

octarine v0.3.0-beta.3 ships the upstream fix for joshjhall/octarine#283 — the `containers` submodule in `.gitmodules` now uses an `https://` URL and `update = none`. With `update = none`, cargo's git fetcher logs `Skipping git submodule … due to update strategy in .gitmodules` and stops recursively initializing it.

That makes the `Rewrite SSH GitHub URLs to HTTPS` step in `security-scan.yml` (added in #414 as a workaround) redundant, so it's removed here.

## Changes

- `Cargo.toml` — pin bumped from `v0.3.0-beta.1` → `v0.3.0-beta.3`
- `Cargo.lock` — refreshed via `cargo update -p octarine` (also picks up `chacha20 v0.10.0`, `rand v0.10.1`, `sha2 v0.11.0` transitively)
- `.github/workflows/security-scan.yml` — `Rewrite SSH GitHub URLs to HTTPS` step removed

## Verification

Local preflight on the bump:
- `cargo update -p octarine` reports `Skipping git submodule "https://github.com/joshjhall/containers.git" due to update strategy in .gitmodules`
- `just build` — clean
- `just test-rust` — 12/12 + 0 doctests passing
- `just security-scan` — `cargo deny` advisories/bans/licenses/sources OK; osv-scanner clean; cargo audit clean (against the 1060-advisory db)

After merge, the next scheduled `Scheduled Dependency Security Scan` run on Monday will validate the workaround removal end-to-end.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, kick `Scheduled Dependency Security Scan` via `workflow_dispatch` to confirm cargo metadata still resolves without the SSH→HTTPS rewrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)