### PR TITLE
feat(containers-common): centralized version parser & constraint comparator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,11 +453,13 @@ version = "0.1.0"
 dependencies = [
  "indexmap",
  "minijinja",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",
  "sha2 0.10.9",
  "tempfile",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2451,6 +2453,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ indexmap = { version = "2", features = ["serde"] }
 inquire = "0.9"
 tempfile = "3"
 sha2 = "0.10"
+semver = { version = "1", features = ["serde"] }
 thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/containers-common/Cargo.toml
+++ b/crates/containers-common/Cargo.toml
@@ -13,7 +13,9 @@ workspace = true
 
 [dependencies]
 indexmap = { workspace = true }
+semver = { workspace = true }
 serde = { workspace = true }
+thiserror = { workspace = true }
 
 minijinja = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/containers-common/README.md
+++ b/crates/containers-common/README.md
@@ -1,0 +1,129 @@
+# containers-common
+
+Shared types and state contracts for the containers build system. Used
+by `stibbons`, `igor`, and `luggage`. Not published; consumed via
+workspace path.
+
+## Modules
+
+- `config` — `.igor.yml` schema and YAML parsing.
+- `feature` — feature registry and dependency resolution.
+- `generate` — content-hash based file generation tracking.
+- `template` — minijinja docker-compose / env-file rendering.
+- `version` — version parser and constraint comparator (this issue).
+
+## `version` — version parser & constraint comparator
+
+The single source of truth for parsing version strings and evaluating
+version constraints. Designed to replace the ad-hoc parsing scattered
+across `bin/check-versions.sh`, the future containers-db linter, the
+luggage resolver, and the stibbons CLI.
+
+### Quick usage
+
+```rust
+use containers_common::version::{Constraint, Version, VersionStyle};
+
+// Parse a version literal — `v` and other tag prefixes are stripped.
+let v = Version::parse("v1.7.0", VersionStyle::Semver)?;
+
+// Parse a constraint and test it.
+let c = Constraint::parse(">=1.5, <2", VersionStyle::Semver)?;
+assert!(c.matches(&v));
+
+// Combine constraints (used by the resolver to merge multiple
+// `requires[]` on the same tool into one effective constraint).
+let other = Constraint::parse(">=1.6", VersionStyle::Semver)?;
+let merged = c.intersect(&other)?;
+assert!(merged.matches(&v));
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+### Grammar
+
+| Form          | Meaning                          |
+| ------------- | -------------------------------- |
+| `1.95.0`      | exact match                      |
+| `>=1.7.0`     | minimum                          |
+| `>=1.7, <2`   | bounded range                    |
+| `1.7.x`       | prefix wildcard (also `1.x`)     |
+| `~1.7.0`      | patch-compatible (cargo-style)   |
+| `^1.7.0`      | minor-compatible (cargo-style)   |
+| `*` / `any`   | unconstrained                    |
+
+Two-component versions (`1.7`) and one-component versions (`2`) pad
+missing fields with zero, so the catalog can store partial pins.
+
+### Prefix tolerance
+
+Tag-style prefixes are stripped at parse time so the catalog can record
+canonical strings while upstream tags ship with prefixes:
+
+| Prefix      | Example         | Becomes  |
+| ----------- | --------------- | -------- |
+| `v`, `V`    | `v1.95.0`       | `1.95.0` |
+| `release-`  | `release-1.0.0` | `1.0.0`  |
+| `r<digit>`  | `r1.2.3`        | `1.2.3`  |
+
+This was the bug class behind the original `v0.3.0 → 0.4.0`
+prefix-drop incident — automation that compared the raw tag strings
+saw a regression where there wasn't one. The test corpus locks in the
+fix.
+
+### Style modes
+
+`VersionStyle` selects the grammar used for parsing:
+
+- `Semver` — default; full grammar above.
+- `Prefix` — same as `Semver` today; reserved for future tightening
+  when the data layer wants to document "this tool's tags are
+  freeform-prefixed."
+- `Calver` — date-shaped versions (`2026.04.29`); ordering is
+  lexicographic on dot-separated integer components.
+- `Opaque` — only exact equality and `*`/`any` work; comparators (`>=`,
+  ranges, wildcards) fail loudly. Safe fallback for tools whose
+  versions don't fit any common grammar.
+
+### Cross-style behavior
+
+`Constraint::matches` returns `false` when the constraint and version
+belong to different styles (a `Semver` constraint never matches a
+`Calver` version). `Constraint::intersect` is stricter — combining two
+constraints with different styles returns
+`IntersectError::StyleMismatch`, since the data layer should never
+produce that combination and a quiet `false` would mask a bug.
+
+### Error types
+
+`VersionError` covers parse failures (delegated `semver::Error`,
+calver component errors, opaque-mode violations, wildcards in version
+literals). `IntersectError::Empty` is the signal the luggage resolver
+uses to render a remediation menu (issue
+[#403](https://github.com/joshjhall/containers/issues/403)).
+
+### Crate evaluation rationale
+
+Per the issue, we evaluated three published crates before picking one:
+
+- **`semver` 1.x** *(chosen)* — the Rust core team crate. Native
+  support for cargo-style `^` and `~`, npm-style `1.x`, comma-separated
+  ranges, and pre-release semantics. Already passes the cargo test
+  suite. We layer prefix-stripping, opaque/calver modes, and an
+  `intersect` operation on top.
+- `node-semver-rs` — npm-grammar-only. Would force npm semantics on
+  cargo-style ranges and split the codebase against `cargo`'s own
+  behavior. Rejected.
+- `pep440-rs` — PEP 440 (Python). Wrong grammar for everything we
+  consume. Rejected.
+
+Rolling our own from scratch was rejected: the cargo-style precedence
+rules are subtle and reproducing them adds a class of bugs we don't
+need.
+
+### Consumer wiring (out of scope here)
+
+This issue lands the library only. Wiring into the containers-db
+validator/linter, the luggage resolver, the stibbons CLI, and
+`bin/check-versions.sh` is tracked separately (see issue #416 notes
+and the design memo at
+[containers-db#4](https://github.com/joshjhall/containers-db/issues/4)).

--- a/crates/containers-common/src/lib.rs
+++ b/crates/containers-common/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod feature;
 pub mod generate;
 pub mod template;
+pub mod version;
 
 /// Library version (tracks workspace, not container system version).
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/containers-common/src/version/constraint.rs
+++ b/crates/containers-common/src/version/constraint.rs
@@ -1,0 +1,557 @@
+//! Version constraint expressions and the operations on them.
+
+use std::fmt;
+
+use semver::{Comparator, Op, Version as SemverVersion, VersionReq};
+
+use super::error::{IntersectError, VersionError};
+use super::parse::{Version, strip_prefix};
+use super::style::VersionStyle;
+
+/// A parsed version constraint expression.
+///
+/// The variant is determined by the [`VersionStyle`] passed to
+/// [`Constraint::parse`]. Use [`Constraint::matches`] to test a [`Version`]
+/// against the constraint, and [`Constraint::intersect`] to combine two
+/// constraints (e.g. when multiple consumers depend on the same tool with
+/// different `requires`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Constraint {
+    /// Matches every version. Produced by `*` or `any` in any style.
+    Any,
+    /// Semver-style constraint (also produced by `Prefix` mode).
+    Semver(VersionReq),
+    /// Calver pin: matches the exact tuple.
+    CalverExact(Vec<u64>),
+    /// Calver range with optional inclusive/exclusive bounds.
+    CalverRange {
+        /// Lower bound, if any.
+        lo: Option<(Vec<u64>, bool)>,
+        /// Upper bound, if any.
+        hi: Option<(Vec<u64>, bool)>,
+    },
+    /// Opaque pin: matches only the exact string.
+    OpaqueExact(String),
+}
+
+impl Constraint {
+    /// Parses a constraint expression under the given style.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VersionError::Empty`] for empty input,
+    /// [`VersionError::OpaqueComparator`] when a comparator is used in
+    /// `Opaque` mode, [`VersionError::Calver`] for malformed calver
+    /// components, or [`VersionError::Semver`] when the underlying
+    /// `semver` crate rejects the input.
+    pub fn parse(s: &str, style: VersionStyle) -> Result<Self, VersionError> {
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            return Err(VersionError::Empty);
+        }
+        if is_any(trimmed) {
+            return Ok(Self::Any);
+        }
+
+        match style {
+            VersionStyle::Semver | VersionStyle::Prefix => {
+                let normalized = normalize_semver_constraint(trimmed);
+                let req = VersionReq::parse(&normalized).map_err(|source| {
+                    VersionError::Semver { input: trimmed.to_owned(), style, source }
+                })?;
+                Ok(Self::Semver(req))
+            }
+            VersionStyle::Calver => parse_calver_constraint(trimmed),
+            VersionStyle::Opaque => parse_opaque_constraint(trimmed),
+        }
+    }
+
+    /// Returns `true` if `v` satisfies this constraint.
+    ///
+    /// Cross-style mismatches always return `false` — a `Semver`
+    /// constraint never matches a `Calver` version, and so on.
+    #[must_use]
+    pub fn matches(&self, v: &Version) -> bool {
+        match (self, v) {
+            (Self::Any, _) => true,
+            (Self::Semver(req), Version::Semver(ver)) => req.matches(ver),
+            (Self::CalverExact(parts), Version::Calver(other)) => parts == other,
+            (Self::CalverRange { lo, hi }, Version::Calver(other)) => {
+                lo.as_ref().is_none_or(|(b, incl)| calver_cmp(other, b, *incl, true))
+                    && hi.as_ref().is_none_or(|(b, incl)| calver_cmp(other, b, *incl, false))
+            }
+            (Self::OpaqueExact(s), Version::Opaque(other)) => s == other,
+            _ => false,
+        }
+    }
+
+    /// Returns the intersection of `self` and `other`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IntersectError::Empty`] if no version satisfies both
+    /// constraints, and [`IntersectError::StyleMismatch`] if the two
+    /// constraints belong to different version styles (e.g. semver vs
+    /// calver — the data layer should never produce this combination).
+    pub fn intersect(&self, other: &Self) -> Result<Self, IntersectError> {
+        match (self, other) {
+            (Self::Any, x) | (x, Self::Any) => Ok(x.clone()),
+            (Self::Semver(a), Self::Semver(b)) => intersect_semver(a, b, self, other),
+            (Self::CalverExact(a), Self::CalverExact(b)) => {
+                if a == b {
+                    Ok(Self::CalverExact(a.clone()))
+                } else {
+                    Err(IntersectError::Empty {
+                        left: format!("{self}"),
+                        right: format!("{other}"),
+                    })
+                }
+            }
+            (
+                Self::CalverRange { lo: a_lo, hi: a_hi },
+                Self::CalverRange { lo: b_lo, hi: b_hi },
+            ) => {
+                let lo = max_calver_bound(a_lo.as_ref(), b_lo.as_ref(), true);
+                let hi = max_calver_bound(a_hi.as_ref(), b_hi.as_ref(), false);
+                let combined = Self::CalverRange { lo: lo.cloned(), hi: hi.cloned() };
+                if calver_range_satisfiable(&combined) {
+                    Ok(combined)
+                } else {
+                    Err(IntersectError::Empty {
+                        left: format!("{self}"),
+                        right: format!("{other}"),
+                    })
+                }
+            }
+            (Self::CalverRange { .. }, Self::CalverExact(_))
+            | (Self::CalverExact(_), Self::CalverRange { .. }) => {
+                let (range, exact) = match self {
+                    Self::CalverExact(_) => (other, self),
+                    _ => (self, other),
+                };
+                if range.matches(&match exact {
+                    Self::CalverExact(p) => Version::Calver(p.clone()),
+                    _ => unreachable!(),
+                }) {
+                    Ok(exact.clone())
+                } else {
+                    Err(IntersectError::Empty {
+                        left: format!("{self}"),
+                        right: format!("{other}"),
+                    })
+                }
+            }
+            (Self::OpaqueExact(a), Self::OpaqueExact(b)) => {
+                if a == b {
+                    Ok(Self::OpaqueExact(a.clone()))
+                } else {
+                    Err(IntersectError::Empty {
+                        left: format!("{self}"),
+                        right: format!("{other}"),
+                    })
+                }
+            }
+            _ => Err(IntersectError::StyleMismatch),
+        }
+    }
+}
+
+// ===== semver helpers =====
+
+fn is_any(s: &str) -> bool {
+    let t = s.trim().to_ascii_lowercase();
+    t == "*" || t == "any"
+}
+
+/// Normalises a semver constraint string before handing it to `VersionReq::parse`.
+///
+/// Strips `v`/`V`/`release-`/`r<digit>` prefixes from individual
+/// version tokens and lowercases `X` to `x` (the semver crate accepts
+/// both, but we normalize for consistency).
+fn normalize_semver_constraint(s: &str) -> String {
+    s.split(',').map(|part| normalize_one_comparator(part.trim())).collect::<Vec<_>>().join(", ")
+}
+
+fn normalize_one_comparator(s: &str) -> String {
+    // A comparator is an optional operator (`>=`, `<=`, `>`, `<`, `=`,
+    // `~`, `^`) followed by a version-like token. Strip prefix from the
+    // version-like token. A bare literal becomes an exact match — the
+    // issue's grammar table says `1.95.0` is exact, but the semver
+    // crate would otherwise interpret it as `^1.95.0`.
+    let (op, rest) = split_op(s);
+    let stripped = strip_prefix(rest.trim());
+    if op.is_empty() {
+        if contains_wildcard(stripped) { stripped.to_owned() } else { format!("={stripped}") }
+    } else {
+        format!("{op}{stripped}")
+    }
+}
+
+fn contains_wildcard(s: &str) -> bool {
+    s.chars().any(|c| c == 'x' || c == 'X' || c == '*')
+}
+
+fn split_op(s: &str) -> (&str, &str) {
+    for op in [">=", "<=", "==", "~=", ">", "<", "=", "~", "^"] {
+        if let Some(rest) = s.strip_prefix(op) {
+            return (op, rest);
+        }
+    }
+    ("", s)
+}
+
+fn intersect_semver(
+    a: &VersionReq,
+    b: &VersionReq,
+    self_for_msg: &Constraint,
+    other_for_msg: &Constraint,
+) -> Result<Constraint, IntersectError> {
+    let mut comparators = a.comparators.clone();
+    comparators.extend(b.comparators.iter().cloned());
+    let combined = VersionReq { comparators };
+    if semver_req_satisfiable(&combined) {
+        Ok(Constraint::Semver(combined))
+    } else {
+        Err(IntersectError::Empty {
+            left: format!("{self_for_msg}"),
+            right: format!("{other_for_msg}"),
+        })
+    }
+}
+
+/// Tests satisfiability of a combined `VersionReq` by deriving an
+/// interval `[lo, hi)` (or its inclusive variants) from the comparator
+/// list and checking it's non-empty.
+fn semver_req_satisfiable(req: &VersionReq) -> bool {
+    let mut lo: Option<(SemverVersion, bool)> = None;
+    let mut hi: Option<(SemverVersion, bool)> = None;
+    let mut pin: Option<SemverVersion> = None;
+
+    for c in &req.comparators {
+        match c.op {
+            Op::Exact => {
+                let v = comparator_lower(c);
+                if let Some(p) = &pin
+                    && *p != v
+                {
+                    return false;
+                }
+                pin = Some(v.clone());
+                lo = max_lo(lo.take(), Some((v.clone(), true)));
+                hi = min_hi(hi.take(), Some((v, true)));
+            }
+            Op::Greater => {
+                lo = max_lo(lo.take(), Some((comparator_lower(c), false)));
+            }
+            Op::GreaterEq => {
+                lo = max_lo(lo.take(), Some((comparator_lower(c), true)));
+            }
+            Op::Less => {
+                hi = min_hi(hi.take(), Some((comparator_lower(c), false)));
+            }
+            Op::LessEq => {
+                hi = min_hi(hi.take(), Some((comparator_lower(c), true)));
+            }
+            Op::Tilde => {
+                let l = comparator_lower(c);
+                let u = tilde_upper(c);
+                lo = max_lo(lo.take(), Some((l, true)));
+                hi = min_hi(hi.take(), Some((u, false)));
+            }
+            Op::Caret => {
+                let l = comparator_lower(c);
+                let u = caret_upper(c);
+                lo = max_lo(lo.take(), Some((l, true)));
+                hi = min_hi(hi.take(), Some((u, false)));
+            }
+            Op::Wildcard => {
+                let (l, u) = wildcard_bounds(c);
+                lo = max_lo(lo.take(), Some((l, true)));
+                hi = min_hi(hi.take(), Some((u, false)));
+            }
+            _ => {} // future-compat: ignore unknown ops in satisfiability check
+        }
+    }
+
+    if let Some(p) = pin {
+        if let Some((l, incl)) = &lo
+            && (*l > p || (*l == p && !incl))
+        {
+            return false;
+        }
+        if let Some((h, incl)) = &hi
+            && (*h < p || (*h == p && !incl))
+        {
+            return false;
+        }
+        return true;
+    }
+
+    match (&lo, &hi) {
+        (Some((l, li)), Some((h, hi_inc))) => match l.cmp(h) {
+            std::cmp::Ordering::Less => true,
+            std::cmp::Ordering::Equal => *li && *hi_inc,
+            std::cmp::Ordering::Greater => false,
+        },
+        _ => true,
+    }
+}
+
+fn comparator_lower(c: &Comparator) -> SemverVersion {
+    SemverVersion {
+        major: c.major,
+        minor: c.minor.unwrap_or(0),
+        patch: c.patch.unwrap_or(0),
+        pre: c.pre.clone(),
+        build: semver::BuildMetadata::EMPTY,
+    }
+}
+
+fn tilde_upper(c: &Comparator) -> SemverVersion {
+    // `~1.2.3` → <1.3.0; `~1.2` → <1.3.0; `~1` → <2.0.0.
+    if c.minor.is_some() {
+        SemverVersion::new(c.major, c.minor.unwrap_or(0).saturating_add(1), 0)
+    } else {
+        SemverVersion::new(c.major.saturating_add(1), 0, 0)
+    }
+}
+
+fn caret_upper(c: &Comparator) -> SemverVersion {
+    // Caret bumps the leftmost non-zero component.
+    let major = c.major;
+    let minor = c.minor.unwrap_or(0);
+    let patch = c.patch.unwrap_or(0);
+    if major > 0 || c.minor.is_none() {
+        SemverVersion::new(major.saturating_add(1), 0, 0)
+    } else if minor > 0 || c.patch.is_none() {
+        SemverVersion::new(major, minor.saturating_add(1), 0)
+    } else {
+        SemverVersion::new(major, minor, patch.saturating_add(1))
+    }
+}
+
+fn wildcard_bounds(c: &Comparator) -> (SemverVersion, SemverVersion) {
+    // `*` is empty comparator list (handled upstream); here we have a
+    // partial wildcard like `1.*` (minor=None) or `1.2.*` (patch=None).
+    let major = c.major;
+    let lower = SemverVersion::new(major, c.minor.unwrap_or(0), 0);
+    let upper = if c.minor.is_none() {
+        SemverVersion::new(major.saturating_add(1), 0, 0)
+    } else {
+        SemverVersion::new(major, c.minor.unwrap_or(0).saturating_add(1), 0)
+    };
+    (lower, upper)
+}
+
+fn max_lo(
+    a: Option<(SemverVersion, bool)>,
+    b: Option<(SemverVersion, bool)>,
+) -> Option<(SemverVersion, bool)> {
+    match (a, b) {
+        (None, x) | (x, None) => x,
+        (Some((av, ai)), Some((bv, bi))) => match av.cmp(&bv) {
+            std::cmp::Ordering::Greater => Some((av, ai)),
+            std::cmp::Ordering::Less => Some((bv, bi)),
+            std::cmp::Ordering::Equal => Some((av, ai && bi)),
+        },
+    }
+}
+
+fn min_hi(
+    a: Option<(SemverVersion, bool)>,
+    b: Option<(SemverVersion, bool)>,
+) -> Option<(SemverVersion, bool)> {
+    match (a, b) {
+        (None, x) | (x, None) => x,
+        (Some((av, ai)), Some((bv, bi))) => match av.cmp(&bv) {
+            std::cmp::Ordering::Less => Some((av, ai)),
+            std::cmp::Ordering::Greater => Some((bv, bi)),
+            std::cmp::Ordering::Equal => Some((av, ai && bi)),
+        },
+    }
+}
+
+// ===== calver helpers =====
+
+fn parse_calver_constraint(s: &str) -> Result<Constraint, VersionError> {
+    // Comma-separated range, e.g. `>=2026.01.01, <2027.01.01`. Must be
+    // checked before the single-comparator branch — a comma-joined
+    // string starts with `>=` and would otherwise be misread.
+    if s.contains(',') {
+        let mut lo: Option<(Vec<u64>, bool)> = None;
+        let mut hi: Option<(Vec<u64>, bool)> = None;
+        for part in s.split(',') {
+            let part = part.trim();
+            let (op, rest) = peel_comparator(part)
+                .ok_or_else(|| VersionError::Calver { input: s.to_owned() })?;
+            let parts = parse_calver_components(rest.trim(), s)?;
+            match op {
+                ">" => lo = Some((parts, false)),
+                ">=" => lo = Some((parts, true)),
+                "<" => hi = Some((parts, false)),
+                "<=" => hi = Some((parts, true)),
+                _ => return Err(VersionError::Calver { input: s.to_owned() }),
+            }
+        }
+        return Ok(Constraint::CalverRange { lo, hi });
+    }
+
+    if let Some((op, rest)) = peel_comparator(s) {
+        let parts = parse_calver_components(rest.trim(), s)?;
+        let (lo, hi) = match op {
+            ">" => (Some((parts, false)), None),
+            ">=" => (Some((parts, true)), None),
+            "<" => (None, Some((parts, false))),
+            "<=" => (None, Some((parts, true))),
+            "=" | "==" => return Ok(Constraint::CalverExact(parts)),
+            _ => return Err(VersionError::Calver { input: s.to_owned() }),
+        };
+        return Ok(Constraint::CalverRange { lo, hi });
+    }
+
+    let parts = parse_calver_components(s, s)?;
+    Ok(Constraint::CalverExact(parts))
+}
+
+fn peel_comparator(s: &str) -> Option<(&'static str, &str)> {
+    for op in [">=", "<=", "==", ">", "<", "="] {
+        if let Some(rest) = s.strip_prefix(op) {
+            return Some((op, rest));
+        }
+    }
+    None
+}
+
+fn parse_calver_components(token: &str, original: &str) -> Result<Vec<u64>, VersionError> {
+    let stripped = strip_prefix(token);
+    let mut parts = Vec::new();
+    for part in stripped.split('.') {
+        let n: u64 =
+            part.parse().map_err(|_| VersionError::Calver { input: original.to_owned() })?;
+        parts.push(n);
+    }
+    if parts.is_empty() {
+        return Err(VersionError::Calver { input: original.to_owned() });
+    }
+    Ok(parts)
+}
+
+fn calver_cmp(value: &[u64], bound: &[u64], inclusive: bool, is_lower_bound: bool) -> bool {
+    use std::cmp::Ordering;
+    match value.cmp(bound) {
+        Ordering::Equal => inclusive,
+        Ordering::Greater => is_lower_bound,
+        Ordering::Less => !is_lower_bound,
+    }
+}
+
+#[allow(clippy::ref_option, clippy::option_if_let_else)]
+fn max_calver_bound<'a>(
+    a: Option<&'a (Vec<u64>, bool)>,
+    b: Option<&'a (Vec<u64>, bool)>,
+    is_lower: bool,
+) -> Option<&'a (Vec<u64>, bool)> {
+    match (a, b) {
+        (None, x) | (x, None) => x,
+        (Some(av), Some(bv)) => {
+            use std::cmp::Ordering;
+            match av.0.cmp(&bv.0) {
+                Ordering::Greater => {
+                    if is_lower {
+                        Some(av)
+                    } else {
+                        Some(bv)
+                    }
+                }
+                Ordering::Less => {
+                    if is_lower {
+                        Some(bv)
+                    } else {
+                        Some(av)
+                    }
+                }
+                Ordering::Equal => {
+                    if av.1 && !bv.1 || !av.1 && bv.1 {
+                        if av.1 { Some(bv) } else { Some(av) }
+                    } else {
+                        Some(av)
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn calver_range_satisfiable(c: &Constraint) -> bool {
+    let Constraint::CalverRange { lo, hi } = c else {
+        return true;
+    };
+    match (lo, hi) {
+        (Some((l, li)), Some((h, hi_inc))) => match l.cmp(h) {
+            std::cmp::Ordering::Less => true,
+            std::cmp::Ordering::Equal => *li && *hi_inc,
+            std::cmp::Ordering::Greater => false,
+        },
+        _ => true,
+    }
+}
+
+// ===== opaque helpers =====
+
+fn parse_opaque_constraint(s: &str) -> Result<Constraint, VersionError> {
+    // In opaque mode, anything that looks like a comparator is rejected.
+    if peel_comparator(s).is_some() || s.contains(',') || s.contains('~') || s.contains('^') {
+        return Err(VersionError::OpaqueComparator { input: s.to_owned() });
+    }
+    if s.chars().any(|c| c == 'x' || c == 'X' || c == '*') && !is_any(s) {
+        return Err(VersionError::OpaqueComparator { input: s.to_owned() });
+    }
+    Ok(Constraint::OpaqueExact(s.to_owned()))
+}
+
+// ===== Display =====
+
+impl fmt::Display for Constraint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Any => f.write_str("*"),
+            Self::Semver(req) => write!(f, "{req}"),
+            Self::CalverExact(parts) => write!(f, "={}", join_dots(parts)),
+            Self::CalverRange { lo, hi } => {
+                let wrote = if let Some((parts, incl)) = lo {
+                    let op = if *incl { ">=" } else { ">" };
+                    write!(f, "{op}{}", join_dots(parts))?;
+                    true
+                } else {
+                    false
+                };
+                if let Some((parts, incl)) = hi {
+                    if wrote {
+                        f.write_str(", ")?;
+                    }
+                    let op = if *incl { "<=" } else { "<" };
+                    write!(f, "{op}{}", join_dots(parts))?;
+                }
+                Ok(())
+            }
+            Self::OpaqueExact(s) => f.write_str(s),
+        }
+    }
+}
+
+fn join_dots(parts: &[u64]) -> String {
+    parts.iter().map(u64::to_string).collect::<Vec<_>>().join(".")
+}
+
+impl serde::Serialize for Constraint {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.collect_str(self)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Constraint {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(d)?;
+        Self::parse(&s, VersionStyle::Semver).map_err(serde::de::Error::custom)
+    }
+}

--- a/crates/containers-common/src/version/error.rs
+++ b/crates/containers-common/src/version/error.rs
@@ -1,0 +1,61 @@
+//! Error types returned by the version module.
+
+use super::VersionStyle;
+
+/// Failure to parse a version literal or constraint expression.
+#[derive(Debug, thiserror::Error)]
+pub enum VersionError {
+    /// The string did not parse as a valid semver version or comparator.
+    #[error("invalid {style:?} version `{input}`: {source}")]
+    Semver {
+        /// The original input that failed to parse.
+        input: String,
+        /// The style under which the parse was attempted.
+        style: VersionStyle,
+        /// The underlying error from the `semver` crate.
+        #[source]
+        source: semver::Error,
+    },
+
+    /// A calver component was not a non-negative integer.
+    #[error("calver components must be non-negative integers, got `{input}`")]
+    Calver {
+        /// The original input.
+        input: String,
+    },
+
+    /// A comparator was used in opaque mode (only exact equality and `*`/`any` are allowed).
+    #[error("opaque mode does not support comparator `{input}`; only exact and `*`/`any` allowed")]
+    OpaqueComparator {
+        /// The disallowed input.
+        input: String,
+    },
+
+    /// A wildcard appeared on the version side, where only literals are valid.
+    #[error("wildcards (`x`, `*`) are not valid in a version literal: `{input}`")]
+    WildcardInVersion {
+        /// The disallowed input.
+        input: String,
+    },
+
+    /// The input was empty.
+    #[error("empty version string")]
+    Empty,
+}
+
+/// Failure to compute the intersection of two constraints.
+#[derive(Debug, thiserror::Error)]
+pub enum IntersectError {
+    /// The two constraints share no satisfying version.
+    #[error("empty intersection: `{left}` ∩ `{right}` matches no version")]
+    Empty {
+        /// Left-hand operand string form.
+        left: String,
+        /// Right-hand operand string form.
+        right: String,
+    },
+
+    /// The two constraints belong to different version styles.
+    #[error("cannot intersect constraints of different version styles")]
+    StyleMismatch,
+}

--- a/crates/containers-common/src/version/mod.rs
+++ b/crates/containers-common/src/version/mod.rs
@@ -1,0 +1,50 @@
+//! Centralized version parser and constraint comparator.
+//!
+//! This module is the single source of truth for parsing version strings
+//! and evaluating version constraints across the containers ecosystem
+//! (containers-db validator/linter, luggage resolver, stibbons CLI,
+//! version-bump automation). One library, one grammar, one bug class
+//! retired.
+//!
+//! # Quick start
+//!
+//! ```
+//! use containers_common::version::{Constraint, Version, VersionStyle};
+//!
+//! let v = Version::parse("v1.7.0", VersionStyle::Semver).unwrap();
+//! let c = Constraint::parse(">=1.5, <2", VersionStyle::Semver).unwrap();
+//! assert!(c.matches(&v));
+//! ```
+//!
+//! # Supported grammar
+//!
+//! | Form          | Meaning                          |
+//! | ------------- | -------------------------------- |
+//! | `1.95.0`      | exact match                      |
+//! | `>=1.7.0`     | minimum                          |
+//! | `>=1.7, <2`   | bounded range                    |
+//! | `1.7.x`       | prefix wildcard                  |
+//! | `~1.7.0`      | patch-compatible (cargo-style)   |
+//! | `^1.7.0`      | minor-compatible (cargo-style)   |
+//! | `*` / `any`   | unconstrained                    |
+//!
+//! Tag-style prefixes `v`, `V`, `release-`, and `r<digit>` are stripped
+//! at parse time so the catalog can store `1.95.0` while upstream tags
+//! ship as `v1.95.0`.
+//!
+//! # Style modes
+//!
+//! See [`VersionStyle`]: `Semver` (default), `Prefix`, `Calver`, `Opaque`.
+//! `Opaque` disables comparators entirely — only exact equality and
+//! `*`/`any` are accepted, which is the safe fallback for tools whose
+//! versions don't fit any common grammar.
+
+mod constraint;
+mod error;
+mod parse;
+mod style;
+
+pub use constraint::Constraint;
+pub use error::{IntersectError, VersionError};
+pub use parse::Version;
+pub use style::VersionStyle;

--- a/crates/containers-common/src/version/parse.rs
+++ b/crates/containers-common/src/version/parse.rs
@@ -1,0 +1,150 @@
+//! Version literal parsing.
+//!
+//! This module owns the [`Version`] enum and the prefix-tolerance helper
+//! used by both [`Version::parse`] and constraint parsing.
+
+use std::fmt;
+
+use super::error::VersionError;
+use super::style::VersionStyle;
+
+/// Strips a single tag-style prefix from a version literal.
+///
+/// Recognised prefixes (longest first): `release-`, `v`, `V`, and `r`
+/// when followed by a digit. The function only strips at the start; it
+/// does not recurse. This is used at parse time so the catalog can store
+/// `1.95.0` while upstream tags ship as `v1.95.0` or `release-1.95.0`.
+#[must_use]
+pub(super) fn strip_prefix(s: &str) -> &str {
+    if let Some(rest) = s.strip_prefix("release-") {
+        return rest;
+    }
+    if let Some(rest) = s.strip_prefix('v').or_else(|| s.strip_prefix('V')) {
+        return rest;
+    }
+    if let Some(rest) = s.strip_prefix('r')
+        && rest.chars().next().is_some_and(|c| c.is_ascii_digit())
+    {
+        return rest;
+    }
+    s
+}
+
+/// A parsed version literal.
+///
+/// The variant is determined by the [`VersionStyle`] passed to [`Version::parse`].
+/// `Prefix` mode produces `Self::Semver` like `Semver` mode does — the
+/// distinction is purely a documentation hint at the data layer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Version {
+    /// Semver-shaped version (also used by `Prefix` mode).
+    Semver(semver::Version),
+    /// Calver: dot-separated non-negative integer components, ordered lexicographically.
+    Calver(Vec<u64>),
+    /// Opaque: stored verbatim, only exact equality is meaningful.
+    Opaque(String),
+}
+
+impl Version {
+    /// Parses a version literal under the given style.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VersionError::Empty`] if `s` is empty after trimming,
+    /// [`VersionError::WildcardInVersion`] if `s` contains `x`, `X`, or `*`,
+    /// [`VersionError::Calver`] if a calver component is non-numeric, or
+    /// [`VersionError::Semver`] if the semver crate rejects the input.
+    pub fn parse(s: &str, style: VersionStyle) -> Result<Self, VersionError> {
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            return Err(VersionError::Empty);
+        }
+
+        if matches!(style, VersionStyle::Semver | VersionStyle::Prefix | VersionStyle::Calver)
+            && contains_wildcard(trimmed)
+        {
+            return Err(VersionError::WildcardInVersion { input: trimmed.to_owned() });
+        }
+
+        match style {
+            VersionStyle::Semver | VersionStyle::Prefix => {
+                let stripped = strip_prefix(trimmed);
+                let parsed = parse_semver_relaxed(stripped).map_err(|source| {
+                    VersionError::Semver { input: trimmed.to_owned(), style, source }
+                })?;
+                Ok(Self::Semver(parsed))
+            }
+            VersionStyle::Calver => {
+                let stripped = strip_prefix(trimmed);
+                let mut parts = Vec::new();
+                for part in stripped.split('.') {
+                    let n: u64 = part
+                        .parse()
+                        .map_err(|_| VersionError::Calver { input: trimmed.to_owned() })?;
+                    parts.push(n);
+                }
+                if parts.is_empty() {
+                    return Err(VersionError::Calver { input: trimmed.to_owned() });
+                }
+                Ok(Self::Calver(parts))
+            }
+            VersionStyle::Opaque => Ok(Self::Opaque(trimmed.to_owned())),
+        }
+    }
+}
+
+/// Parses a version, padding missing minor/patch components with zero.
+///
+/// `semver::Version::parse` requires `major.minor.patch`; the catalog
+/// often holds `1.7` or even `2`. This helper accepts those forms.
+fn parse_semver_relaxed(s: &str) -> Result<semver::Version, semver::Error> {
+    let core_end = s.find(['-', '+']).unwrap_or(s.len());
+    let (core, suffix) = s.split_at(core_end);
+    let dots = core.matches('.').count();
+    let padded_core = match dots {
+        0 => format!("{core}.0.0"),
+        1 => format!("{core}.0"),
+        _ => core.to_owned(),
+    };
+    let combined = format!("{padded_core}{suffix}");
+    semver::Version::parse(&combined)
+}
+
+fn contains_wildcard(s: &str) -> bool {
+    s.chars().any(|c| c == 'x' || c == 'X' || c == '*')
+}
+
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Semver(v) => write!(f, "{v}"),
+            Self::Calver(parts) => {
+                let mut first = true;
+                for p in parts {
+                    if !first {
+                        f.write_str(".")?;
+                    }
+                    first = false;
+                    write!(f, "{p}")?;
+                }
+                Ok(())
+            }
+            Self::Opaque(s) => f.write_str(s),
+        }
+    }
+}
+
+impl serde::Serialize for Version {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.collect_str(self)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Version {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(d)?;
+        // Default to Semver for serde — consumers who need a different
+        // style should deserialize as String and call `Version::parse`.
+        Self::parse(&s, VersionStyle::Semver).map_err(serde::de::Error::custom)
+    }
+}

--- a/crates/containers-common/src/version/style.rs
+++ b/crates/containers-common/src/version/style.rs
@@ -1,0 +1,27 @@
+//! [`VersionStyle`] — the four parser modes supported by this crate.
+
+/// The grammar a version string is interpreted under.
+///
+/// Tooldb tools tag themselves with one of these so the parser knows
+/// how to read their version literals and constraints. Defaulting to
+/// `Semver` is safe for the common case.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Default, serde::Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum VersionStyle {
+    /// Semantic versioning (cargo / npm / `semver` crate). Default.
+    #[default]
+    Semver,
+    /// Same grammar as `Semver`, but the data layer documents that
+    /// upstream tags routinely carry arbitrary prefixes. Behaviourally
+    /// identical to `Semver` in v1; reserved for future tightening.
+    Prefix,
+    /// Date-shaped versions (e.g. `2026.04.29`). Components are
+    /// non-negative integers compared lexicographically.
+    Calver,
+    /// Genuinely freeform versions. Only exact equality and `*` / `any`
+    /// are meaningful; comparators (`>=`, ranges, wildcards) are an
+    /// error.
+    Opaque,
+}

--- a/crates/containers-common/tests/version_constraint.rs
+++ b/crates/containers-common/tests/version_constraint.rs
@@ -1,0 +1,113 @@
+//! Tests for [`Constraint::parse`] and [`Constraint::matches`] — the
+//! grammar surface (cargo `^`/`~`, npm `1.x`, ranges, `any`/`*`).
+
+use containers_common::version::{Constraint, Version, VersionError, VersionStyle};
+
+fn ver(s: &str) -> Version {
+    Version::parse(s, VersionStyle::Semver).unwrap()
+}
+
+fn cn(s: &str) -> Constraint {
+    Constraint::parse(s, VersionStyle::Semver).unwrap()
+}
+
+#[test]
+fn exact_pin_matches_only_that_version() {
+    let c = cn("1.95.0");
+    assert!(c.matches(&ver("1.95.0")));
+    assert!(!c.matches(&ver("1.95.1")));
+    assert!(!c.matches(&ver("1.94.0")));
+}
+
+#[test]
+fn ge_minimum_matches_higher() {
+    let c = cn(">=1.7.0");
+    assert!(c.matches(&ver("1.7.0")));
+    assert!(c.matches(&ver("1.7.5")));
+    assert!(c.matches(&ver("2.0.0")));
+    assert!(!c.matches(&ver("1.6.99")));
+}
+
+#[test]
+fn bounded_range_matches_inside_only() {
+    let c = cn(">=1.7, <2");
+    assert!(c.matches(&ver("1.7.0")));
+    assert!(c.matches(&ver("1.99.0")));
+    assert!(!c.matches(&ver("2.0.0")));
+    assert!(!c.matches(&ver("1.6.0")));
+}
+
+#[test]
+fn caret_minor_compatible() {
+    // ^1.2.3 := >=1.2.3, <2.0.0
+    let c = cn("^1.2.3");
+    assert!(c.matches(&ver("1.2.3")));
+    assert!(c.matches(&ver("1.5.0")));
+    assert!(!c.matches(&ver("2.0.0")));
+    assert!(!c.matches(&ver("1.2.2")));
+}
+
+#[test]
+fn tilde_patch_compatible() {
+    // ~1.2.3 := >=1.2.3, <1.3.0
+    let c = cn("~1.2.3");
+    assert!(c.matches(&ver("1.2.3")));
+    assert!(c.matches(&ver("1.2.9")));
+    assert!(!c.matches(&ver("1.3.0")));
+    assert!(!c.matches(&ver("1.2.2")));
+}
+
+#[test]
+fn npm_minor_wildcard() {
+    // 1.x matches any 1.y.z
+    let c = cn("1.x");
+    assert!(c.matches(&ver("1.0.0")));
+    assert!(c.matches(&ver("1.7.5")));
+    assert!(!c.matches(&ver("2.0.0")));
+}
+
+#[test]
+fn npm_patch_wildcard() {
+    // 1.7.x matches any 1.7.z
+    let c = cn("1.7.x");
+    assert!(c.matches(&ver("1.7.0")));
+    assert!(c.matches(&ver("1.7.99")));
+    assert!(!c.matches(&ver("1.8.0")));
+    assert!(!c.matches(&ver("1.6.99")));
+}
+
+#[test]
+fn star_matches_anything() {
+    let c = cn("*");
+    assert!(c.matches(&ver("0.0.1")));
+    assert!(c.matches(&ver("99.99.99")));
+}
+
+#[test]
+fn any_keyword_is_unconstrained() {
+    let c = cn("any");
+    assert!(c.matches(&ver("0.0.1")));
+    assert!(c.matches(&ver("100.0.0")));
+    let c2 = cn("ANY");
+    assert!(c2.matches(&ver("0.0.1")));
+}
+
+#[test]
+fn constraint_strips_v_prefix_in_tokens() {
+    let c = Constraint::parse(">=v1.7.0, <v2", VersionStyle::Semver).unwrap();
+    assert!(c.matches(&ver("1.7.0")));
+    assert!(!c.matches(&ver("2.0.0")));
+}
+
+#[test]
+fn empty_constraint_is_rejected() {
+    assert!(matches!(Constraint::parse("", VersionStyle::Semver), Err(VersionError::Empty)));
+}
+
+#[test]
+fn malformed_constraint_returns_semver_error() {
+    assert!(matches!(
+        Constraint::parse("nope", VersionStyle::Semver),
+        Err(VersionError::Semver { .. })
+    ));
+}

--- a/crates/containers-common/tests/version_intersect.rs
+++ b/crates/containers-common/tests/version_intersect.rs
@@ -1,0 +1,97 @@
+//! Tests for [`Constraint::intersect`] — combining constraints, empty
+//! intersections, and style mismatches.
+
+use containers_common::version::{Constraint, IntersectError, Version, VersionStyle};
+
+fn ver(s: &str) -> Version {
+    Version::parse(s, VersionStyle::Semver).unwrap()
+}
+
+fn cn(s: &str) -> Constraint {
+    Constraint::parse(s, VersionStyle::Semver).unwrap()
+}
+
+#[test]
+fn intersect_overlapping_ranges_narrows_to_inner_bounds() {
+    // >=1.7,<2.0 ∩ >=1.8.5,<3.0 should match 1.9.0 but reject the
+    // boundaries that fall outside either operand.
+    let combined = cn(">=1.7, <2.0").intersect(&cn(">=1.8.5, <3.0")).unwrap();
+    assert!(combined.matches(&ver("1.8.5")));
+    assert!(combined.matches(&ver("1.9.0")));
+    assert!(!combined.matches(&ver("1.8.0")));
+    assert!(!combined.matches(&ver("2.0.0")));
+    assert!(!combined.matches(&ver("3.0.0")));
+}
+
+#[test]
+fn intersect_with_any_returns_other() {
+    let lhs = cn(">=1.0");
+    let rhs = cn("*");
+    let combined = lhs.intersect(&rhs).unwrap();
+    assert_eq!(combined, lhs);
+    let combined2 = rhs.intersect(&lhs).unwrap();
+    assert_eq!(combined2, lhs);
+}
+
+#[test]
+fn empty_intersection_returns_loud_error() {
+    let err = cn(">=2.0").intersect(&cn("<1.0")).unwrap_err();
+    let IntersectError::Empty { left, right } = err else {
+        panic!("expected Empty, got {err:?}");
+    };
+    assert!(left.contains(">=2.0"), "left should contain operand: {left}");
+    assert!(right.contains("<1.0"), "right should contain operand: {right}");
+}
+
+#[test]
+fn empty_intersection_for_disjoint_ranges() {
+    assert!(matches!(
+        cn(">=2.0, <3.0").intersect(&cn(">=4.0, <5.0")).unwrap_err(),
+        IntersectError::Empty { .. }
+    ));
+}
+
+#[test]
+fn intersect_pin_with_compatible_range() {
+    let combined = cn("=1.5.0").intersect(&cn(">=1.0, <2.0")).unwrap();
+    assert!(combined.matches(&ver("1.5.0")));
+    assert!(!combined.matches(&ver("1.4.0")));
+}
+
+#[test]
+fn intersect_pin_with_incompatible_range_is_empty() {
+    assert!(matches!(
+        cn("=1.5.0").intersect(&cn(">=2.0")).unwrap_err(),
+        IntersectError::Empty { .. }
+    ));
+}
+
+#[test]
+fn intersect_caret_with_minimum() {
+    // ^1.2.3 := >=1.2.3, <2.0.0; ∩ >=1.5 = >=1.5, <2.0.0
+    let combined = cn("^1.2.3").intersect(&cn(">=1.5")).unwrap();
+    assert!(combined.matches(&ver("1.5.0")));
+    assert!(combined.matches(&ver("1.99.99")));
+    assert!(!combined.matches(&ver("1.4.0")));
+    assert!(!combined.matches(&ver("2.0.0")));
+}
+
+#[test]
+fn intersect_two_caret_ranges_disjoint() {
+    // ^1.0 := >=1.0, <2.0; ^2.0 := >=2.0, <3.0; disjoint at 2.0
+    assert!(matches!(cn("^1.0").intersect(&cn("^2.0")).unwrap_err(), IntersectError::Empty { .. }));
+}
+
+#[test]
+fn intersect_two_pins_same_version_succeeds() {
+    let combined = cn("=1.5.0").intersect(&cn("=1.5.0")).unwrap();
+    assert!(combined.matches(&ver("1.5.0")));
+}
+
+#[test]
+fn intersect_two_pins_differing_versions_is_empty() {
+    assert!(matches!(
+        cn("=1.5.0").intersect(&cn("=1.6.0")).unwrap_err(),
+        IntersectError::Empty { .. }
+    ));
+}

--- a/crates/containers-common/tests/version_parse.rs
+++ b/crates/containers-common/tests/version_parse.rs
@@ -1,0 +1,119 @@
+//! Tests for [`Version::parse`] — basic parsing, prefix tolerance,
+//! and rejection of bad inputs.
+
+use containers_common::version::{Version, VersionError, VersionStyle};
+
+#[test]
+fn semver_basic_three_part() {
+    let v = Version::parse("1.95.0", VersionStyle::Semver).unwrap();
+    assert_eq!(format!("{v}"), "1.95.0");
+}
+
+#[test]
+fn semver_two_part_pads_to_three() {
+    let v = Version::parse("1.7", VersionStyle::Semver).unwrap();
+    assert_eq!(format!("{v}"), "1.7.0");
+}
+
+#[test]
+fn semver_one_part_pads_to_three() {
+    let v = Version::parse("2", VersionStyle::Semver).unwrap();
+    assert_eq!(format!("{v}"), "2.0.0");
+}
+
+#[test]
+fn semver_strips_v_prefix() {
+    let v = Version::parse("v1.95.0", VersionStyle::Semver).unwrap();
+    let bare = Version::parse("1.95.0", VersionStyle::Semver).unwrap();
+    assert_eq!(v, bare);
+}
+
+#[test]
+fn semver_strips_capital_v_prefix() {
+    assert_eq!(
+        Version::parse("V1.0.0", VersionStyle::Semver).unwrap(),
+        Version::parse("1.0.0", VersionStyle::Semver).unwrap(),
+    );
+}
+
+#[test]
+fn semver_strips_release_prefix() {
+    assert_eq!(
+        Version::parse("release-1.0.0", VersionStyle::Semver).unwrap(),
+        Version::parse("1.0.0", VersionStyle::Semver).unwrap(),
+    );
+}
+
+#[test]
+fn semver_strips_r_prefix_when_followed_by_digit() {
+    assert_eq!(
+        Version::parse("r1.2.3", VersionStyle::Semver).unwrap(),
+        Version::parse("1.2.3", VersionStyle::Semver).unwrap(),
+    );
+}
+
+#[test]
+fn semver_does_not_strip_r_when_followed_by_letter() {
+    // "release-" is the only `r…` prefix that strips a non-digit; bare
+    // `r` followed by a letter (e.g. `rhel`) must not be eaten.
+    assert!(Version::parse("rhel", VersionStyle::Semver).is_err());
+}
+
+#[test]
+fn prefix_drop_regression() {
+    // The classic `v0.3.0 → 0.4.0` boundary: all four must round-trip
+    // and compare correctly across the prefix change.
+    let tags = ["v0.3.0", "v0.3.1", "0.4.0", "0.5.0"];
+    let parsed: Vec<_> =
+        tags.iter().map(|t| Version::parse(t, VersionStyle::Semver).unwrap()).collect();
+    let strings: Vec<_> = parsed.iter().map(|v| format!("{v}")).collect();
+    assert_eq!(strings, vec!["0.3.0", "0.3.1", "0.4.0", "0.5.0"]);
+}
+
+#[test]
+fn mixed_prefix_corpus_all_parse() {
+    let tags = ["v1.0", "release-1.1", "1.2", "r1.3"];
+    let parsed: Vec<_> =
+        tags.iter().map(|t| Version::parse(t, VersionStyle::Semver).unwrap()).collect();
+    let strings: Vec<_> = parsed.iter().map(|v| format!("{v}")).collect();
+    assert_eq!(strings, vec!["1.0.0", "1.1.0", "1.2.0", "1.3.0"]);
+}
+
+#[test]
+fn semver_accepts_pre_release() {
+    let v = Version::parse("1.0.0-rc.1", VersionStyle::Semver).unwrap();
+    assert_eq!(format!("{v}"), "1.0.0-rc.1");
+}
+
+#[test]
+fn empty_string_is_rejected() {
+    assert!(matches!(Version::parse("", VersionStyle::Semver), Err(VersionError::Empty)));
+    assert!(matches!(Version::parse("   ", VersionStyle::Semver), Err(VersionError::Empty)));
+}
+
+#[test]
+fn non_numeric_input_is_rejected() {
+    assert!(matches!(
+        Version::parse("version", VersionStyle::Semver),
+        Err(VersionError::Semver { .. })
+    ));
+}
+
+#[test]
+fn wildcard_in_version_literal_is_rejected() {
+    assert!(matches!(
+        Version::parse("1.*.0", VersionStyle::Semver),
+        Err(VersionError::WildcardInVersion { .. })
+    ));
+    assert!(matches!(
+        Version::parse("1.x", VersionStyle::Semver),
+        Err(VersionError::WildcardInVersion { .. })
+    ));
+}
+
+#[test]
+fn prefix_mode_behaves_like_semver_today() {
+    let bare = Version::parse("v1.7.0", VersionStyle::Prefix).unwrap();
+    let semver = Version::parse("v1.7.0", VersionStyle::Semver).unwrap();
+    assert_eq!(bare, semver);
+}

--- a/crates/containers-common/tests/version_styles.rs
+++ b/crates/containers-common/tests/version_styles.rs
@@ -1,0 +1,128 @@
+//! Tests for non-semver style modes: `Calver` and `Opaque`, plus
+//! cross-style behavior.
+
+use containers_common::version::{Constraint, IntersectError, Version, VersionError, VersionStyle};
+
+// ===== Calver =====
+
+#[test]
+fn calver_exact_match() {
+    let v = Version::parse("2026.04.29", VersionStyle::Calver).unwrap();
+    let c = Constraint::parse("2026.04.29", VersionStyle::Calver).unwrap();
+    assert!(c.matches(&v));
+    assert!(!c.matches(&Version::parse("2026.05.01", VersionStyle::Calver).unwrap()));
+}
+
+#[test]
+fn calver_lexicographic_ordering() {
+    let earlier = Version::parse("2026.04.29", VersionStyle::Calver).unwrap();
+    let later = Version::parse("2026.05.01", VersionStyle::Calver).unwrap();
+    let range = Constraint::parse(">=2026.04.30", VersionStyle::Calver).unwrap();
+    assert!(!range.matches(&earlier));
+    assert!(range.matches(&later));
+}
+
+#[test]
+fn calver_bounded_range() {
+    let c = Constraint::parse(">=2026.01.01, <2027.01.01", VersionStyle::Calver).unwrap();
+    assert!(c.matches(&Version::parse("2026.04.29", VersionStyle::Calver).unwrap()));
+    assert!(!c.matches(&Version::parse("2025.12.31", VersionStyle::Calver).unwrap()));
+    assert!(!c.matches(&Version::parse("2027.06.01", VersionStyle::Calver).unwrap()));
+}
+
+#[test]
+fn calver_intersect_overlapping() {
+    let a = Constraint::parse(">=2026.01.01, <2027.01.01", VersionStyle::Calver).unwrap();
+    let b = Constraint::parse(">=2026.06.01, <2028.01.01", VersionStyle::Calver).unwrap();
+    let combined = a.intersect(&b).unwrap();
+    assert!(combined.matches(&Version::parse("2026.07.01", VersionStyle::Calver).unwrap()));
+    assert!(!combined.matches(&Version::parse("2026.05.01", VersionStyle::Calver).unwrap()));
+    assert!(!combined.matches(&Version::parse("2027.01.01", VersionStyle::Calver).unwrap()));
+}
+
+#[test]
+fn calver_intersect_disjoint_is_empty() {
+    let a = Constraint::parse(">=2026.01.01", VersionStyle::Calver).unwrap();
+    let b = Constraint::parse("<2025.01.01", VersionStyle::Calver).unwrap();
+    assert!(matches!(a.intersect(&b).unwrap_err(), IntersectError::Empty { .. }));
+}
+
+#[test]
+fn calver_rejects_non_numeric_components() {
+    assert!(matches!(
+        Version::parse("2026.april.29", VersionStyle::Calver),
+        Err(VersionError::Calver { .. })
+    ));
+}
+
+// ===== Opaque =====
+
+#[test]
+fn opaque_exact_match_works() {
+    let v = Version::parse("1.95.0", VersionStyle::Opaque).unwrap();
+    let c = Constraint::parse("1.95.0", VersionStyle::Opaque).unwrap();
+    assert!(c.matches(&v));
+}
+
+#[test]
+fn opaque_string_pin_matches_only_exact_string() {
+    let v = Version::parse("freeform-tag-A", VersionStyle::Opaque).unwrap();
+    let c = Constraint::parse("freeform-tag-A", VersionStyle::Opaque).unwrap();
+    assert!(c.matches(&v));
+    let other = Version::parse("freeform-tag-B", VersionStyle::Opaque).unwrap();
+    assert!(!c.matches(&other));
+}
+
+#[test]
+fn opaque_any_matches_anything() {
+    let c = Constraint::parse("any", VersionStyle::Opaque).unwrap();
+    assert!(c.matches(&Version::parse("anything", VersionStyle::Opaque).unwrap()));
+    assert!(c.matches(&Version::parse("else", VersionStyle::Opaque).unwrap()));
+}
+
+#[test]
+fn opaque_rejects_comparator() {
+    assert!(matches!(
+        Constraint::parse(">=1.95", VersionStyle::Opaque),
+        Err(VersionError::OpaqueComparator { .. })
+    ));
+    assert!(matches!(
+        Constraint::parse("^1.0", VersionStyle::Opaque),
+        Err(VersionError::OpaqueComparator { .. })
+    ));
+    assert!(matches!(
+        Constraint::parse("~1.0", VersionStyle::Opaque),
+        Err(VersionError::OpaqueComparator { .. })
+    ));
+}
+
+#[test]
+fn opaque_rejects_wildcard_other_than_any() {
+    assert!(matches!(
+        Constraint::parse("1.x", VersionStyle::Opaque),
+        Err(VersionError::OpaqueComparator { .. })
+    ));
+}
+
+// ===== Cross-style =====
+
+#[test]
+fn semver_constraint_does_not_match_calver_version() {
+    let semver_c = Constraint::parse(">=1.0", VersionStyle::Semver).unwrap();
+    let calver_v = Version::parse("2026.04.29", VersionStyle::Calver).unwrap();
+    assert!(!semver_c.matches(&calver_v));
+}
+
+#[test]
+fn intersect_across_styles_returns_style_mismatch() {
+    let semver = Constraint::parse(">=1.0", VersionStyle::Semver).unwrap();
+    let calver = Constraint::parse(">=2026.01.01", VersionStyle::Calver).unwrap();
+    assert!(matches!(semver.intersect(&calver).unwrap_err(), IntersectError::StyleMismatch));
+}
+
+#[test]
+fn intersect_semver_with_opaque_returns_style_mismatch() {
+    let semver = Constraint::parse(">=1.0", VersionStyle::Semver).unwrap();
+    let opaque = Constraint::parse("1.0", VersionStyle::Opaque).unwrap();
+    assert!(matches!(semver.intersect(&opaque).unwrap_err(), IntersectError::StyleMismatch));
+}


### PR DESCRIPTION
## Summary

Introduces `containers-common::version` — a single `Version` + `Constraint` library every consumer (containers-db linter, luggage resolver, stibbons CLI, version-bump scripts) will share, replacing the ad-hoc parsing that produced the `v0.3.0 → 0.4.0` prefix-drop bug.

- Built on the [`semver` 1.x](https://crates.io/crates/semver) crate with a thin wrapper for prefix tolerance (`v` / `V` / `release-` / `r<digit>`), opaque + calver style modes, and an `intersect()` operation the resolver needs
- Library only — no consumer wiring yet (separate issues, see issue #416)
- Crate-evaluation rationale documented in `crates/containers-common/README.md` (semver chosen over `node-semver-rs` and `pep440-rs`)

## API surface

```rust
use containers_common::version::{Constraint, Version, VersionStyle};

let v = Version::parse("v1.7.0", VersionStyle::Semver)?;
let c = Constraint::parse(">=1.5, <2", VersionStyle::Semver)?;
assert!(c.matches(&v));

let other = Constraint::parse(">=1.6", VersionStyle::Semver)?;
let merged = c.intersect(&other)?;
```

`VersionStyle::{Semver, Prefix, Calver, Opaque}` selects the parse grammar; `Constraint::intersect` returns `IntersectError::Empty` for unsatisfiable combinations (the signal the luggage resolver uses for its remediation menu in #403).

## Test plan

- [x] 51-case integration test corpus across 4 files (`tests/version_*.rs`):
  - Prefix-drop regression (`v0.3.0`, `v0.3.1`, `0.4.0`, `0.5.0`)
  - Mixed-prefix corpora (`v`, `V`, `release-`, `r<digit>`)
  - Cargo-style `^` / `~` semantics
  - npm-style `1.x` / `1.7.x` wildcards
  - Range intersection (`>=1.7,<2.0 ∩ >=1.8.5,<3.0` → matches `1.9.0`, not `1.8.0` or `2.0.0`)
  - Empty intersection (`>=2.0 ∩ <1.0` → loud error)
  - Opaque-mode rejection of comparators
  - Calver ordering and ranges
  - Cross-style intersect → `StyleMismatch`
  - Bad inputs (empty, non-numeric, wildcard-in-version)
- [x] `just test containers-common` — 106 tests pass (54 inline + 51 integration + 1 doctest)
- [x] `just lint v5` — clippy + rustfmt clean
- [x] Pre-push hook green — typos, cargo-deny, cargo-test, osv-scanner

Closes #416