### PR TITLE
ci(lefthook): lint only changed files on PRs in Run Tests job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,9 +122,35 @@ jobs:
           conform enforce --base-branch "origin/${BASE_REF}"
 
       - name: Run linting (lefthook)
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          echo "Running all linters via lefthook (single source of truth)..."
-          lefthook run pre-commit --all-files
+          # On PRs, lint only the files changed against the base branch.
+          # Hooks with a `glob` skip themselves when no matching file is
+          # in the list, so Rust-only / docs-only / workflow-only PRs no
+          # longer pay the full-repo shellcheck/shfmt/rumdl cost.
+          # Push events (main / tags / workflow_dispatch) still run the
+          # full sweep, preserving the drift safety net on the canonical
+          # branch.
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            mapfile -t CHANGED < <(git diff --name-only "origin/${BASE_REF}...HEAD")
+            if [ "${#CHANGED[@]}" -eq 0 ]; then
+              echo "No files changed against origin/${BASE_REF} — skipping lefthook."
+              exit 0
+            fi
+            echo "Running lefthook against changed files:"
+            printf '  %s\n' "${CHANGED[@]}"
+            # Lefthook 2.1.6's --files-from-stdin filter drops matching
+            # files (observed locally); use the repeated --file flag
+            # which honors hook globs correctly.
+            ARGS=()
+            for f in "${CHANGED[@]}"; do ARGS+=(--file "$f"); done
+            lefthook run pre-commit --no-stage-fixed "${ARGS[@]}"
+          else
+            echo "Running all linters via lefthook (full sweep)..."
+            lefthook run pre-commit --all-files
+          fi
 
       - name: Run secret scanning with Gitleaks
         uses: gitleaks/gitleaks-action@v2


### PR DESCRIPTION
## Summary

- The `Run linting (lefthook)` step in the `Run Tests` job ran
  `lefthook run pre-commit --all-files` on every event, paying full-repo
  shellcheck/shfmt/rumdl/enforce-command-prefix cost on PRs that touch
  zero matching files (e.g. PR #417 sat ~10 minutes here while the
  actual Rust work finished elsewhere in 2-7 minutes).
- On `pull_request`, diff against `origin/${BASE_REF}` and pass each
  changed path to lefthook via repeated `--file` flags. Hooks with a
  `glob` skip when no matching path is in the list, so Rust-only,
  docs-only, and workflow-only PRs cut to seconds.
- On `push` / `tag` / `workflow_dispatch`, keep `--all-files` so the
  canonical-branch drift safety net is preserved.
- Adds `--no-stage-fixed` to suppress git-add noise from `stage_fixed: true`
  hooks running outside a commit context.

### Why repeated `--file` and not `--files-from-stdin`

Lefthook 2.1.6's `--files-from-stdin` filter drops matching files
locally — verified: `cargo-lint` skipped even with `Cargo.toml` in the
list. The repeated `--file <path>` form honors hook globs correctly.

## Test plan

- [x] `just lint-workflows` (actionlint) clean on the new step
- [x] Local: `lefthook run pre-commit --no-stage-fixed --file .github/workflows/ci.yml` runs in 0.26s and only fires `actionlint` / `dprint-yaml` / `gitleaks` etc., demonstrating the speedup
- [x] Local: simulated Rust file lists confirm `cargo-lint` / `shellcheck` / `taplo` fire only when their matching paths are present, skip otherwise
- [x] `just test` passes (2951 unit tests)
- [x] `lefthook.yml` is unmodified — no change to local pre-commit/pre-push behavior
- [ ] CI verification: this PR's own `Run Tests` step should run lefthook against just `.github/workflows/ci.yml` (yaml + actionlint hooks only) and finish in seconds rather than minutes

## Acceptance criteria from #418

- [x] On a Rust-only PR the lefthook step finishes in <~30s — verified locally; CI confirmation will land on the next Rust PR
- [x] PRs touching shell files still run shellcheck/shfmt/enforce-command-prefix
- [x] PRs touching markdown still run rumdl
- [x] No regression in local pre-push or pre-commit hook coverage (`lefthook.yml` untouched)

Closes #418