### PR TITLE
feat(tooldb): add just db-* recipes for containers-db schema validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ just fmt           # cargo fmt --all
 just build         # cargo build --workspace
 just check-versions
 just install-hooks # lefthook install
+just db-validate   # validate sibling containers-db schemas + fixtures
 ```
 
 The raw commands these wrap — useful when debugging or when `just` isn't available:

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ just test-integration                  # integration only
 just test-integration-one python_dev   # single integration test
 just test-feature python-dev           # quick single-feature test in isolation
 just lint                              # run every lefthook hook on all files
+just db-validate                       # validate sibling containers-db schemas + fixtures
 ```
 
 When testing Docker builds manually, **always use the integration test

--- a/justfile
+++ b/justfile
@@ -10,6 +10,29 @@ default:
     @just --list --unsorted
 
 # ============================================================================
+# containers-db (sibling repo) — see "containers-db" section below
+# ============================================================================
+
+# Path to the sibling containers-db checkout. Devcontainer mounts it at
+# /workspace/containers-db; host clones typically use ../containers-db.
+# Override with CONTAINERS_DB=/path/to/containers-db.
+CONTAINERS_DB := env_var_or_default("CONTAINERS_DB", justfile_directory() + "/../containers-db")
+
+# ajv-cli + ajv-formats versions are pinned to match the source-of-truth CI
+# workflow at containers-db/.github/workflows/validate.yml — bump in lockstep
+# with that workflow (and only that workflow).
+AJV_CLI_VERSION := "5.0.0"
+AJV_FORMATS_VERSION := "3.0.1"
+
+# Mandatory ajv flags. Every db-* recipe interpolates {{ AJV_FLAGS }} so the
+# spec dialect and format plugin can never be silently dropped.
+# --spec=draft2020 selects JSON Schema 2020-12 (the schemas use
+# `unevaluatedProperties` and `$dynamicRef`, which behave differently under
+# the default draft-07). -c ajv-formats enables the `format` keyword
+# (uri, date-time, …), which is otherwise a no-op.
+AJV_FLAGS := "--spec=draft2020 -c ajv-formats"
+
+# ============================================================================
 # Tests
 # ============================================================================
 
@@ -234,6 +257,108 @@ check-env:
 # Refresh checksums after version bumps
 update-checksums:
     ./bin/update-checksums.sh
+
+# ============================================================================
+# containers-db
+# ============================================================================
+# Wrappers around the ajv-cli commands that the containers-db CI workflow
+# runs. The mandatory flags (--spec=draft2020, -c ajv-formats) are baked in
+# via AJV_FLAGS so contributors can't silently drop them.
+#
+# Catalog path comes from $CONTAINERS_DB (default: ../containers-db sibling).
+# Source of truth for command shape and pinned versions:
+#   containers-db/.github/workflows/validate.yml
+
+# Internal: fail fast if the containers-db checkout is missing.
+[private]
+_db-check:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -d "{{ CONTAINERS_DB }}" ]; then
+        echo "containers-db not found at: {{ CONTAINERS_DB }}" >&2
+        echo "" >&2
+        echo "Clone joshjhall/containers-db as a sibling of this repo, or set" >&2
+        echo "CONTAINERS_DB=/path/to/containers-db before invoking." >&2
+        exit 1
+    fi
+
+# Compile both containers-db schemas (catches schema-internal mistakes).
+db-compile: _db-check
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd "{{ CONTAINERS_DB }}"
+    npx --yes -p ajv-cli@{{ AJV_CLI_VERSION }} -p ajv-formats@{{ AJV_FORMATS_VERSION }} -- \
+        ajv compile {{ AJV_FLAGS }} -s schema/tool.schema.json
+    npx --yes -p ajv-cli@{{ AJV_CLI_VERSION }} -p ajv-formats@{{ AJV_FORMATS_VERSION }} -- \
+        ajv compile {{ AJV_FLAGS }} -s schema/version.schema.json
+
+# Validate every fixture (positive cases pass, _negative/* must fail).
+db-validate: db-compile
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd "{{ CONTAINERS_DB }}"
+    ajv() {
+        npx --yes -p ajv-cli@{{ AJV_CLI_VERSION }} -p ajv-formats@{{ AJV_FORMATS_VERSION }} -- ajv "$@"
+    }
+    # Positive fixtures
+    ajv validate {{ AJV_FLAGS }} -s schema/tool.schema.json    -d fixtures/sample-tool/index.json
+    ajv validate {{ AJV_FLAGS }} -s schema/version.schema.json -d "fixtures/sample-tool/versions/*.json"
+    ajv validate {{ AJV_FLAGS }} -s schema/version.schema.json -d "fixtures/tier*-example.json"
+    # Cross-reference + comparator-placeholder check
+    node scripts/validate-cross-refs.mjs
+    # Negative fixtures: each must be rejected by ajv OR by validate-cross-refs
+    # (matches the workflow's combined ajv_rc/xref_rc check).
+    for fixture in fixtures/_negative/*.json; do
+        ajv_rc=0
+        xref_rc=0
+        set +e
+        ajv validate {{ AJV_FLAGS }} -s schema/version.schema.json -d "$fixture"
+        ajv_rc=$?
+        node scripts/validate-cross-refs.mjs --only "$fixture"
+        xref_rc=$?
+        set -e
+        if [ "$ajv_rc" -eq 0 ] && [ "$xref_rc" -eq 0 ]; then
+            echo "ERROR: negative fixture $fixture passed both ajv AND cross-ref" >&2
+            exit 1
+        fi
+        echo "Negative fixture $fixture correctly rejected (ajv=$ajv_rc, xref=$xref_rc)"
+    done
+
+# Validate one tool's index (and versions/, if present).
+db-validate-tool TOOL: db-compile
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd "{{ CONTAINERS_DB }}"
+    if [ ! -d "tools/{{ TOOL }}" ]; then
+        echo "tools/{{ TOOL }}/ not found in {{ CONTAINERS_DB }}" >&2
+        exit 1
+    fi
+    ajv() {
+        npx --yes -p ajv-cli@{{ AJV_CLI_VERSION }} -p ajv-formats@{{ AJV_FORMATS_VERSION }} -- ajv "$@"
+    }
+    ajv validate {{ AJV_FLAGS }} -s schema/tool.schema.json -d "tools/{{ TOOL }}/index.json"
+    if compgen -G "tools/{{ TOOL }}/versions/*.json" >/dev/null; then
+        ajv validate {{ AJV_FLAGS }} -s schema/version.schema.json -d "tools/{{ TOOL }}/versions/*.json"
+    fi
+
+# Validate every tool under tools/.
+db-validate-all: db-compile
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd "{{ CONTAINERS_DB }}"
+    ajv() {
+        npx --yes -p ajv-cli@{{ AJV_CLI_VERSION }} -p ajv-formats@{{ AJV_FORMATS_VERSION }} -- ajv "$@"
+    }
+    shopt -s nullglob
+    for dir in tools/*/; do
+        tool="${dir%/}"
+        tool="${tool#tools/}"
+        echo "=== $tool ==="
+        ajv validate {{ AJV_FLAGS }} -s schema/tool.schema.json -d "tools/$tool/index.json"
+        if compgen -G "tools/$tool/versions/*.json" >/dev/null; then
+            ajv validate {{ AJV_FLAGS }} -s schema/version.schema.json -d "tools/$tool/versions/*.json"
+        fi
+    done
 
 # ============================================================================
 # Release


### PR DESCRIPTION
## Summary

- Wrap the long `ajv-cli` invocations the `containers-db` CI workflow runs
  in four justfile recipes (`db-compile`, `db-validate`, `db-validate-tool TOOL`,
  `db-validate-all`) plus a private `_db-check` guard.
- Hard-bake `--spec=draft2020 -c ajv-formats` into a shared `AJV_FLAGS` justfile
  variable so contributors can't silently drop them — both flags fail closed
  (validation returns success but the wrong dialect / format keyword is
  ignored), which is the failure mode the issue calls out.
- Pin `ajv-cli@5.0.0` and `ajv-formats@3.0.1` as justfile variables matching
  `containers-db/.github/workflows/validate.yml`, with a comment naming that
  workflow as the source of truth for future bumps.
- Resolve the sibling catalog via `${CONTAINERS_DB:-../containers-db}` so the
  recipes work from the devcontainer (`/workspace/containers-db`) and from a
  host clone without configuration.
- Document `just db-validate` in `README.md` "Testing" and `CLAUDE.md` recipe
  summary.

## Test plan

- [x] `just db-compile` — both schemas compile cleanly
- [x] `just db-validate` — all positive fixtures pass; all 9 negative
      fixtures correctly rejected by either ajv or `validate-cross-refs.mjs`
      (matches the workflow's combined `ajv_rc || xref_rc` semantics)
- [x] `just db-validate-tool rust` — index + 5 versions
- [x] `just db-validate-tool gcc` — index only (system_package, no versions/)
- [x] `just db-validate-all` — all 6 tools under `tools/` pass
- [x] `CONTAINERS_DB=/nonexistent just db-compile` — exit 1 with the
      documented "clone joshjhall/containers-db..." message
- [x] `just db-validate-tool nonexistent-tool` — exit 1 with clear error
- [x] `just lint-docs` clean, `just --fmt --check` clean
- [x] `just test` — 2951 passed, 0 failed (no regressions)

## Decision: don't fold into `just lint` / `just test`

The issue's open question. Folded was tempting but `containers-db` is an
optional sibling — it isn't present in parent-repo CI and may not be on
host clones — so making `lint`/`test` depend on it would break the common
path. Kept `db-*` as a separate group, matching the existing convention
(`lint-docker`, `lint-workflows`, `check-versions` are all distinct concerns).

Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)