### PR TITLE
feat(luggage): activity-aware version selection and recommendation gating

### DIFF
--- a/crates/containers-common/src/tooldb/tool.rs
+++ b/crates/containers-common/src/tooldb/tool.rs
@@ -120,6 +120,36 @@ pub enum ActivityScore {
     Unknown,
 }
 
+impl ActivityScore {
+    /// Numeric rank, where lower means more active.
+    ///
+    /// `Unknown` ranks worst so forward-compat fallbacks fail policy checks
+    /// by default — better to refuse a tool we can't classify than to
+    /// silently recommend one.
+    #[must_use]
+    pub const fn rank(self) -> u8 {
+        match self {
+            Self::VeryActive => 0,
+            Self::Active => 1,
+            Self::Maintained => 2,
+            Self::Slow => 3,
+            Self::Stale => 4,
+            Self::Dormant => 5,
+            Self::Abandoned => 6,
+            Self::Unknown => 7,
+        }
+    }
+
+    /// True when `self` is at least as active as `threshold`.
+    ///
+    /// Reads as "this tool is *at least* maintained":
+    /// `score.is_at_least(ActivityScore::Maintained)`.
+    #[must_use]
+    pub const fn is_at_least(self, threshold: Self) -> bool {
+        self.rank() <= threshold.rank()
+    }
+}
+
 /// Raw scanner signals behind an [`ActivityScore`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -316,5 +346,60 @@ mod tests {
         }"#;
         let res: Result<Tool, _> = serde_json::from_str(json);
         assert!(res.is_err(), "extra fields should be rejected");
+    }
+
+    #[test]
+    fn activity_score_rank_is_monotonic() {
+        let ladder = [
+            ActivityScore::VeryActive,
+            ActivityScore::Active,
+            ActivityScore::Maintained,
+            ActivityScore::Slow,
+            ActivityScore::Stale,
+            ActivityScore::Dormant,
+            ActivityScore::Abandoned,
+            ActivityScore::Unknown,
+        ];
+        for window in ladder.windows(2) {
+            assert!(
+                window[0].rank() < window[1].rank(),
+                "{:?}.rank()={} should be less than {:?}.rank()={}",
+                window[0],
+                window[0].rank(),
+                window[1],
+                window[1].rank(),
+            );
+        }
+    }
+
+    #[test]
+    fn is_at_least_treats_self_as_satisfying_threshold() {
+        for score in [
+            ActivityScore::VeryActive,
+            ActivityScore::Maintained,
+            ActivityScore::Abandoned,
+            ActivityScore::Unknown,
+        ] {
+            assert!(score.is_at_least(score), "{score:?} should satisfy itself");
+        }
+    }
+
+    #[test]
+    fn is_at_least_active_passes_for_more_active_tiers() {
+        let threshold = ActivityScore::Maintained;
+        assert!(ActivityScore::VeryActive.is_at_least(threshold));
+        assert!(ActivityScore::Active.is_at_least(threshold));
+        assert!(ActivityScore::Maintained.is_at_least(threshold));
+        assert!(!ActivityScore::Slow.is_at_least(threshold));
+        assert!(!ActivityScore::Stale.is_at_least(threshold));
+        assert!(!ActivityScore::Dormant.is_at_least(threshold));
+        assert!(!ActivityScore::Abandoned.is_at_least(threshold));
+    }
+
+    #[test]
+    fn unknown_fails_default_threshold_but_not_loosest() {
+        assert!(!ActivityScore::Unknown.is_at_least(ActivityScore::Maintained));
+        assert!(!ActivityScore::Unknown.is_at_least(ActivityScore::Abandoned));
+        assert!(ActivityScore::Unknown.is_at_least(ActivityScore::Unknown));
     }
 }

--- a/crates/luggage/README.md
+++ b/crates/luggage/README.md
@@ -1,0 +1,83 @@
+# luggage
+
+Catalog loader and version/platform resolver for the
+[containers-db](https://github.com/joshjhall/containers-db) tool catalog.
+Used by `stibbons` (project setup wizard) and `igor` (container runtime
+manager). See the lib docs at `crates/luggage/src/lib.rs` for the API
+surface and quick-start example.
+
+## What it does
+
+Given a tool id, a version request (latest / channel / exact / partial),
+and a target platform, luggage answers *"what should I install and how
+should I verify it?"* — returning a typed [`ResolvedInstall`] with the
+chosen install method, verification metadata, dependencies, and any
+non-fatal warnings. It does not (yet) execute installs.
+
+## Activity-tier policy
+
+Every tool in the catalog carries an [`ActivityScore`] in one of seven
+buckets, scored by the upstream scanner. Resolution is gated by a
+[`ResolutionPolicy`] that decides which tiers to accept, whether to refuse
+versions below the tool's `minimum_recommended`, and whether to warn on
+borderline tiers.
+
+Three preset bundles cover the common consumers:
+
+| Tier          | `Stibbons` (default) | `Igor`     | `Permissive` |
+| ------------- | -------------------- | ---------- | ------------ |
+| `very-active` | accept               | accept     | accept       |
+| `active`      | accept               | accept     | accept       |
+| `maintained`  | accept               | accept     | accept       |
+| `slow`        | refuse               | accept     | accept       |
+| `stale`       | refuse               | accept     | accept       |
+| `dormant`     | refuse               | refuse     | accept       |
+| `abandoned`   | refuse               | refuse     | accept       |
+| `unknown`     | refuse               | refuse     | accept       |
+
+`Stibbons` additionally warns when the policy *does* admit a `slow` or
+`stale` tool (i.e. when a caller has lowered `min_activity` but kept
+`warn_on_slow_or_stale = true`). `Igor` and `Permissive` suppress these
+warnings by default.
+
+## `minimum_recommended`
+
+When a tool sets `minimum_recommended`, resolution refuses versions below
+it unless the policy enables `allow_below_min_recommended`, in which case
+the result carries a [`ResolutionWarning::BelowMinimumRecommended`] entry
+instead. This protects the wizard from quietly recommending a stale pin
+while still letting `igor` honor an explicit user pin.
+
+## CLI
+
+```text
+luggage resolve <tool> [--version <v> | --channel <name>]
+                       [--policy stibbons|igor|permissive]
+                       [--allow-abandoned]
+                       [--allow-below-min-recommended]
+                       [--os <distro>] [--os-version <ver>] [--arch <arch>]
+                       [--catalog <path>] [--json]
+```
+
+- `--policy` selects the preset bundle. Defaults to `stibbons`.
+- `--allow-abandoned` lowers `min_activity` to `Abandoned` regardless of
+  preset (useful for one-off installs of a known-archived tool).
+- `--allow-below-min-recommended` flips the bool on regardless of preset.
+- Without `--os`/`--os-version`/`--arch`, the host is auto-detected from
+  `/etc/os-release` and `std::env::consts::ARCH`.
+
+Exit codes: `0` on success, `2` when the host platform is unsupported
+(`UnsupportedPlatform`, `NoMatchingInstallMethod`), `1` for everything else
+including policy violations. Bash callers can branch on `2` for an
+"install if possible, skip otherwise" pattern.
+
+## See also
+
+- Catalog repo: <https://github.com/joshjhall/containers-db>
+- Schema: `schema/tool.schema.json` and `schema/version.schema.json`
+- Design notes: `.claude/memory/luggage-tooldb-design.md`
+
+[`ActivityScore`]: ../containers-common/src/tooldb/tool.rs
+[`ResolutionPolicy`]: src/policy.rs
+[`ResolvedInstall`]: src/resolver.rs
+[`ResolutionWarning::BelowMinimumRecommended`]: src/resolver.rs

--- a/crates/luggage/src/bin/luggage.rs
+++ b/crates/luggage/src/bin/luggage.rs
@@ -17,8 +17,12 @@ use std::io;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use clap::{Args, Parser, Subcommand};
-use luggage::{Catalog, CatalogSource, LuggageError, Platform, ResolvedInstall, VersionSpec};
+use clap::{Args, Parser, Subcommand, ValueEnum};
+use containers_common::tooldb::ActivityScore;
+use luggage::{
+    Catalog, CatalogSource, LuggageError, Platform, PolicyPreset, ResolutionPolicy,
+    ResolutionWarning, ResolvedInstall, VersionSpec,
+};
 
 /// Luggage — catalog loader and version/platform resolver.
 #[derive(Parser, Debug)]
@@ -67,9 +71,45 @@ struct ResolveArgs {
     #[arg(long, env = "CONTAINERS_DB", default_value = "../containers-db")]
     catalog: PathBuf,
 
+    /// Named policy preset to start from. Defaults to `stibbons`.
+    #[arg(long, value_enum)]
+    policy: Option<PolicyChoice>,
+
+    /// Allow tools whose activity tier is `dormant` or `abandoned`. Lowers
+    /// `min_activity` to `Abandoned` regardless of preset.
+    #[arg(long)]
+    allow_abandoned: bool,
+
+    /// Allow versions below the tool's `minimum_recommended` (emits a
+    /// warning instead of refusing).
+    #[arg(long)]
+    allow_below_min_recommended: bool,
+
     /// Emit JSON instead of human-readable output.
     #[arg(long)]
     json: bool,
+}
+
+/// CLI mirror of [`luggage::PolicyPreset`].
+#[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
+#[clap(rename_all = "lowercase")]
+enum PolicyChoice {
+    /// Stibbons defaults: refuse below-Maintained, refuse below-min, warn on slow/stale.
+    Stibbons,
+    /// Igor defaults: accept down to Stale, allow below-min.
+    Igor,
+    /// Permissive: accept any tier.
+    Permissive,
+}
+
+impl From<PolicyChoice> for PolicyPreset {
+    fn from(value: PolicyChoice) -> Self {
+        match value {
+            PolicyChoice::Stibbons => Self::Stibbons,
+            PolicyChoice::Igor => Self::Igor,
+            PolicyChoice::Permissive => Self::Permissive,
+        }
+    }
 }
 
 fn main() -> ExitCode {
@@ -106,8 +146,9 @@ fn cmd_resolve(args: &ResolveArgs) -> Result<(), LuggageError> {
     let catalog = Catalog::load(CatalogSource::LocalPath(args.catalog.clone()))?;
     let spec = build_spec(args.version.as_deref(), args.channel.as_deref());
     let platform = build_platform(args)?;
+    let policy = build_policy(args);
 
-    let resolved = catalog.resolve(&args.tool, &spec, &platform)?;
+    let resolved = catalog.resolve_with_policy(&args.tool, &spec, &platform, &policy)?;
 
     if args.json {
         let out = serde_json::to_string_pretty(&resolved)
@@ -115,8 +156,27 @@ fn cmd_resolve(args: &ResolveArgs) -> Result<(), LuggageError> {
         println!("{out}");
     } else {
         print_human(&resolved);
+        report_warnings(&resolved.warnings);
     }
     Ok(())
+}
+
+/// Build the policy from CLI flags. Precedence:
+///
+/// 1. `--policy <name>` (or [`ResolutionPolicy::default()`] when absent)
+/// 2. `--allow-abandoned` lowers `min_activity` to `Abandoned`
+/// 3. `--allow-below-min-recommended` flips the bool on
+fn build_policy(args: &ResolveArgs) -> ResolutionPolicy {
+    let mut policy = args.policy.map_or_else(ResolutionPolicy::default, |choice| {
+        ResolutionPolicy::from_preset(PolicyPreset::from(choice))
+    });
+    if args.allow_abandoned {
+        policy.min_activity = ActivityScore::Abandoned;
+    }
+    if args.allow_below_min_recommended {
+        policy.allow_below_min_recommended = true;
+    }
+    policy
 }
 
 /// Pick a [`VersionSpec`] from the CLI flags.
@@ -234,6 +294,23 @@ fn report_error(err: &LuggageError) {
     }
 }
 
+fn report_warnings(warnings: &[ResolutionWarning]) {
+    for w in warnings {
+        match w {
+            ResolutionWarning::SlowOrStaleActivity { score } => {
+                eprintln!(
+                    "warning: tool activity is `{score:?}` — pinning is fine but expect fewer upstream releases"
+                );
+            }
+            ResolutionWarning::BelowMinimumRecommended { version, minimum } => {
+                eprintln!(
+                    "warning: resolved version `{version}` is below `minimum_recommended` `{minimum}`",
+                );
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -283,5 +360,55 @@ mod tests {
     fn verify_cli() {
         use clap::CommandFactory;
         Cli::command().debug_assert();
+    }
+
+    fn args_with(
+        policy: Option<PolicyChoice>,
+        allow_abandoned: bool,
+        below_min: bool,
+    ) -> ResolveArgs {
+        ResolveArgs {
+            tool: "rust".into(),
+            version: None,
+            channel: None,
+            os: None,
+            os_version: None,
+            arch: None,
+            catalog: PathBuf::from("/tmp"),
+            policy,
+            allow_abandoned,
+            allow_below_min_recommended: below_min,
+            json: false,
+        }
+    }
+
+    #[test]
+    fn build_policy_defaults_to_stibbons() {
+        let p = build_policy(&args_with(None, false, false));
+        assert_eq!(p, ResolutionPolicy::stibbons());
+    }
+
+    #[test]
+    fn build_policy_uses_chosen_preset() {
+        let p = build_policy(&args_with(Some(PolicyChoice::Permissive), false, false));
+        assert_eq!(p, ResolutionPolicy::permissive());
+        let p = build_policy(&args_with(Some(PolicyChoice::Igor), false, false));
+        assert_eq!(p, ResolutionPolicy::igor());
+    }
+
+    #[test]
+    fn build_policy_allow_abandoned_overrides_min_activity() {
+        let p = build_policy(&args_with(Some(PolicyChoice::Stibbons), true, false));
+        assert_eq!(p.min_activity, ActivityScore::Abandoned);
+        // Other fields preserved from preset.
+        assert!(!p.allow_below_min_recommended);
+        assert!(p.warn_on_slow_or_stale);
+    }
+
+    #[test]
+    fn build_policy_allow_below_min_overrides_bool() {
+        let p = build_policy(&args_with(None, false, true));
+        assert!(p.allow_below_min_recommended);
+        assert_eq!(p.min_activity, ActivityScore::Maintained);
     }
 }

--- a/crates/luggage/src/catalog.rs
+++ b/crates/luggage/src/catalog.rs
@@ -13,11 +13,12 @@ use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use containers_common::tooldb::{Tool, ToolVersion};
+use containers_common::tooldb::{ActivityScore, Kind, Tool, ToolVersion};
 use containers_common::version::{Version, VersionStyle};
 
 use crate::error::{LuggageError, Result};
 use crate::platform::Platform;
+use crate::policy::ResolutionPolicy;
 use crate::resolver::{self, ResolvedInstall, VersionSpec};
 
 /// Where to load the catalog from.
@@ -93,11 +94,12 @@ impl Catalog {
         self.tools.get(id)
     }
 
-    /// Resolve `(tool, spec, platform)` into a concrete install plan.
+    /// Resolve `(tool, spec, platform)` into a concrete install plan using
+    /// the default [`ResolutionPolicy`] (stibbons-strict).
     ///
     /// # Errors
     ///
-    /// See [`resolver::resolve`] for the full set of possible errors.
+    /// See [`resolver::resolve_with_policy`] for the full set of possible errors.
     pub fn resolve(
         &self,
         tool: &str,
@@ -106,6 +108,44 @@ impl Catalog {
     ) -> Result<ResolvedInstall> {
         let entry = self.tools.get(tool).ok_or_else(|| LuggageError::ToolNotFound(tool.into()))?;
         resolver::resolve(entry, spec, platform)
+    }
+
+    /// Resolve `(tool, spec, platform)` into a concrete install plan, gated
+    /// by a caller-supplied [`ResolutionPolicy`].
+    ///
+    /// # Errors
+    ///
+    /// See [`resolver::resolve_with_policy`] for the full set of possible errors.
+    pub fn resolve_with_policy(
+        &self,
+        tool: &str,
+        spec: &VersionSpec,
+        platform: &Platform,
+        policy: &ResolutionPolicy,
+    ) -> Result<ResolvedInstall> {
+        let entry = self.tools.get(tool).ok_or_else(|| LuggageError::ToolNotFound(tool.into()))?;
+        resolver::resolve_with_policy(entry, spec, platform, policy)
+    }
+
+    /// Tools of the given [`Kind`] whose activity tier is at least
+    /// `Maintained`, sorted by `display_name` for deterministic output.
+    ///
+    /// Use this from the stibbons wizard to populate the recommended-tool
+    /// list — the tier filter prevents abandoned tools from leaking into
+    /// the picker.
+    #[must_use]
+    pub fn recommended(&self, kind: Kind) -> Vec<&Tool> {
+        let mut out: Vec<&Tool> = self
+            .tools
+            .values()
+            .filter(|e| {
+                e.index.kind == kind
+                    && e.index.activity.score.is_at_least(ActivityScore::Maintained)
+            })
+            .map(|e| &e.index)
+            .collect();
+        out.sort_by(|a, b| a.display_name.cmp(&b.display_name));
+        out
     }
 
     fn load_local(root: &Path) -> Result<Self> {
@@ -367,5 +407,46 @@ mod tests {
         fs::write(tmp.path().join("tools/rust/versions/notes.txt"), "ignored").unwrap();
         let cat = Catalog::load(CatalogSource::LocalPath(tmp.path().to_owned())).unwrap();
         assert_eq!(cat.tool_entry("rust").unwrap().versions.len(), 2);
+    }
+
+    fn write_tool(root: &Path, id: &str, kind: &str, score: &str, display_name: &str) {
+        let dir = root.join(format!("tools/{id}"));
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("index.json"),
+            format!(
+                r#"{{
+                    "schemaVersion": 1,
+                    "id": "{id}",
+                    "display_name": "{display_name}",
+                    "kind": "{kind}",
+                    "activity": {{ "score": "{score}", "scanned_at": "2026-01-01T00:00:00Z" }}
+                }}"#,
+            ),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn recommended_filters_by_kind_and_activity() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Build a mixed catalog: two CLI tools above the cutoff, one CLI
+        // below, one Library above (different kind).
+        write_tool(tmp.path(), "tool_a", "cli", "very-active", "Aardvark");
+        write_tool(tmp.path(), "tool_c", "cli", "maintained", "Camel");
+        write_tool(tmp.path(), "tool_d", "cli", "stale", "Dingo");
+        write_tool(tmp.path(), "tool_b", "library", "very-active", "Bobcat");
+
+        let cat = Catalog::load(CatalogSource::LocalPath(tmp.path().to_owned())).unwrap();
+        let recommended = cat.recommended(Kind::Cli);
+        let names: Vec<&str> = recommended.iter().map(|t| t.display_name.as_str()).collect();
+        assert_eq!(names, ["Aardvark", "Camel"], "expected sorted CLI tools above cutoff");
+
+        let libraries = cat.recommended(Kind::Library);
+        assert_eq!(libraries.len(), 1);
+        assert_eq!(libraries[0].id, "tool_b");
+
+        // Service kind is empty in this fixture.
+        assert!(cat.recommended(Kind::Service).is_empty());
     }
 }

--- a/crates/luggage/src/error.rs
+++ b/crates/luggage/src/error.rs
@@ -10,6 +10,7 @@
 use std::fmt;
 use std::path::PathBuf;
 
+use containers_common::tooldb::ActivityScore;
 use containers_common::version::VersionError;
 use thiserror::Error;
 
@@ -100,6 +101,35 @@ pub enum LuggageError {
     /// A version literal in the catalog or a request failed to parse.
     #[error(transparent)]
     VersionParse(#[from] VersionError),
+
+    /// Tool's activity score is below the policy's `min_activity` threshold.
+    #[error(
+        "tool `{tool}` has activity `{score:?}`, below the policy threshold `{threshold:?}`; \
+         pass `--allow-abandoned` or a more permissive `--policy` to override"
+    )]
+    ActivityBelowThreshold {
+        /// Tool id.
+        tool: String,
+        /// Tool's actual activity tier.
+        score: ActivityScore,
+        /// Policy's `min_activity` threshold.
+        threshold: ActivityScore,
+    },
+
+    /// Resolved version is below the tool's `minimum_recommended` and the
+    /// policy does not allow it.
+    #[error(
+        "tool `{tool}` resolved to version `{version}`, below `minimum_recommended` `{minimum}`; \
+         pass `--allow-below-min-recommended` to override"
+    )]
+    BelowMinimumRecommended {
+        /// Tool id.
+        tool: String,
+        /// Resolved version literal.
+        version: String,
+        /// Tool's `minimum_recommended` value.
+        minimum: String,
+    },
 
     /// Auto-detection of the host platform failed (e.g. `/etc/os-release` missing).
     #[error("could not auto-detect platform: {0}")]
@@ -197,6 +227,33 @@ mod tests {
     fn version_not_found_exit_code_is_one() {
         let err = LuggageError::VersionNotFound { tool: "rust".into(), spec: "9.9.9".into() };
         assert_eq!(err.exit_code(), 1);
+    }
+
+    #[test]
+    fn activity_below_threshold_exit_code_is_one() {
+        let err = LuggageError::ActivityBelowThreshold {
+            tool: "ghost".into(),
+            score: ActivityScore::Abandoned,
+            threshold: ActivityScore::Maintained,
+        };
+        assert_eq!(err.exit_code(), 1);
+        let msg = format!("{err}");
+        assert!(msg.contains("ghost"));
+        assert!(msg.contains("Abandoned"));
+        assert!(msg.contains("Maintained"));
+    }
+
+    #[test]
+    fn below_minimum_recommended_exit_code_is_one() {
+        let err = LuggageError::BelowMinimumRecommended {
+            tool: "rust".into(),
+            version: "1.50.0".into(),
+            minimum: "1.84.0".into(),
+        };
+        assert_eq!(err.exit_code(), 1);
+        let msg = format!("{err}");
+        assert!(msg.contains("1.50.0"));
+        assert!(msg.contains("1.84.0"));
     }
 
     #[test]

--- a/crates/luggage/src/lib.rs
+++ b/crates/luggage/src/lib.rs
@@ -28,9 +28,11 @@
 pub mod catalog;
 pub mod error;
 pub mod platform;
+pub mod policy;
 pub mod resolver;
 
 pub use catalog::{Catalog, CatalogSource};
 pub use error::{LuggageError, Result};
 pub use platform::Platform;
-pub use resolver::{ResolvedInstall, VersionSpec};
+pub use policy::{PolicyPreset, ResolutionPolicy};
+pub use resolver::{ResolutionWarning, ResolvedInstall, VersionSpec};

--- a/crates/luggage/src/policy.rs
+++ b/crates/luggage/src/policy.rs
@@ -1,0 +1,150 @@
+//! Resolution policy — caller-supplied gating rules for [`crate::Catalog::resolve_with_policy`].
+//!
+//! A [`ResolutionPolicy`] tells luggage three things:
+//!
+//! 1. The lowest [`ActivityScore`] the resolver will accept (anything below
+//!    fails with [`crate::LuggageError::ActivityBelowThreshold`]).
+//! 2. Whether to allow versions below the tool's `minimum_recommended`
+//!    (otherwise: [`crate::LuggageError::BelowMinimumRecommended`]).
+//! 3. Whether to attach a warning when the tool is in the `Slow` or `Stale`
+//!    band rather than silently passing.
+//!
+//! Three presets cover the common consumers:
+//!
+//! | Preset       | `min_activity` | below-min | warn slow/stale |
+//! |--------------|----------------|-----------|-----------------|
+//! | `Stibbons`   | `Maintained`   | refuse    | yes             |
+//! | `Igor`       | `Stale`        | allow     | no              |
+//! | `Permissive` | `Abandoned`    | allow     | no              |
+//!
+//! `Default` matches `Stibbons` — the wizard surface is luggage's most
+//! safety-critical caller, so the safe default is the strict one.
+//!
+//! See `crates/luggage/README.md` for the full tier semantics.
+
+use containers_common::tooldb::ActivityScore;
+
+/// Caller-supplied gating policy for [`crate::Catalog::resolve_with_policy`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResolutionPolicy {
+    /// Lowest activity tier the resolver will accept.
+    pub min_activity: ActivityScore,
+    /// True to permit selecting versions below the tool's
+    /// `minimum_recommended`. When false, below-minimum versions yield
+    /// [`crate::LuggageError::BelowMinimumRecommended`].
+    pub allow_below_min_recommended: bool,
+    /// True to attach a [`crate::ResolutionWarning::SlowOrStaleActivity`]
+    /// warning when the tool is in the `Slow` or `Stale` band.
+    pub warn_on_slow_or_stale: bool,
+}
+
+/// Named preset bundles. See module docs for the cell-by-cell breakdown.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PolicyPreset {
+    /// Stibbons wizard defaults: refuse below-Maintained, refuse below-min, warn on slow/stale.
+    Stibbons,
+    /// Igor runtime defaults: accept down to Stale, allow below-min, no warnings.
+    Igor,
+    /// Permissive: accept anything, allow below-min, no warnings. Used by `--policy permissive`.
+    Permissive,
+}
+
+impl ResolutionPolicy {
+    /// The default policy used by [`crate::Catalog::resolve`] and the
+    /// stibbons wizard. Refuses anything below `Maintained` and anything
+    /// below `minimum_recommended`; warns on `Slow`/`Stale`.
+    #[must_use]
+    pub const fn stibbons() -> Self {
+        Self {
+            min_activity: ActivityScore::Maintained,
+            allow_below_min_recommended: false,
+            warn_on_slow_or_stale: true,
+        }
+    }
+
+    /// The runtime install policy. Accepts down to `Stale` (igor will
+    /// install whatever the user asked for as long as it isn't outright
+    /// dormant) and tolerates below-min versions silently.
+    #[must_use]
+    pub const fn igor() -> Self {
+        Self {
+            min_activity: ActivityScore::Stale,
+            allow_below_min_recommended: true,
+            warn_on_slow_or_stale: false,
+        }
+    }
+
+    /// Permissive policy: all tiers permitted, including dormant and
+    /// abandoned. Used by `--policy permissive` and tests.
+    #[must_use]
+    pub const fn permissive() -> Self {
+        Self {
+            min_activity: ActivityScore::Abandoned,
+            allow_below_min_recommended: true,
+            warn_on_slow_or_stale: false,
+        }
+    }
+
+    /// Build a policy from a named preset.
+    #[must_use]
+    pub const fn from_preset(preset: PolicyPreset) -> Self {
+        match preset {
+            PolicyPreset::Stibbons => Self::stibbons(),
+            PolicyPreset::Igor => Self::igor(),
+            PolicyPreset::Permissive => Self::permissive(),
+        }
+    }
+}
+
+impl Default for ResolutionPolicy {
+    fn default() -> Self {
+        Self::stibbons()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_matches_stibbons_preset() {
+        assert_eq!(ResolutionPolicy::default(), ResolutionPolicy::stibbons());
+    }
+
+    #[test]
+    fn stibbons_preset_is_strict() {
+        let p = ResolutionPolicy::stibbons();
+        assert_eq!(p.min_activity, ActivityScore::Maintained);
+        assert!(!p.allow_below_min_recommended);
+        assert!(p.warn_on_slow_or_stale);
+    }
+
+    #[test]
+    fn igor_preset_is_lenient_about_min_recommended() {
+        let p = ResolutionPolicy::igor();
+        assert_eq!(p.min_activity, ActivityScore::Stale);
+        assert!(p.allow_below_min_recommended);
+        assert!(!p.warn_on_slow_or_stale);
+    }
+
+    #[test]
+    fn permissive_preset_accepts_everything() {
+        let p = ResolutionPolicy::permissive();
+        assert_eq!(p.min_activity, ActivityScore::Abandoned);
+        assert!(p.allow_below_min_recommended);
+        assert!(!p.warn_on_slow_or_stale);
+    }
+
+    #[test]
+    fn from_preset_round_trips() {
+        assert_eq!(
+            ResolutionPolicy::from_preset(PolicyPreset::Stibbons),
+            ResolutionPolicy::stibbons(),
+        );
+        assert_eq!(ResolutionPolicy::from_preset(PolicyPreset::Igor), ResolutionPolicy::igor());
+        assert_eq!(
+            ResolutionPolicy::from_preset(PolicyPreset::Permissive),
+            ResolutionPolicy::permissive(),
+        );
+    }
+}

--- a/crates/luggage/src/resolver.rs
+++ b/crates/luggage/src/resolver.rs
@@ -25,7 +25,7 @@
 use std::fmt;
 
 use containers_common::tooldb::{
-    Dependency, InstallMethod, Invoke, PostInstall, SupportStatus, Verification,
+    ActivityScore, Dependency, InstallMethod, Invoke, PostInstall, SupportStatus, Verification,
 };
 use containers_common::version::{Constraint, Version, VersionStyle};
 use serde::Serialize;
@@ -33,6 +33,7 @@ use serde::Serialize;
 use crate::catalog::ToolEntry;
 use crate::error::{LuggageError, Result};
 use crate::platform::{self, Platform};
+use crate::policy::ResolutionPolicy;
 
 /// What version of a tool to resolve.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -88,27 +89,116 @@ pub struct ResolvedInstall {
     pub dependencies: Option<Vec<Dependency>>,
     /// The platform that produced this resolution.
     pub platform: Platform,
+    /// Non-fatal warnings raised by the policy gate.
+    ///
+    /// Empty by default. JSON consumers can branch on the `kind` discriminant.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<ResolutionWarning>,
 }
 
-/// Resolve `(entry, spec, platform)` into an install plan.
+/// A non-fatal observation from the policy gate.
+///
+/// Tagged with `kind` so JSON consumers can match on a stable string and
+/// pull the variant-specific fields off the same object.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ResolutionWarning {
+    /// The tool's activity tier is `Slow` or `Stale`.
+    SlowOrStaleActivity {
+        /// The actual activity score (always `Slow` or `Stale` here).
+        score: ActivityScore,
+    },
+    /// The chosen version is below the tool's `minimum_recommended` and
+    /// the policy chose to allow it rather than refuse outright.
+    BelowMinimumRecommended {
+        /// Resolved version literal.
+        version: String,
+        /// The tool's `minimum_recommended` value.
+        minimum: String,
+    },
+}
+
+/// Resolve `(entry, spec, platform)` into an install plan using the
+/// [`ResolutionPolicy::default()`] (stibbons-strict) policy.
 ///
 /// # Errors
 ///
-/// - [`LuggageError::VersionNotFound`] if no version satisfied `spec`.
-/// - [`LuggageError::UnsupportedPlatform`] if the version's `support_matrix`
-///   has an `unsupported` row matching the platform.
-/// - [`LuggageError::NoMatchingInstallMethod`] if no `install_methods[]`
-///   entry's predicate matches.
-/// - [`LuggageError::VersionParse`] if a version literal is malformed.
+/// See [`resolve_with_policy`] for the full set of possible errors.
 pub fn resolve(
     entry: &ToolEntry,
     spec: &VersionSpec,
     platform: &Platform,
 ) -> Result<ResolvedInstall> {
-    let style = entry.index.version_style.unwrap_or(VersionStyle::Semver);
-    let (_chosen_version, chosen_doc) = pick_version(entry, spec, style)?;
+    resolve_with_policy(entry, spec, platform, &ResolutionPolicy::default())
+}
 
-    // Step 2 — support matrix gate.
+/// Resolve `(entry, spec, platform)` into an install plan, gated by a
+/// caller-supplied [`ResolutionPolicy`].
+///
+/// Order of operations:
+///
+/// 1. **Activity gate** — refuse outright when the tool's activity score
+///    is below `policy.min_activity`.
+/// 2. **Version pick** — same logic as the unpoliced path.
+/// 3. **`minimum_recommended` gate** — when the chosen version is below
+///    the tool's `minimum_recommended`, either refuse (default) or attach
+///    a warning (when `policy.allow_below_min_recommended`).
+/// 4. **Support matrix gate** — refuse when the platform appears with
+///    `unsupported` status.
+/// 5. **Install method walk** — first matching predicate wins; refuse
+///    when none match.
+/// 6. **Slow/stale warning** — when `policy.warn_on_slow_or_stale` and the
+///    activity tier is `Slow` or `Stale`, attach a warning.
+///
+/// # Errors
+///
+/// - [`LuggageError::ActivityBelowThreshold`] if step 1 fails.
+/// - [`LuggageError::VersionNotFound`] if no version satisfied `spec`.
+/// - [`LuggageError::BelowMinimumRecommended`] if step 3 refuses.
+/// - [`LuggageError::UnsupportedPlatform`] if step 4 refuses.
+/// - [`LuggageError::NoMatchingInstallMethod`] if step 5 finds no match.
+/// - [`LuggageError::VersionParse`] if a version literal is malformed.
+pub fn resolve_with_policy(
+    entry: &ToolEntry,
+    spec: &VersionSpec,
+    platform: &Platform,
+    policy: &ResolutionPolicy,
+) -> Result<ResolvedInstall> {
+    let mut warnings = Vec::new();
+
+    // Step 1 — activity gate.
+    let score = entry.index.activity.score;
+    if !score.is_at_least(policy.min_activity) {
+        return Err(LuggageError::ActivityBelowThreshold {
+            tool: entry.index.id.clone(),
+            score,
+            threshold: policy.min_activity,
+        });
+    }
+
+    let style = entry.index.version_style.unwrap_or(VersionStyle::Semver);
+    let (chosen_version, chosen_doc) = pick_version(entry, spec, style)?;
+
+    // Step 3 — minimum_recommended gate.
+    if let Some(min_str) = entry.index.minimum_recommended.as_deref() {
+        let parsed_min = Version::parse(min_str, style)?;
+        if chosen_version < &parsed_min {
+            if policy.allow_below_min_recommended {
+                warnings.push(ResolutionWarning::BelowMinimumRecommended {
+                    version: chosen_doc.version.clone(),
+                    minimum: min_str.to_owned(),
+                });
+            } else {
+                return Err(LuggageError::BelowMinimumRecommended {
+                    tool: entry.index.id.clone(),
+                    version: chosen_doc.version.clone(),
+                    minimum: min_str.to_owned(),
+                });
+            }
+        }
+    }
+
+    // Step 4 — support matrix gate.
     for row in &chosen_doc.support_matrix {
         if platform::matches_support(platform, row) && row.status == SupportStatus::Unsupported {
             return Err(LuggageError::UnsupportedPlatform(Box::new(
@@ -125,7 +215,7 @@ pub fn resolve(
         }
     }
 
-    // Step 3 — install method walk.
+    // Step 5 — install method walk.
     let method = chosen_doc
         .install_methods
         .iter()
@@ -138,7 +228,12 @@ pub fn resolve(
             arch: platform.arch.clone(),
         })?;
 
-    Ok(build_resolved(&entry.index.id, &chosen_doc.version, method, platform.clone()))
+    // Step 6 — slow/stale warning.
+    if policy.warn_on_slow_or_stale && matches!(score, ActivityScore::Slow | ActivityScore::Stale) {
+        warnings.push(ResolutionWarning::SlowOrStaleActivity { score });
+    }
+
+    Ok(build_resolved(&entry.index.id, &chosen_doc.version, method, platform.clone(), warnings))
 }
 
 fn pick_version<'a>(
@@ -247,6 +342,7 @@ fn build_resolved(
     version: &str,
     method: &InstallMethod,
     platform: Platform,
+    warnings: Vec<ResolutionWarning>,
 ) -> ResolvedInstall {
     ResolvedInstall {
         tool: tool.to_owned(),
@@ -259,6 +355,7 @@ fn build_resolved(
         post_install: method.post_install.clone(),
         dependencies: method.dependencies.clone(),
         platform,
+        warnings,
     }
 }
 
@@ -495,5 +592,183 @@ mod tests {
     fn build_partial_constraint_rejects_three_dots() {
         let err = build_partial_constraint("1.2.3").unwrap_err();
         assert!(matches!(err, LuggageError::Catalog(_)));
+    }
+
+    fn entry_with_score(score: ActivityScore) -> ToolEntry {
+        let mut tool = make_tool();
+        tool.activity.score = score;
+        tool.minimum_recommended = None;
+        let mut map = BTreeMap::new();
+        let parsed = Version::parse("1.95.0", VersionStyle::Semver).unwrap();
+        map.insert(parsed, make_version("1.95.0", vec![], vec![make_method(vec!["debian"])]));
+        ToolEntry { index: tool, versions: map }
+    }
+
+    #[test]
+    fn default_policy_accepts_maintained_or_better() {
+        for score in [ActivityScore::VeryActive, ActivityScore::Active, ActivityScore::Maintained] {
+            let entry = entry_with_score(score);
+            let r = resolve_with_policy(
+                &entry,
+                &VersionSpec::Latest,
+                &debian_amd64(),
+                &ResolutionPolicy::default(),
+            )
+            .unwrap();
+            assert!(r.warnings.is_empty(), "tier {score:?} should produce no warnings");
+        }
+    }
+
+    #[test]
+    fn warn_on_slow_or_stale_fires_only_when_admitted() {
+        // Build a policy that admits Slow/Stale and asks for warnings —
+        // this is the only configuration in which the warning is reachable
+        // (the default policy refuses Slow/Stale before they get this far).
+        let policy = ResolutionPolicy {
+            min_activity: ActivityScore::Stale,
+            warn_on_slow_or_stale: true,
+            allow_below_min_recommended: false,
+        };
+        for score in [ActivityScore::Slow, ActivityScore::Stale] {
+            let entry = entry_with_score(score);
+            let r = resolve_with_policy(&entry, &VersionSpec::Latest, &debian_amd64(), &policy)
+                .unwrap();
+            assert_eq!(r.warnings.len(), 1, "tier {score:?} should emit one warning");
+            match &r.warnings[0] {
+                ResolutionWarning::SlowOrStaleActivity { score: actual } => {
+                    assert_eq!(*actual, score);
+                }
+                ResolutionWarning::BelowMinimumRecommended { .. } => {
+                    panic!("expected SlowOrStaleActivity, got BelowMinimumRecommended");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn default_policy_refuses_below_maintained() {
+        for score in [
+            ActivityScore::Slow,
+            ActivityScore::Stale,
+            ActivityScore::Dormant,
+            ActivityScore::Abandoned,
+            ActivityScore::Unknown,
+        ] {
+            let entry = entry_with_score(score);
+            let err = resolve_with_policy(
+                &entry,
+                &VersionSpec::Latest,
+                &debian_amd64(),
+                &ResolutionPolicy::default(),
+            )
+            .unwrap_err();
+            match err {
+                LuggageError::ActivityBelowThreshold { score: actual, threshold, .. } => {
+                    assert_eq!(actual, score);
+                    assert_eq!(threshold, ActivityScore::Maintained);
+                }
+                other => panic!("expected ActivityBelowThreshold for {score:?}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn permissive_policy_accepts_all_tiers() {
+        let policy = ResolutionPolicy::permissive();
+        for score in [
+            ActivityScore::VeryActive,
+            ActivityScore::Active,
+            ActivityScore::Maintained,
+            ActivityScore::Slow,
+            ActivityScore::Stale,
+            ActivityScore::Dormant,
+            ActivityScore::Abandoned,
+        ] {
+            let entry = entry_with_score(score);
+            let r = resolve_with_policy(&entry, &VersionSpec::Latest, &debian_amd64(), &policy)
+                .unwrap();
+            assert!(r.warnings.is_empty(), "permissive policy should suppress warnings");
+        }
+    }
+
+    #[test]
+    fn igor_policy_accepts_down_to_stale() {
+        let policy = ResolutionPolicy::igor();
+        for score in [ActivityScore::Maintained, ActivityScore::Slow, ActivityScore::Stale] {
+            let entry = entry_with_score(score);
+            assert!(
+                resolve_with_policy(&entry, &VersionSpec::Latest, &debian_amd64(), &policy).is_ok(),
+                "igor should accept {score:?}",
+            );
+        }
+        let entry = entry_with_score(ActivityScore::Dormant);
+        assert!(
+            resolve_with_policy(&entry, &VersionSpec::Latest, &debian_amd64(), &policy).is_err(),
+            "igor should still refuse Dormant",
+        );
+    }
+
+    #[test]
+    fn below_minimum_recommended_refuses_by_default() {
+        let mut entry = entry_with_score(ActivityScore::VeryActive);
+        entry.index.minimum_recommended = Some("2.0.0".into());
+        // Tool only has 1.95.0 in versions; latest will pick that, which is below 2.0.0.
+        let err = resolve_with_policy(
+            &entry,
+            &VersionSpec::Latest,
+            &debian_amd64(),
+            &ResolutionPolicy::default(),
+        )
+        .unwrap_err();
+        match err {
+            LuggageError::BelowMinimumRecommended { version, minimum, .. } => {
+                assert_eq!(version, "1.95.0");
+                assert_eq!(minimum, "2.0.0");
+            }
+            other => panic!("expected BelowMinimumRecommended, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn below_minimum_recommended_warns_when_allowed() {
+        let mut entry = entry_with_score(ActivityScore::VeryActive);
+        entry.index.minimum_recommended = Some("2.0.0".into());
+        let policy = ResolutionPolicy { allow_below_min_recommended: true, ..Default::default() };
+        let r =
+            resolve_with_policy(&entry, &VersionSpec::Latest, &debian_amd64(), &policy).unwrap();
+        assert_eq!(r.warnings.len(), 1);
+        match &r.warnings[0] {
+            ResolutionWarning::BelowMinimumRecommended { version, minimum } => {
+                assert_eq!(version, "1.95.0");
+                assert_eq!(minimum, "2.0.0");
+            }
+            ResolutionWarning::SlowOrStaleActivity { .. } => {
+                panic!("expected BelowMinimumRecommended, got SlowOrStaleActivity");
+            }
+        }
+    }
+
+    #[test]
+    fn above_minimum_recommended_emits_no_warning() {
+        let mut entry = entry_with_score(ActivityScore::VeryActive);
+        entry.index.minimum_recommended = Some("1.0.0".into());
+        let r = resolve_with_policy(
+            &entry,
+            &VersionSpec::Latest,
+            &debian_amd64(),
+            &ResolutionPolicy::default(),
+        )
+        .unwrap();
+        assert!(r.warnings.is_empty());
+    }
+
+    #[test]
+    fn slow_or_stale_warning_suppressed_when_policy_disables() {
+        let entry = entry_with_score(ActivityScore::Slow);
+        let policy =
+            ResolutionPolicy { warn_on_slow_or_stale: false, ..ResolutionPolicy::permissive() };
+        let r =
+            resolve_with_policy(&entry, &VersionSpec::Latest, &debian_amd64(), &policy).unwrap();
+        assert!(r.warnings.is_empty());
     }
 }

--- a/crates/luggage/testdata/policy_catalog/tools/tool_abandoned/index.json
+++ b/crates/luggage/testdata/policy_catalog/tools/tool_abandoned/index.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "id": "tool_abandoned",
+  "display_name": "Tool Abandoned",
+  "kind": "cli",
+  "activity": { "score": "abandoned", "scanned_at": "2026-04-29T00:00:00Z" },
+  "version_style": "semver",
+  "default_version": "1.0.0",
+  "minimum_recommended": "0.1.0",
+  "available": [{ "version": "1.0.0" }]
+}

--- a/crates/luggage/testdata/policy_catalog/tools/tool_abandoned/versions/1.0.0.json
+++ b/crates/luggage/testdata/policy_catalog/tools/tool_abandoned/versions/1.0.0.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "tool": "tool_abandoned",
+  "version": "1.0.0",
+  "channel": "stable",
+  "support_matrix": [
+    { "os": "debian", "os_version": "13", "arch": "amd64", "status": "supported" }
+  ],
+  "install_methods": [
+    {
+      "name": "stub",
+      "platform": { "os": ["debian"], "arch": ["amd64"] },
+      "verification": { "tier": 4, "tofu": true }
+    }
+  ],
+  "metadata": {
+    "added_at": "2026-04-29T00:00:00Z",
+    "schema_version": 1
+  }
+}

--- a/crates/luggage/testdata/policy_catalog/tools/tool_active/index.json
+++ b/crates/luggage/testdata/policy_catalog/tools/tool_active/index.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "id": "tool_active",
+  "display_name": "Tool Active",
+  "kind": "cli",
+  "activity": { "score": "active", "scanned_at": "2026-04-29T00:00:00Z" },
+  "version_style": "semver",
+  "default_version": "1.0.0",
+  "minimum_recommended": "0.1.0",
+  "available": [{ "version": "1.0.0" }]
+}

--- a/crates/luggage/testdata/policy_catalog/tools/tool_active/versions/1.0.0.json
+++ b/crates/luggage/testdata/policy_catalog/tools/tool_active/versions/1.0.0.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "tool": "tool_active",
+  "version": "1.0.0",
+  "channel": "stable",
+  "support_matrix": [
+    { "os": "debian", "os_version": "13", "arch": "amd64", "status": "supported" }
+  ],
+  "install_methods": [
+    {
+      "name": "stub",
+      "platform": { "os": ["debian"], "arch": ["amd64"] },
+      "verification": { "tier": 4, "tofu": true }
+    }
+  ],
+  "metadata": {
+    "added_at": "2026-04-29T00:00:00Z",
+    "schema_version": 1
+  }
+}

--- a/crates/luggage/testdata/policy_catalog/tools/tool_below_min/index.json
+++ b/crates/luggage/testdata/policy_catalog/tools/tool_below_min/index.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "id": "tool_below_min",
+  "display_name": "Tool Below Min",
+  "kind": "cli",
+  "activity": { "score": "very-active", "scanned_at": "2026-04-29T00:00:00Z" },
+  "version_style": "semver",
+  "default_version": "1.0.0",
+  "minimum_recommended": "2.0.0",
+  "available": [{ "version": "1.0.0" }]
+}

--- a/crates/luggage/testdata/policy_catalog/tools/tool_below_min/versions/1.0.0.json
+++ b/crates/luggage/testdata/policy_catalog/tools/tool_below_min/versions/1.0.0.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "tool": "tool_below_min",
+  "version": "1.0.0",
+  "channel": "stable",
+  "support_matrix": [
+    { "os": "debian", "os_version": "13", "arch": "amd64", "status": "supported" }
+  ],
+  "install_methods": [
+    {
+      "name": "stub",
+      "platform": { "os": ["debian"], "arch": ["amd64"] },
+      "verification": { "tier": 4, "tofu": true }
+    }
+  ],
+  "metadata": {
+    "added_at": "2026-04-29T00:00:00Z",
+    "schema_version": 1
+  }
+}

--- a/crates/luggage/testdata/policy_catalog/tools/tool_dormant/index.json
+++ b/crates/luggage/testdata/policy_catalog/tools/tool_dormant/index.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "id": "tool_dormant",
+  "display_name": "Tool Dormant",
+  "kind": "cli",
+  "activity": { "score": "dormant", "scanned_at": "2026-04-29T00:00:00Z" },
+  "version_style": "semver",
+  "default_version": "1.0.0",
+  "minimum_recommended": "0.1.0",
+  "available": [{ "version": "1.0.0" }]
+}

--- a/crates/luggage/testdata/policy_catalog/tools/tool_dormant/versions/1.0.0.json
+++ b/crates/luggage/testdata/policy_catalog/tools/tool_dormant/versions/1.0.0.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "tool": "tool_dormant",
+  "version": "1.0.0",
+  "channel": "stable",
+  "support_matrix": [
+    { "os": "debian", "os_version": "13", "arch": "amd64", "status": "supported" }
+  ],
+  "install_methods": [
+    {
+      "name": "stub",
+      "platform": { "os": ["debian"], "arch": ["amd64"] },
+      "verification": { "tier": 4, "tofu": true }
+    }
+  ],
+  "metadata": {
+    "added_at": "2026-04-29T00:00:00Z",
+    "schema_version": 1
+  }
+}

--- a/crates/luggage/testdata/policy_catalog/tools/tool_maintained/index.json
+++ b/crates/luggage/testdata/policy_catalog/tools/tool_maintained/index.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "id": "tool_maintained",
+  "display_name": "Tool Maintained",
+  "kind": "cli",
+  "activity": { "score": "maintained", "scanned_at": "2026-04-29T00:00:00Z" },
+  "version_style": "semver",
+  "default_version": "1.0.0",
+  "minimum_recommended": "0.1.0",
+  "available": [{ "version": "1.0.0" }]
+}

--- a/crates/luggage/testdata/policy_catalog/tools/tool_maintained/versions/1.0.0.json
+++ b/crates/luggage/testdata/policy_catalog/tools/tool_maintained/versions/1.0.0.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "tool": "tool_maintained",
+  "version": "1.0.0",
+  "channel": "stable",
+  "support_matrix": [
+    { "os": "debian", "os_version": "13", "arch": "amd64", "status": "supported" }
+  ],
+  "install_methods": [
+    {
+      "name": "stub",
+      "platform": { "os": ["debian"], "arch": ["amd64"] },
+      "verification": { "tier": 4, "tofu": true }
+    }
+  ],
+  "metadata": {
+    "added_at": "2026-04-29T00:00:00Z",
+    "schema_version": 1
+  }
+}

--- a/crates/luggage/testdata/policy_catalog/tools/tool_slow/index.json
+++ b/crates/luggage/testdata/policy_catalog/tools/tool_slow/index.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "id": "tool_slow",
+  "display_name": "Tool Slow",
+  "kind": "cli",
+  "activity": { "score": "slow", "scanned_at": "2026-04-29T00:00:00Z" },
+  "version_style": "semver",
+  "default_version": "1.0.0",
+  "minimum_recommended": "0.1.0",
+  "available": [{ "version": "1.0.0" }]
+}

--- a/crates/luggage/testdata/policy_catalog/tools/tool_slow/versions/1.0.0.json
+++ b/crates/luggage/testdata/policy_catalog/tools/tool_slow/versions/1.0.0.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "tool": "tool_slow",
+  "version": "1.0.0",
+  "channel": "stable",
+  "support_matrix": [
+    { "os": "debian", "os_version": "13", "arch": "amd64", "status": "supported" }
+  ],
+  "install_methods": [
+    {
+      "name": "stub",
+      "platform": { "os": ["debian"], "arch": ["amd64"] },
+      "verification": { "tier": 4, "tofu": true }
+    }
+  ],
+  "metadata": {
+    "added_at": "2026-04-29T00:00:00Z",
+    "schema_version": 1
+  }
+}

--- a/crates/luggage/testdata/policy_catalog/tools/tool_stale/index.json
+++ b/crates/luggage/testdata/policy_catalog/tools/tool_stale/index.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "id": "tool_stale",
+  "display_name": "Tool Stale",
+  "kind": "cli",
+  "activity": { "score": "stale", "scanned_at": "2026-04-29T00:00:00Z" },
+  "version_style": "semver",
+  "default_version": "1.0.0",
+  "minimum_recommended": "0.1.0",
+  "available": [{ "version": "1.0.0" }]
+}

--- a/crates/luggage/testdata/policy_catalog/tools/tool_stale/versions/1.0.0.json
+++ b/crates/luggage/testdata/policy_catalog/tools/tool_stale/versions/1.0.0.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "tool": "tool_stale",
+  "version": "1.0.0",
+  "channel": "stable",
+  "support_matrix": [
+    { "os": "debian", "os_version": "13", "arch": "amd64", "status": "supported" }
+  ],
+  "install_methods": [
+    {
+      "name": "stub",
+      "platform": { "os": ["debian"], "arch": ["amd64"] },
+      "verification": { "tier": 4, "tofu": true }
+    }
+  ],
+  "metadata": {
+    "added_at": "2026-04-29T00:00:00Z",
+    "schema_version": 1
+  }
+}

--- a/crates/luggage/testdata/policy_catalog/tools/tool_very_active/index.json
+++ b/crates/luggage/testdata/policy_catalog/tools/tool_very_active/index.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "id": "tool_very_active",
+  "display_name": "Tool Very Active",
+  "kind": "cli",
+  "activity": { "score": "very-active", "scanned_at": "2026-04-29T00:00:00Z" },
+  "version_style": "semver",
+  "default_version": "1.0.0",
+  "minimum_recommended": "0.1.0",
+  "available": [{ "version": "1.0.0" }]
+}

--- a/crates/luggage/testdata/policy_catalog/tools/tool_very_active/versions/1.0.0.json
+++ b/crates/luggage/testdata/policy_catalog/tools/tool_very_active/versions/1.0.0.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "tool": "tool_very_active",
+  "version": "1.0.0",
+  "channel": "stable",
+  "support_matrix": [
+    { "os": "debian", "os_version": "13", "arch": "amd64", "status": "supported" }
+  ],
+  "install_methods": [
+    {
+      "name": "stub",
+      "platform": { "os": ["debian"], "arch": ["amd64"] },
+      "verification": { "tier": 4, "tofu": true }
+    }
+  ],
+  "metadata": {
+    "added_at": "2026-04-29T00:00:00Z",
+    "schema_version": 1
+  }
+}

--- a/crates/luggage/tests/policy_tests.rs
+++ b/crates/luggage/tests/policy_tests.rs
@@ -1,0 +1,160 @@
+//! Integration tests for [`luggage`]'s activity-policy gating.
+//!
+//! Each test spawns the CLI against `testdata/policy_catalog/`, which has
+//! one tool per activity tier plus a `tool_below_min` tool whose only
+//! version sits below `minimum_recommended`. Hermetic — no dependency on a
+//! sibling containers-db checkout.
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+const fn binary() -> &'static str {
+    env!("CARGO_BIN_EXE_luggage")
+}
+
+fn catalog_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("testdata/policy_catalog")
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(binary())
+        .args(args)
+        .args(["--os", "debian", "--os-version", "13", "--arch", "amd64"])
+        .arg("--catalog")
+        .arg(catalog_dir())
+        .output()
+        .expect("spawn luggage")
+}
+
+fn assert_exit(out: &Output, expected: i32) {
+    let actual = out.status.code().unwrap_or(-1);
+    assert_eq!(
+        actual,
+        expected,
+        "expected exit {expected}, got {actual}\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+#[test]
+fn default_policy_accepts_very_active() {
+    let out = run(&["resolve", "tool_very_active", "--json"]);
+    assert_exit(&out, 0);
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("parse JSON");
+    assert!(
+        v.get("warnings").is_none(),
+        "very-active tool should serialize without a warnings field, got: {v}",
+    );
+}
+
+#[test]
+fn default_policy_accepts_active_and_maintained() {
+    for tier in ["tool_active", "tool_maintained"] {
+        let out = run(&["resolve", tier]);
+        assert_exit(&out, 0);
+    }
+}
+
+#[test]
+fn default_policy_refuses_slow_and_stale() {
+    for tier in ["tool_slow", "tool_stale"] {
+        let out = run(&["resolve", tier]);
+        assert_exit(&out, 1);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("activity"),
+            "stderr should explain activity threshold for {tier}: {stderr}",
+        );
+    }
+}
+
+#[test]
+fn default_policy_refuses_dormant_and_abandoned() {
+    for tier in ["tool_dormant", "tool_abandoned"] {
+        let out = run(&["resolve", tier]);
+        assert_exit(&out, 1);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("below the policy threshold"),
+            "stderr should explain threshold for {tier}: {stderr}",
+        );
+    }
+}
+
+#[test]
+fn permissive_policy_accepts_every_tier() {
+    for tier in [
+        "tool_very_active",
+        "tool_active",
+        "tool_maintained",
+        "tool_slow",
+        "tool_stale",
+        "tool_dormant",
+        "tool_abandoned",
+    ] {
+        let out = run(&["resolve", tier, "--policy", "permissive"]);
+        assert_exit(&out, 0);
+    }
+}
+
+#[test]
+fn igor_policy_accepts_down_to_stale() {
+    for tier in ["tool_maintained", "tool_slow", "tool_stale"] {
+        let out = run(&["resolve", tier, "--policy", "igor"]);
+        assert_exit(&out, 0);
+    }
+    // igor still refuses dormant.
+    let out = run(&["resolve", "tool_dormant", "--policy", "igor"]);
+    assert_exit(&out, 1);
+}
+
+#[test]
+fn allow_abandoned_overrides_default_policy() {
+    let out = run(&["resolve", "tool_abandoned", "--allow-abandoned"]);
+    assert_exit(&out, 0);
+}
+
+#[test]
+fn slow_warning_serialized_when_admitted() {
+    // Use --policy stibbons + --allow-abandoned to admit a Slow tool while
+    // keeping warn_on_slow_or_stale = true.
+    let out = run(&["resolve", "tool_slow", "--allow-abandoned", "--json"]);
+    assert_exit(&out, 0);
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("parse JSON");
+    let warnings = v["warnings"].as_array().expect("warnings array");
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(warnings[0]["kind"], "slow_or_stale_activity");
+    assert_eq!(warnings[0]["score"], "slow");
+}
+
+#[test]
+fn permissive_policy_suppresses_warnings() {
+    let out = run(&["resolve", "tool_slow", "--policy", "permissive", "--json"]);
+    assert_exit(&out, 0);
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("parse JSON");
+    assert!(v.get("warnings").is_none(), "permissive policy should suppress warnings, got: {v}");
+}
+
+#[test]
+fn below_minimum_recommended_refused_by_default() {
+    let out = run(&["resolve", "tool_below_min"]);
+    assert_exit(&out, 1);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("minimum_recommended"),
+        "stderr should mention minimum_recommended: {stderr}",
+    );
+}
+
+#[test]
+fn below_minimum_recommended_warns_when_allowed() {
+    let out = run(&["resolve", "tool_below_min", "--allow-below-min-recommended", "--json"]);
+    assert_exit(&out, 0);
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("parse JSON");
+    let warnings = v["warnings"].as_array().expect("warnings array");
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(warnings[0]["kind"], "below_minimum_recommended");
+    assert_eq!(warnings[0]["version"], "1.0.0");
+    assert_eq!(warnings[0]["minimum"], "2.0.0");
+}


### PR DESCRIPTION
## Summary

- Add `ResolutionPolicy` with three preset bundles (`stibbons`, `igor`, `permissive`) gating `Catalog::resolve` on activity tier and the tool's `minimum_recommended` field.
- New `resolve_with_policy()` does the gating; `resolve()` becomes a thin `Default::default()` wrapper so existing callers keep working.
- New `Catalog::recommended(kind)` API for the stibbons wizard — returns `Maintained`-or-better tools sorted by display name.
- Two new typed errors (`ActivityBelowThreshold`, `BelowMinimumRecommended`, both exit 1) and a `ResolutionWarning` enum attached to `ResolvedInstall.warnings` for non-fatal observations.
- `ActivityScore::rank()` / `is_at_least()` helpers on the shared enum in `containers-common` (Unknown ranks worst as a fail-safe for forward-compat).
- CLI: `--policy`, `--allow-abandoned`, `--allow-below-min-recommended`.
- Per-tier fixture catalog under `crates/luggage/testdata/policy_catalog/` and a new `crates/luggage/README.md` documenting tier semantics.

## Test plan

- [x] `cargo test --workspace` — full suite passes (resolver-level unit tests cover each tier × each policy combo; 11 new CLI integration tests in `policy_tests.rs`).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `just lint` — all 19 lefthook hooks pass.
- [x] Manual smoke test:
  - default policy refuses `tool_abandoned` (exit 1, "below the policy threshold")
  - `--allow-abandoned` admits it (exit 0)
  - `--policy permissive` accepts every tier and suppresses warnings
  - `--allow-below-min-recommended` converts the below-min error into a JSON-serialized warning

Closes #404