### PR TITLE
feat(luggage): install execution engine with tier 3 verification (#405)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1621,10 +1621,13 @@ dependencies = [
  "containers-common",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
+ "shell-words",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
+ "ureq",
 ]
 
 [[package]]
@@ -2326,7 +2329,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2577,6 +2582,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -3101,6 +3112,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3306,6 +3332,24 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/crates/luggage/Cargo.toml
+++ b/crates/luggage/Cargo.toml
@@ -16,9 +16,13 @@ containers-common = { workspace = true }
 clap = { workspace = true, features = ["env"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
+shell-words = "1"
+tempfile = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+ureq = { version = "2", default-features = false, features = ["tls"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/luggage/src/bin/luggage.rs
+++ b/crates/luggage/src/bin/luggage.rs
@@ -20,8 +20,8 @@ use std::process::ExitCode;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use containers_common::tooldb::ActivityScore;
 use luggage::{
-    Catalog, CatalogSource, LuggageError, Platform, PolicyPreset, ResolutionPolicy,
-    ResolutionWarning, ResolvedInstall, VersionSpec,
+    Catalog, CatalogSource, InstallReport, Installer, InstallerOptions, LuggageError, Platform,
+    PolicyPreset, ResolutionPolicy, ResolutionWarning, ResolvedInstall, VersionSpec,
 };
 
 /// Luggage — catalog loader and version/platform resolver.
@@ -40,6 +40,8 @@ struct Cli {
 enum Commands {
     /// Resolve `(tool, version, platform)` into a concrete install plan.
     Resolve(ResolveArgs),
+    /// Install a tool — download, verify, run installer, validate.
+    Install(InstallArgs),
 }
 
 #[derive(Args, Debug)]
@@ -47,6 +49,17 @@ struct ResolveArgs {
     /// Catalog tool id (e.g. `rust`, `node`).
     tool: String,
 
+    #[command(flatten)]
+    common: CommonArgs,
+
+    /// Emit JSON instead of human-readable output.
+    #[arg(long)]
+    json: bool,
+}
+
+/// CLI fields shared by `resolve` and `install`.
+#[derive(Args, Debug)]
+struct CommonArgs {
     /// Exact or partial version (e.g. `1.95.0`, `1.84`). Mutually exclusive with `--channel`.
     #[arg(long, conflicts_with = "channel")]
     version: Option<String>,
@@ -84,10 +97,50 @@ struct ResolveArgs {
     /// warning instead of refusing).
     #[arg(long)]
     allow_below_min_recommended: bool,
+}
 
-    /// Emit JSON instead of human-readable output.
+/// `luggage install <tool>[@<version>]` arguments.
+#[derive(Args, Debug)]
+struct InstallArgs {
+    /// Catalog tool id with an optional `@<version>` suffix
+    /// (e.g. `rust`, `rust@1.95.0`, `node@22`).
+    tool: String,
+
+    #[command(flatten)]
+    common: CommonArgs,
+
+    /// Print the substituted install plan as JSON without performing I/O.
     #[arg(long)]
-    json: bool,
+    dry_run: bool,
+
+    /// Reinstall even when the idempotency check thinks the tool is current.
+    #[arg(long)]
+    force: bool,
+
+    /// Per-feature log directory.
+    #[arg(long, default_value = "/var/log/luggage")]
+    log_dir: PathBuf,
+
+    /// Where the installer symlinks tool binaries.
+    #[arg(long, default_value = "/usr/local/bin")]
+    bin_root: PathBuf,
+
+    /// Cache root for tool data (`CARGO_HOME` and `RUSTUP_HOME` live under here).
+    #[arg(long, default_value = "/cache")]
+    cache_root: PathBuf,
+
+    /// Scratch directory for downloads.
+    #[arg(long, default_value = "/tmp")]
+    tmp_root: PathBuf,
+
+    /// Override the install user (defaults to `$USERNAME`, then `vscode`).
+    #[arg(long)]
+    user: Option<String>,
+
+    /// Skip system-package installation. Use when the host package
+    /// manager is unavailable or already pre-populated.
+    #[arg(long)]
+    skip_system_packages: bool,
 }
 
 /// CLI mirror of [`luggage::PolicyPreset`].
@@ -132,24 +185,18 @@ fn main() -> ExitCode {
                 ExitCode::from(u8::try_from(e.exit_code()).unwrap_or(1))
             }
         },
+        Commands::Install(args) => match cmd_install(&args) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(e) => {
+                report_error(&e);
+                ExitCode::from(u8::try_from(e.exit_code()).unwrap_or(1))
+            }
+        },
     }
 }
 
 fn cmd_resolve(args: &ResolveArgs) -> Result<(), LuggageError> {
-    if !args.catalog.is_dir() {
-        return Err(LuggageError::Catalog(format!(
-            "catalog path `{}` is not a directory; pass --catalog or set CONTAINERS_DB",
-            args.catalog.display()
-        )));
-    }
-
-    let catalog = Catalog::load(CatalogSource::LocalPath(args.catalog.clone()))?;
-    let spec = build_spec(args.version.as_deref(), args.channel.as_deref());
-    let platform = build_platform(args)?;
-    let policy = build_policy(args);
-
-    let resolved = catalog.resolve_with_policy(&args.tool, &spec, &platform, &policy)?;
-
+    let resolved = resolve_for(&args.tool, &args.common)?;
     if args.json {
         let out = serde_json::to_string_pretty(&resolved)
             .map_err(|source| LuggageError::Parse { path: PathBuf::from("<stdout>"), source })?;
@@ -161,19 +208,105 @@ fn cmd_resolve(args: &ResolveArgs) -> Result<(), LuggageError> {
     Ok(())
 }
 
+fn cmd_install(args: &InstallArgs) -> Result<(), LuggageError> {
+    // Accept `tool@version` shorthand. Conflict with `--version` is an error.
+    let (tool_id, inline_version) = split_tool_version(&args.tool);
+    if inline_version.is_some() && args.common.version.is_some() {
+        return Err(LuggageError::Catalog(
+            "specify the version once: either `tool@version` or `--version`, not both".into(),
+        ));
+    }
+    let common = inline_version.map_or_else(
+        || clone_common(&args.common),
+        |v| {
+            let mut c = clone_common(&args.common);
+            c.version = Some(v.to_owned());
+            c
+        },
+    );
+    let resolved = resolve_for(tool_id, &common)?;
+    report_warnings(&resolved.warnings);
+
+    let opts = InstallerOptions {
+        dry_run: args.dry_run,
+        force: args.force,
+        log_dir: args.log_dir.clone(),
+        bin_root: args.bin_root.clone(),
+        cache_root: args.cache_root.clone(),
+        tmp_root: args.tmp_root.clone(),
+        user_override: args.user.clone(),
+        install_system_packages: !args.skip_system_packages,
+    };
+    let installer = Installer::with_options(opts);
+
+    if args.dry_run {
+        let plan = installer.plan(&resolved)?;
+        let out = serde_json::to_string_pretty(&plan)
+            .map_err(|source| LuggageError::Parse { path: PathBuf::from("<stdout>"), source })?;
+        println!("{out}");
+        return Ok(());
+    }
+
+    let report: InstallReport = installer.run(&resolved)?;
+    if report.already_installed {
+        println!("{}@{} already installed", report.tool, report.version);
+    } else {
+        println!("installed {}@{}", report.tool, report.version);
+    }
+    if let Some(p) = &report.log_path {
+        println!("  log: {}", p.display());
+    }
+    Ok(())
+}
+
+/// Resolve `(tool, common)` into a [`ResolvedInstall`]. Shared by both
+/// subcommands so flag semantics stay in lockstep.
+fn resolve_for(tool: &str, common: &CommonArgs) -> Result<ResolvedInstall, LuggageError> {
+    if !common.catalog.is_dir() {
+        return Err(LuggageError::Catalog(format!(
+            "catalog path `{}` is not a directory; pass --catalog or set CONTAINERS_DB",
+            common.catalog.display()
+        )));
+    }
+    let catalog = Catalog::load(CatalogSource::LocalPath(common.catalog.clone()))?;
+    let spec = build_spec(common.version.as_deref(), common.channel.as_deref());
+    let platform = build_platform(common)?;
+    let policy = build_policy(common);
+    catalog.resolve_with_policy(tool, &spec, &platform, &policy)
+}
+
+/// Split a `tool[@version]` string into `(tool, Option<version>)`.
+fn split_tool_version(s: &str) -> (&str, Option<&str>) {
+    s.split_once('@').map_or((s, None), |(t, v)| (t, Some(v)))
+}
+
+fn clone_common(c: &CommonArgs) -> CommonArgs {
+    CommonArgs {
+        version: c.version.clone(),
+        channel: c.channel.clone(),
+        os: c.os.clone(),
+        os_version: c.os_version.clone(),
+        arch: c.arch.clone(),
+        catalog: c.catalog.clone(),
+        policy: c.policy,
+        allow_abandoned: c.allow_abandoned,
+        allow_below_min_recommended: c.allow_below_min_recommended,
+    }
+}
+
 /// Build the policy from CLI flags. Precedence:
 ///
 /// 1. `--policy <name>` (or [`ResolutionPolicy::default()`] when absent)
 /// 2. `--allow-abandoned` lowers `min_activity` to `Abandoned`
 /// 3. `--allow-below-min-recommended` flips the bool on
-fn build_policy(args: &ResolveArgs) -> ResolutionPolicy {
-    let mut policy = args.policy.map_or_else(ResolutionPolicy::default, |choice| {
+fn build_policy(common: &CommonArgs) -> ResolutionPolicy {
+    let mut policy = common.policy.map_or_else(ResolutionPolicy::default, |choice| {
         ResolutionPolicy::from_preset(PolicyPreset::from(choice))
     });
-    if args.allow_abandoned {
+    if common.allow_abandoned {
         policy.min_activity = ActivityScore::Abandoned;
     }
-    if args.allow_below_min_recommended {
+    if common.allow_below_min_recommended {
         policy.allow_below_min_recommended = true;
     }
     policy
@@ -196,10 +329,10 @@ fn build_spec(version: Option<&str>, channel: Option<&str>) -> VersionSpec {
     }
 }
 
-fn build_platform(args: &ResolveArgs) -> Result<Platform, LuggageError> {
+fn build_platform(common: &CommonArgs) -> Result<Platform, LuggageError> {
     let detected = detect_platform();
 
-    let os = match (&args.os, &detected) {
+    let os = match (&common.os, &detected) {
         (Some(o), _) => o.clone(),
         (None, Ok(p)) => p.os.clone(),
         (None, Err(e)) => {
@@ -208,11 +341,11 @@ fn build_platform(args: &ResolveArgs) -> Result<Platform, LuggageError> {
             )));
         }
     };
-    let os_version = args
+    let os_version = common
         .os_version
         .clone()
         .or_else(|| detected.as_ref().ok().and_then(|p| p.os_version.clone()));
-    let arch = match (&args.arch, &detected) {
+    let arch = match (&common.arch, &detected) {
         (Some(a), _) => a.clone(),
         (None, Ok(p)) => p.arch.clone(),
         (None, Err(_)) => translate_arch(std::env::consts::ARCH).to_owned(),
@@ -362,13 +495,12 @@ mod tests {
         Cli::command().debug_assert();
     }
 
-    fn args_with(
+    fn common_with(
         policy: Option<PolicyChoice>,
         allow_abandoned: bool,
         below_min: bool,
-    ) -> ResolveArgs {
-        ResolveArgs {
-            tool: "rust".into(),
+    ) -> CommonArgs {
+        CommonArgs {
             version: None,
             channel: None,
             os: None,
@@ -378,27 +510,26 @@ mod tests {
             policy,
             allow_abandoned,
             allow_below_min_recommended: below_min,
-            json: false,
         }
     }
 
     #[test]
     fn build_policy_defaults_to_stibbons() {
-        let p = build_policy(&args_with(None, false, false));
+        let p = build_policy(&common_with(None, false, false));
         assert_eq!(p, ResolutionPolicy::stibbons());
     }
 
     #[test]
     fn build_policy_uses_chosen_preset() {
-        let p = build_policy(&args_with(Some(PolicyChoice::Permissive), false, false));
+        let p = build_policy(&common_with(Some(PolicyChoice::Permissive), false, false));
         assert_eq!(p, ResolutionPolicy::permissive());
-        let p = build_policy(&args_with(Some(PolicyChoice::Igor), false, false));
+        let p = build_policy(&common_with(Some(PolicyChoice::Igor), false, false));
         assert_eq!(p, ResolutionPolicy::igor());
     }
 
     #[test]
     fn build_policy_allow_abandoned_overrides_min_activity() {
-        let p = build_policy(&args_with(Some(PolicyChoice::Stibbons), true, false));
+        let p = build_policy(&common_with(Some(PolicyChoice::Stibbons), true, false));
         assert_eq!(p.min_activity, ActivityScore::Abandoned);
         // Other fields preserved from preset.
         assert!(!p.allow_below_min_recommended);
@@ -407,8 +538,23 @@ mod tests {
 
     #[test]
     fn build_policy_allow_below_min_overrides_bool() {
-        let p = build_policy(&args_with(None, false, true));
+        let p = build_policy(&common_with(None, false, true));
         assert!(p.allow_below_min_recommended);
         assert_eq!(p.min_activity, ActivityScore::Maintained);
+    }
+
+    #[test]
+    fn split_tool_version_handles_bare_tool() {
+        assert_eq!(split_tool_version("rust"), ("rust", None));
+    }
+
+    #[test]
+    fn split_tool_version_handles_at_suffix() {
+        assert_eq!(split_tool_version("rust@1.95.0"), ("rust", Some("1.95.0")));
+    }
+
+    #[test]
+    fn split_tool_version_handles_partial_suffix() {
+        assert_eq!(split_tool_version("rust@1.84"), ("rust", Some("1.84")));
     }
 }

--- a/crates/luggage/src/error.rs
+++ b/crates/luggage/src/error.rs
@@ -142,6 +142,72 @@ pub enum LuggageError {
     /// Catalog content failed an internal cross-check (e.g. duplicate version).
     #[error("catalog error: {0}")]
     Catalog(String),
+
+    /// An install pipeline stage failed in a way that doesn't map to one of
+    /// the more specific variants below.
+    #[error("install stage `{stage}` failed: {message}")]
+    InstallStageFailed {
+        /// Stage identifier (e.g. `"download"`, `"chmod"`).
+        stage: &'static str,
+        /// Human-readable detail.
+        message: String,
+    },
+
+    /// 4-tier verification rejected a downloaded artifact.
+    #[error("verification (tier {tier}) failed for {tool}@{version}: {reason}")]
+    VerificationFailed {
+        /// Tool id.
+        tool: String,
+        /// Tool version.
+        version: String,
+        /// Verification tier (`1`–`4`).
+        tier: u8,
+        /// Human-readable detail.
+        reason: String,
+    },
+
+    /// HTTP fetch failed after the configured retry budget was exhausted.
+    #[error("download from {url} failed after {attempts} attempts: {message}")]
+    DownloadFailed {
+        /// URL being fetched.
+        url: String,
+        /// Number of attempts before giving up.
+        attempts: u32,
+        /// Underlying error message.
+        message: String,
+    },
+
+    /// Host package manager (apt/apk/dnf) refused to install one or more
+    /// dependency packages.
+    #[error("package manager failed: {message}")]
+    PackageManagerFailed {
+        /// Human-readable detail.
+        message: String,
+    },
+
+    /// A `post_install[]` step failed.
+    #[error("post-install step `{step}` failed: {message}")]
+    PostInstallFailed {
+        /// Step identifier (e.g. `"component_add:rust-src"`).
+        step: String,
+        /// Human-readable detail.
+        message: String,
+    },
+
+    /// Post-install validation could not confirm the tool is installed.
+    #[error("validation failed for {tool}@{version}: {message}")]
+    ValidationFailed {
+        /// Tool id.
+        tool: String,
+        /// Tool version.
+        version: String,
+        /// Human-readable detail.
+        message: String,
+    },
+
+    /// A URL template referenced a placeholder we don't have a value for.
+    #[error("template substitution: missing key `{0}`")]
+    TemplateMissingKey(String),
 }
 
 impl LuggageError {
@@ -287,5 +353,75 @@ mod tests {
         }));
         let msg = format!("{err}");
         assert!(msg.contains("windows/any/amd64"));
+    }
+
+    #[test]
+    fn install_stage_failed_exit_code_is_one() {
+        let err = LuggageError::InstallStageFailed {
+            stage: "download",
+            message: "connection refused".into(),
+        };
+        assert_eq!(err.exit_code(), 1);
+        assert!(format!("{err}").contains("download"));
+    }
+
+    #[test]
+    fn verification_failed_exit_code_is_one() {
+        let err = LuggageError::VerificationFailed {
+            tool: "rust".into(),
+            version: "1.95.0".into(),
+            tier: 3,
+            reason: "sha256 mismatch".into(),
+        };
+        assert_eq!(err.exit_code(), 1);
+        let msg = format!("{err}");
+        assert!(msg.contains("tier 3"));
+        assert!(msg.contains("rust@1.95.0"));
+        assert!(msg.contains("sha256 mismatch"));
+    }
+
+    #[test]
+    fn download_failed_exit_code_is_one() {
+        let err = LuggageError::DownloadFailed {
+            url: "https://example.test/x".into(),
+            attempts: 8,
+            message: "timeout".into(),
+        };
+        assert_eq!(err.exit_code(), 1);
+        let msg = format!("{err}");
+        assert!(msg.contains("8 attempts"));
+    }
+
+    #[test]
+    fn package_manager_failed_exit_code_is_one() {
+        let err = LuggageError::PackageManagerFailed { message: "apt-get returned 100".into() };
+        assert_eq!(err.exit_code(), 1);
+    }
+
+    #[test]
+    fn post_install_failed_exit_code_is_one() {
+        let err = LuggageError::PostInstallFailed {
+            step: "component_add:rust-src".into(),
+            message: "rustup component add failed".into(),
+        };
+        assert_eq!(err.exit_code(), 1);
+        assert!(format!("{err}").contains("component_add:rust-src"));
+    }
+
+    #[test]
+    fn validation_failed_exit_code_is_one() {
+        let err = LuggageError::ValidationFailed {
+            tool: "rust".into(),
+            version: "1.95.0".into(),
+            message: "rustc --version mismatch".into(),
+        };
+        assert_eq!(err.exit_code(), 1);
+    }
+
+    #[test]
+    fn template_missing_key_exit_code_is_one() {
+        let err = LuggageError::TemplateMissingKey("rustup_target".into());
+        assert_eq!(err.exit_code(), 1);
+        assert!(format!("{err}").contains("rustup_target"));
     }
 }

--- a/crates/luggage/src/installer/download.rs
+++ b/crates/luggage/src/installer/download.rs
@@ -1,0 +1,161 @@
+//! HTTP client trait + production [`UreqClient`].
+//!
+//! The trait exists so tests can swap a deterministic in-memory stub for
+//! `ureq` without listening on a port. Production code calls
+//! [`UreqClient::default`] and forgets the trait exists.
+//!
+//! Retry policy mirrors `lib/features/rust.sh`'s `curl --retry 8 --retry-delay 10`.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::thread::sleep;
+use std::time::Duration;
+
+use crate::error::{LuggageError, Result};
+
+/// Maximum number of GET attempts before giving up.
+const DEFAULT_MAX_ATTEMPTS: u32 = 8;
+
+/// Linear delay between attempts.
+const DEFAULT_RETRY_DELAY: Duration = Duration::from_secs(10);
+
+/// Fetch bytes for a URL.
+///
+/// Trait-wrapped so tests can inject a stub. Production callers should
+/// hold a [`UreqClient`].
+pub trait HttpClient: Send + Sync {
+    /// Fetch the body at `url` as raw bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LuggageError::DownloadFailed`] on network or HTTP errors
+    /// after the configured retry budget is exhausted.
+    fn get(&self, url: &str) -> Result<Vec<u8>>;
+}
+
+/// Production HTTP client backed by `ureq`.
+///
+/// Retries up to [`DEFAULT_MAX_ATTEMPTS`] times with [`DEFAULT_RETRY_DELAY`]
+/// between attempts. Sleep delay is configurable so tests can avoid
+/// real-time waits.
+#[derive(Debug, Clone)]
+pub struct UreqClient {
+    max_attempts: u32,
+    retry_delay: Duration,
+}
+
+impl Default for UreqClient {
+    fn default() -> Self {
+        Self { max_attempts: DEFAULT_MAX_ATTEMPTS, retry_delay: DEFAULT_RETRY_DELAY }
+    }
+}
+
+impl UreqClient {
+    /// Build a client with custom retry tuning. Mostly useful in tests.
+    #[must_use]
+    pub const fn with_retry(max_attempts: u32, retry_delay: Duration) -> Self {
+        Self { max_attempts, retry_delay }
+    }
+}
+
+impl HttpClient for UreqClient {
+    fn get(&self, url: &str) -> Result<Vec<u8>> {
+        let mut last_message = String::new();
+        for attempt in 1..=self.max_attempts {
+            match ureq::get(url).call() {
+                Ok(resp) => {
+                    let mut bytes = Vec::new();
+                    if let Err(e) = resp.into_reader().read_to_end(&mut bytes) {
+                        last_message = format!("read body: {e}");
+                    } else {
+                        return Ok(bytes);
+                    }
+                }
+                Err(e) => last_message = format!("{e}"),
+            }
+            if attempt < self.max_attempts {
+                sleep(self.retry_delay);
+            }
+        }
+        Err(LuggageError::DownloadFailed {
+            url: url.to_owned(),
+            attempts: self.max_attempts,
+            message: last_message,
+        })
+    }
+}
+
+/// Deterministic in-memory HTTP client for tests.
+///
+/// Wires URL → response bytes ahead of time. Unknown URLs return
+/// [`LuggageError::DownloadFailed`].
+#[derive(Debug, Default)]
+pub struct MockHttpClient {
+    responses: Mutex<HashMap<String, Vec<u8>>>,
+}
+
+impl MockHttpClient {
+    /// Build an empty mock.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a (url → body) entry.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the inner mutex is poisoned, which only happens if a
+    /// previous user of the mock panicked while holding it. Tests treat
+    /// that as a bug.
+    pub fn insert(&self, url: impl Into<String>, body: impl Into<Vec<u8>>) {
+        self.responses.lock().unwrap().insert(url.into(), body.into());
+    }
+}
+
+impl HttpClient for MockHttpClient {
+    fn get(&self, url: &str) -> Result<Vec<u8>> {
+        self.responses.lock().unwrap().get(url).cloned().ok_or_else(|| {
+            LuggageError::DownloadFailed {
+                url: url.to_owned(),
+                attempts: 1,
+                message: "mock: no response wired".into(),
+            }
+        })
+    }
+}
+
+// `std::io::Read` is needed for `into_reader().read_to_end(...)` above.
+use std::io::Read as _;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mock_returns_inserted_body() {
+        let m = MockHttpClient::new();
+        m.insert("https://example.test/x", b"payload".to_vec());
+        let body = m.get("https://example.test/x").unwrap();
+        assert_eq!(body, b"payload");
+    }
+
+    #[test]
+    fn mock_unknown_url_returns_download_failed() {
+        let m = MockHttpClient::new();
+        let err = m.get("https://example.test/missing").unwrap_err();
+        match err {
+            LuggageError::DownloadFailed { attempts: 1, url, .. } => {
+                assert_eq!(url, "https://example.test/missing");
+            }
+            other => panic!("expected DownloadFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ureq_default_uses_published_constants() {
+        let c = UreqClient::default();
+        assert_eq!(c.max_attempts, DEFAULT_MAX_ATTEMPTS);
+        assert_eq!(c.retry_delay, DEFAULT_RETRY_DELAY);
+    }
+}

--- a/crates/luggage/src/installer/idempotency.rs
+++ b/crates/luggage/src/installer/idempotency.rs
@@ -1,0 +1,106 @@
+//! Idempotency pre-check: skip install when the tool is already at the
+//! target version.
+//!
+//! For the rust pilot the convention is "`<bin_root>/<tool> --version`
+//! contains `<version>`" — exactly what bash's `lib/features/rust.sh` does
+//! with `command -v rustc && rustc --version | grep -q "$RUST_VERSION"`.
+//!
+//! When the catalog tool id and its primary binary name differ (e.g.
+//! `rust` → `rustc`), [`primary_binary`] keeps a small in-code mapping.
+//! This is a stopgap; a future catalog field (issue #404) will declare a
+//! per-tool version-check command so each tool can decide what "already
+//! installed" means.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Map a catalog tool id to the primary binary name luggage should
+/// `--version`-check. Defaults to the tool id itself when no mapping
+/// exists. Stopgap until catalog `validation_tiers` lands (issue #404).
+#[must_use]
+pub fn primary_binary(tool: &str) -> &str {
+    match tool {
+        "rust" => "rustc",
+        _ => tool,
+    }
+}
+
+/// Check whether `tool` at `version` is already on disk under `bin_root`.
+///
+/// Returns `false` for any reason it can't confirm — missing binary,
+/// non-zero exit, output without the version literal, I/O error. The
+/// caller must treat `false` as "go install"; only `true` should skip.
+#[must_use]
+pub fn already_installed(tool: &str, version: &str, bin_root: &Path) -> bool {
+    let binary = bin_root.join(primary_binary(tool));
+    if !binary.exists() {
+        return false;
+    }
+    let Ok(output) = Command::new(&binary).arg("--version").output() else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    stdout.contains(version) || stderr.contains(version)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt as _;
+
+    use tempfile::tempdir;
+
+    #[cfg(unix)]
+    fn write_shim(dir: &Path, name: &str, version_line: &str) {
+        let path = dir.join(name);
+        fs::write(&path, format!("#!/bin/sh\necho '{version_line}'\n")).unwrap();
+        let mut perms = fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&path, perms).unwrap();
+    }
+
+    #[test]
+    fn missing_binary_returns_false() {
+        let dir = tempdir().unwrap();
+        assert!(!already_installed("rustc", "1.95.0", dir.path()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn matching_version_returns_true() {
+        let dir = tempdir().unwrap();
+        write_shim(dir.path(), "rustc", "rustc 1.95.0 (abcdef0)");
+        assert!(already_installed("rustc", "1.95.0", dir.path()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn nonmatching_version_returns_false() {
+        let dir = tempdir().unwrap();
+        write_shim(dir.path(), "rustc", "rustc 1.84.0 (abcdef0)");
+        assert!(!already_installed("rustc", "1.95.0", dir.path()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rust_tool_id_resolves_to_rustc_binary() {
+        let dir = tempdir().unwrap();
+        write_shim(dir.path(), "rustc", "rustc 1.95.0 (abcdef0)");
+        assert!(
+            already_installed("rust", "1.95.0", dir.path()),
+            "catalog tool id `rust` should map to `rustc` binary",
+        );
+    }
+
+    #[test]
+    fn primary_binary_defaults_to_tool_id() {
+        assert_eq!(primary_binary("node"), "node");
+        assert_eq!(primary_binary("rust"), "rustc");
+    }
+}

--- a/crates/luggage/src/installer/logging.rs
+++ b/crates/luggage/src/installer/logging.rs
@@ -1,0 +1,169 @@
+//! Per-feature logging that mirrors `lib/base/logging.sh`.
+//!
+//! Each invocation of `luggage install` opens a per-feature log file at
+//! `<log_dir>/<tool>-<version>.log` and emits records in the same shape
+//! the bash feature scripts produce, so downstream tools (notably
+//! `check-build-logs.sh`) keep working unchanged during the migration:
+//!
+//! ```text
+//! [HH:MM:SS] FEATURE START: <tool> <version>
+//! [HH:MM:SS] COMMAND #N: <description>
+//! Executing: <argv>
+//! ────────────────────
+//! <stdout/stderr>
+//! ────────────────────
+//! Exit code: N (Duration: Xs)
+//! [HH:MM:SS] FEATURE END
+//! ```
+//!
+//! Each line is also forwarded via `tracing::info!` so `--verbose` users
+//! see the same timeline on stderr.
+
+use std::fs::{File, OpenOptions, create_dir_all};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use tracing::info;
+
+use crate::error::{LuggageError, Result};
+
+/// Feature-scoped logger; one per `luggage install` invocation.
+pub struct FeatureLogger {
+    file: Mutex<File>,
+    path: PathBuf,
+    step: AtomicUsize,
+    started: Instant,
+}
+
+impl FeatureLogger {
+    /// Create a logger writing to `<log_dir>/<tool>-<version>.log`.
+    ///
+    /// # Errors
+    ///
+    /// - [`LuggageError::Io`] when `log_dir` cannot be created or the log
+    ///   file cannot be opened for append.
+    pub fn open(log_dir: &Path, tool: &str, version: &str) -> Result<Self> {
+        create_dir_all(log_dir)
+            .map_err(|e| LuggageError::Io { path: log_dir.to_owned(), source: e })?;
+        let path = log_dir.join(format!("{tool}-{version}.log"));
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .map_err(|e| LuggageError::Io { path: path.clone(), source: e })?;
+        Ok(Self {
+            file: Mutex::new(file),
+            path,
+            step: AtomicUsize::new(0),
+            started: Instant::now(),
+        })
+    }
+
+    /// Path to the underlying log file.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Emit a `FEATURE START` banner.
+    pub fn feature_start(&self, tool: &str, version: &str) {
+        let line = format!("[{}] FEATURE START: {tool} {version}", clock());
+        info!("{line}");
+        self.write_line(&line);
+    }
+
+    /// Emit a numbered `COMMAND #N: <description>` banner.
+    ///
+    /// Increments the internal step counter; subsequent calls get the next
+    /// number.
+    pub fn step(&self, description: &str) {
+        let n = self.step.fetch_add(1, Ordering::Relaxed) + 1;
+        let line = format!("[{}] COMMAND #{n}: {description}", clock());
+        info!("{line}");
+        self.write_line(&line);
+    }
+
+    /// Emit a free-form message in the bash style.
+    pub fn message(&self, msg: &str) {
+        info!("{msg}");
+        self.write_line(msg);
+    }
+
+    /// Emit a `FEATURE END` banner with elapsed time.
+    pub fn feature_end(&self) {
+        let elapsed = self.started.elapsed();
+        let line = format!("[{}] FEATURE END (duration: {:.2}s)", clock(), elapsed.as_secs_f64());
+        info!("{line}");
+        self.write_line(&line);
+    }
+
+    fn write_line(&self, line: &str) {
+        if let Ok(mut f) = self.file.lock() {
+            let _: io::Result<()> = (|| {
+                f.write_all(line.as_bytes())?;
+                f.write_all(b"\n")?;
+                Ok(())
+            })();
+        }
+    }
+}
+
+/// Format current wall-clock time as `HH:MM:SS` (UTC).
+fn clock() -> String {
+    let secs = SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| d.as_secs());
+    let h = (secs / 3600) % 24;
+    let m = (secs / 60) % 60;
+    let s = secs % 60;
+    format!("{h:02}:{m:02}:{s:02}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    #[test]
+    fn open_creates_log_file() {
+        let dir = tempdir().unwrap();
+        let logger = FeatureLogger::open(dir.path(), "rust", "1.95.0").unwrap();
+        assert!(logger.path().exists());
+        assert!(logger.path().to_string_lossy().ends_with("rust-1.95.0.log"));
+    }
+
+    #[test]
+    fn step_counter_increments_per_call() {
+        let dir = tempdir().unwrap();
+        let logger = FeatureLogger::open(dir.path(), "rust", "1.95.0").unwrap();
+        logger.feature_start("rust", "1.95.0");
+        logger.step("first");
+        logger.step("second");
+        logger.feature_end();
+        let body = fs::read_to_string(logger.path()).unwrap();
+        assert!(body.contains("FEATURE START: rust 1.95.0"));
+        assert!(body.contains("COMMAND #1: first"));
+        assert!(body.contains("COMMAND #2: second"));
+        assert!(body.contains("FEATURE END"));
+    }
+
+    #[test]
+    fn message_emits_verbatim_line() {
+        let dir = tempdir().unwrap();
+        let logger = FeatureLogger::open(dir.path(), "x", "0").unwrap();
+        logger.message("hello");
+        let body = fs::read_to_string(logger.path()).unwrap();
+        assert!(body.contains("hello"));
+    }
+
+    #[test]
+    fn clock_returns_eight_chars() {
+        let s = clock();
+        assert_eq!(s.len(), 8);
+        assert_eq!(s.chars().filter(|&c| c == ':').count(), 2);
+    }
+}

--- a/crates/luggage/src/installer/methods/mod.rs
+++ b/crates/luggage/src/installer/methods/mod.rs
@@ -1,0 +1,214 @@
+//! Install-method execution dispatch.
+//!
+//! Catalog `InstallMethod.name` is a free string; this module dispatches on
+//! it. Only the `rustup-init` family (`rustup-init`, `rustup-init-musl`)
+//! is wired up in this issue. Everything else returns
+//! [`crate::LuggageError::NotImplemented`] and ships in follow-up issues
+//! per #405's decomposition note.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::process::Command;
+use std::sync::Mutex;
+
+use crate::error::{LuggageError, Result};
+
+pub mod script_installer;
+
+/// Outcome of running a child process.
+#[derive(Debug, Clone)]
+pub struct CommandOutcome {
+    /// Process exit status (`Some(code)` or `None` if the process was
+    /// terminated by a signal).
+    pub status: Option<i32>,
+    /// Captured stdout.
+    pub stdout: Vec<u8>,
+    /// Captured stderr.
+    pub stderr: Vec<u8>,
+}
+
+impl CommandOutcome {
+    /// True iff the process exited with code 0.
+    #[must_use]
+    pub const fn success(&self) -> bool {
+        matches!(self.status, Some(0))
+    }
+}
+
+/// Execute argvs. Trait-wrapped so tests can stub.
+pub trait CommandRunner: Send + Sync {
+    /// Run `program` with `args`. Production runners shell out; test
+    /// runners typically record the argv and return a canned outcome.
+    ///
+    /// # Errors
+    ///
+    /// - [`LuggageError::InstallStageFailed`] when the runner could not
+    ///   even spawn the child process.
+    fn run(&self, program: &str, args: &[String]) -> Result<CommandOutcome>;
+}
+
+/// Production [`CommandRunner`] backed by `std::process::Command`.
+#[derive(Debug, Default)]
+pub struct ProcessRunner;
+
+impl CommandRunner for ProcessRunner {
+    fn run(&self, program: &str, args: &[String]) -> Result<CommandOutcome> {
+        let output = Command::new(program).args(args).output().map_err(|e| {
+            LuggageError::InstallStageFailed {
+                stage: "spawn",
+                message: format!("failed to launch `{program}`: {e}"),
+            }
+        })?;
+        Ok(CommandOutcome {
+            status: output.status.code(),
+            stdout: output.stdout,
+            stderr: output.stderr,
+        })
+    }
+}
+
+/// Recording [`CommandRunner`] for hermetic tests.
+///
+/// Captures every (program, args) pair, then replays a default-success
+/// outcome unless a per-program override is wired via [`Self::set_outcome`].
+#[derive(Debug, Default)]
+pub struct RecordingRunner {
+    calls: Mutex<Vec<(String, Vec<String>)>>,
+    outcomes: Mutex<Vec<(String, CommandOutcome)>>,
+}
+
+impl RecordingRunner {
+    /// Build an empty recorder.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Pin the next outcome for a `program` invocation.
+    ///
+    /// Outcomes are matched FIFO by program name; missing entries default
+    /// to exit-0 with empty output.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the inner mutex is poisoned.
+    pub fn set_outcome(&self, program: &str, outcome: CommandOutcome) {
+        self.outcomes.lock().unwrap().push((program.to_owned(), outcome));
+    }
+
+    /// Snapshot of recorded calls in invocation order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the inner mutex is poisoned.
+    #[must_use]
+    pub fn calls(&self) -> Vec<(String, Vec<String>)> {
+        self.calls.lock().unwrap().clone()
+    }
+}
+
+impl CommandRunner for RecordingRunner {
+    fn run(&self, program: &str, args: &[String]) -> Result<CommandOutcome> {
+        self.calls.lock().unwrap().push((program.to_owned(), args.to_vec()));
+        let pinned = {
+            let mut outcomes = self.outcomes.lock().unwrap();
+            outcomes.iter().position(|(p, _)| p == program).map(|idx| outcomes.remove(idx).1)
+        };
+        Ok(pinned.unwrap_or(CommandOutcome {
+            status: Some(0),
+            stdout: Vec::new(),
+            stderr: Vec::new(),
+        }))
+    }
+}
+
+/// Per-method execution context plumbed in from [`super::Installer`].
+pub struct MethodContext<'a> {
+    /// Path to the downloaded artifact (e.g. `/tmp/.../rustup-init`).
+    pub artifact: &'a Path,
+    /// Already-substituted installer args from `Invoke.args`.
+    pub args: &'a [String],
+    /// Already-substituted env exports from `Invoke.env`.
+    pub env: &'a BTreeMap<String, String>,
+    /// User to run the install as (e.g. `vscode`).
+    pub user: &'a str,
+    /// Cache root (`/cache` in production).
+    pub cache_root: &'a Path,
+    /// Bin root for symlinks (`/usr/local/bin` in production).
+    pub bin_root: &'a Path,
+    /// Command runner (production: `ProcessRunner`; tests: `RecordingRunner`).
+    pub runner: &'a dyn CommandRunner,
+}
+
+/// Dispatch on `method_name`.
+///
+/// # Errors
+///
+/// - [`LuggageError::NotImplemented`] for any method other than the
+///   rustup-init shape.
+pub fn dispatch(method_name: &str, ctx: &MethodContext<'_>) -> Result<()> {
+    match method_name {
+        "rustup-init" | "rustup-init-musl" => script_installer::run(ctx),
+        _ => Err(LuggageError::NotImplemented(
+            "install method not yet wired (only rustup-init/rustup-init-musl in this issue)",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx<'a>(
+        artifact: &'a Path,
+        args: &'a [String],
+        env: &'a BTreeMap<String, String>,
+        user: &'a str,
+        cache: &'a Path,
+        bin: &'a Path,
+        runner: &'a dyn CommandRunner,
+    ) -> MethodContext<'a> {
+        MethodContext { artifact, args, env, user, cache_root: cache, bin_root: bin, runner }
+    }
+
+    #[test]
+    fn dispatch_unknown_method_returns_not_implemented() {
+        let runner = RecordingRunner::new();
+        let env = BTreeMap::new();
+        let args: Vec<String> = vec![];
+        let bin = Path::new("/tmp/bin");
+        let cache = Path::new("/tmp/cache");
+        let artifact = Path::new("/tmp/x");
+        let c = ctx(artifact, &args, &env, "vscode", cache, bin, &runner);
+        let err = dispatch("apt", &c).unwrap_err();
+        assert!(matches!(err, LuggageError::NotImplemented(_)));
+    }
+
+    #[test]
+    fn recording_runner_records_argv_and_returns_default_success() {
+        let r = RecordingRunner::new();
+        let outcome = r.run("ls", &["-la".into()]).unwrap();
+        assert!(outcome.success());
+        assert_eq!(r.calls(), vec![("ls".to_owned(), vec!["-la".to_owned()])]);
+    }
+
+    #[test]
+    fn recording_runner_returns_pinned_outcome() {
+        let r = RecordingRunner::new();
+        r.set_outcome(
+            "rustup-init",
+            CommandOutcome { status: Some(2), stdout: b"out".to_vec(), stderr: b"err".to_vec() },
+        );
+        let outcome = r.run("rustup-init", &[]).unwrap();
+        assert!(!outcome.success());
+        assert_eq!(outcome.status, Some(2));
+        assert_eq!(outcome.stderr, b"err");
+    }
+
+    #[test]
+    fn command_outcome_success_only_for_zero() {
+        assert!(CommandOutcome { status: Some(0), stdout: vec![], stderr: vec![] }.success());
+        assert!(!CommandOutcome { status: Some(1), stdout: vec![], stderr: vec![] }.success());
+        assert!(!CommandOutcome { status: None, stdout: vec![], stderr: vec![] }.success());
+    }
+}

--- a/crates/luggage/src/installer/methods/script_installer.rs
+++ b/crates/luggage/src/installer/methods/script_installer.rs
@@ -13,6 +13,7 @@
 
 use std::collections::BTreeMap;
 use std::fs;
+#[cfg(unix)]
 use std::os::unix::fs as unix_fs;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt as _;
@@ -94,6 +95,13 @@ pub fn run(ctx: &MethodContext<'_>) -> Result<()> {
 /// Symlink `<cargo_home>/bin/<name>` → `<bin_root>/<name>` for each
 /// binary in [`RUST_BINARIES`]. Existing symlinks are replaced; existing
 /// non-symlinks are left alone (avoids clobbering distro-managed files).
+///
+/// Unix-only — the catalog already marks rust as `unsupported` on Windows
+/// in `support_matrix`, so this path is unreachable there. The non-unix
+/// build returns `NotImplemented` so the crate still compiles for any
+/// host that doesn't go through the resolver (e.g. `cargo build` on
+/// Windows for a developer working on something unrelated).
+#[cfg(unix)]
 fn install_symlinks(
     cargo_home: &std::path::Path,
     bin_root: &std::path::Path,
@@ -122,6 +130,17 @@ fn install_symlinks(
     // function shell out for cross-distro quirks (e.g. SELinux contexts).
     let _ = runner;
     Ok(())
+}
+
+#[cfg(not(unix))]
+fn install_symlinks(
+    _cargo_home: &std::path::Path,
+    _bin_root: &std::path::Path,
+    _runner: &dyn CommandRunner,
+) -> Result<()> {
+    Err(LuggageError::NotImplemented(
+        "rustup-init script-installer is unix-only; rust on Windows is `unsupported` in catalog",
+    ))
 }
 
 #[cfg(test)]

--- a/crates/luggage/src/installer/methods/script_installer.rs
+++ b/crates/luggage/src/installer/methods/script_installer.rs
@@ -1,0 +1,271 @@
+//! `rustup-init` / `rustup-init-musl` install method.
+//!
+//! Reproduces the side-effects of `lib/features/rust.sh` in Rust:
+//!
+//! 1. Ensure `cache_root/cargo` and `cache_root/rustup` exist.
+//! 2. Mark the downloaded artifact executable.
+//! 3. `su - <user> -c "export CARGO_HOME=...; export RUSTUP_HOME=...;
+//!    <artifact> <args...>"`.
+//! 4. Symlink the standard set of rust binaries into `bin_root`.
+//!
+//! Only the rust-shape symlink set is wired up. Future install methods
+//! that produce different binary sets get their own dispatch arm.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::os::unix::fs as unix_fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt as _;
+
+use shell_words::quote;
+
+use super::{CommandRunner, MethodContext};
+use crate::error::{LuggageError, Result};
+use crate::installer::user::su_command;
+
+/// Binaries the rust install must surface in `bin_root` for parity with
+/// `lib/features/rust.sh`.
+pub const RUST_BINARIES: &[&str] =
+    &["rustc", "cargo", "rustup", "rust-analyzer", "rustfmt", "clippy-driver"];
+
+/// Run the rustup-init flow.
+///
+/// # Errors
+///
+/// - [`LuggageError::Io`] when cache or bin directories cannot be
+///   created/manipulated.
+/// - [`LuggageError::InstallStageFailed`] when chmod or the runner cannot
+///   perform a step.
+/// - [`LuggageError::PostInstallFailed`] when `su -c rustup-init` exits
+///   non-zero. (Despite the name, the failure happens during install
+///   rather than post-install — but the error variant fits "user-running
+///   command failed" semantics best.)
+pub fn run(ctx: &MethodContext<'_>) -> Result<()> {
+    // 1. Ensure cache directories exist.
+    let cargo_home = ctx.cache_root.join("cargo");
+    let rustup_home = ctx.cache_root.join("rustup");
+    for dir in [&cargo_home, &rustup_home] {
+        fs::create_dir_all(dir).map_err(|e| LuggageError::Io { path: dir.clone(), source: e })?;
+    }
+
+    // 2. chmod +x the downloaded installer.
+    #[cfg(unix)]
+    {
+        let mut perms = fs::metadata(ctx.artifact)
+            .map_err(|e| LuggageError::Io { path: ctx.artifact.to_owned(), source: e })?
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(ctx.artifact, perms)
+            .map_err(|e| LuggageError::Io { path: ctx.artifact.to_owned(), source: e })?;
+    }
+
+    // 3. Build the env map (caller's exports + our cargo/rustup pins) and
+    //    the inner shell payload, then dispatch to su.
+    let mut env: BTreeMap<String, String> = ctx.env.clone();
+    env.entry("CARGO_HOME".to_owned()).or_insert_with(|| cargo_home.display().to_string());
+    env.entry("RUSTUP_HOME".to_owned()).or_insert_with(|| rustup_home.display().to_string());
+
+    let mut body = String::new();
+    body.push_str(&quote(&ctx.artifact.display().to_string()));
+    for arg in ctx.args {
+        body.push(' ');
+        body.push_str(&quote(arg));
+    }
+
+    let argv = su_command(ctx.user, &env, &body);
+    let outcome = ctx.runner.run(&argv[0], &argv[1..])?;
+    if !outcome.success() {
+        return Err(LuggageError::PostInstallFailed {
+            step: "rustup-init".into(),
+            message: format!(
+                "rustup-init exited with status {:?}: {}",
+                outcome.status,
+                String::from_utf8_lossy(&outcome.stderr).trim_end(),
+            ),
+        });
+    }
+
+    // 4. Symlink the rust binaries into bin_root.
+    install_symlinks(&cargo_home, ctx.bin_root, ctx.runner)?;
+
+    Ok(())
+}
+
+/// Symlink `<cargo_home>/bin/<name>` → `<bin_root>/<name>` for each
+/// binary in [`RUST_BINARIES`]. Existing symlinks are replaced; existing
+/// non-symlinks are left alone (avoids clobbering distro-managed files).
+fn install_symlinks(
+    cargo_home: &std::path::Path,
+    bin_root: &std::path::Path,
+    runner: &dyn CommandRunner,
+) -> Result<()> {
+    fs::create_dir_all(bin_root)
+        .map_err(|e| LuggageError::Io { path: bin_root.to_owned(), source: e })?;
+    for name in RUST_BINARIES {
+        let target = cargo_home.join("bin").join(name);
+        let link = bin_root.join(name);
+        if link.exists() {
+            let metadata = fs::symlink_metadata(&link)
+                .map_err(|e| LuggageError::Io { path: link.clone(), source: e })?;
+            if metadata.file_type().is_symlink() {
+                fs::remove_file(&link)
+                    .map_err(|e| LuggageError::Io { path: link.clone(), source: e })?;
+            } else {
+                continue;
+            }
+        }
+        unix_fs::symlink(&target, &link)
+            .map_err(|e| LuggageError::Io { path: link.clone(), source: e })?;
+    }
+    // The runner is unused here today (symlink syscalls go direct), but
+    // accepting it keeps the API uniform and lets future versions of this
+    // function shell out for cross-distro quirks (e.g. SELinux contexts).
+    let _ = runner;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::fs;
+    use std::path::Path;
+
+    use tempfile::tempdir;
+
+    use crate::installer::methods::{CommandOutcome, RecordingRunner};
+
+    fn make_artifact(dir: &Path) -> std::path::PathBuf {
+        let path = dir.join("rustup-init");
+        fs::write(&path, b"#!/bin/sh\necho stub\n").unwrap();
+        path
+    }
+
+    #[test]
+    fn run_invokes_su_with_expected_payload() {
+        let cache = tempdir().unwrap();
+        let bin = tempdir().unwrap();
+        let tmp = tempdir().unwrap();
+        let artifact = make_artifact(tmp.path());
+        let runner = RecordingRunner::new();
+        let env = BTreeMap::new();
+        let args = vec!["-y".to_owned(), "--default-toolchain".to_owned(), "1.95.0".to_owned()];
+
+        let ctx = MethodContext {
+            artifact: &artifact,
+            args: &args,
+            env: &env,
+            user: "vscode",
+            cache_root: cache.path(),
+            bin_root: bin.path(),
+            runner: &runner,
+        };
+        run(&ctx).unwrap();
+
+        let calls = runner.calls();
+        let su_call = calls.iter().find(|(p, _)| p == "su").expect("expected at least one su call");
+        let su_args = &su_call.1;
+        assert_eq!(su_args[0], "-");
+        assert_eq!(su_args[1], "vscode");
+        assert_eq!(su_args[2], "-c");
+        let payload = &su_args[3];
+        assert!(payload.contains("CARGO_HOME"));
+        assert!(payload.contains("RUSTUP_HOME"));
+        assert!(payload.contains("--default-toolchain"));
+        assert!(payload.contains("1.95.0"));
+        assert!(payload.contains(&artifact.display().to_string()));
+    }
+
+    #[test]
+    fn run_creates_cache_directories() {
+        let cache = tempdir().unwrap();
+        let bin = tempdir().unwrap();
+        let tmp = tempdir().unwrap();
+        let artifact = make_artifact(tmp.path());
+        let runner = RecordingRunner::new();
+        let env = BTreeMap::new();
+        let args: Vec<String> = vec![];
+
+        let ctx = MethodContext {
+            artifact: &artifact,
+            args: &args,
+            env: &env,
+            user: "vscode",
+            cache_root: cache.path(),
+            bin_root: bin.path(),
+            runner: &runner,
+        };
+        run(&ctx).unwrap();
+
+        assert!(cache.path().join("cargo").is_dir());
+        assert!(cache.path().join("rustup").is_dir());
+    }
+
+    #[test]
+    fn run_symlinks_rust_binaries() {
+        let cache = tempdir().unwrap();
+        let bin = tempdir().unwrap();
+        let tmp = tempdir().unwrap();
+        let artifact = make_artifact(tmp.path());
+        let runner = RecordingRunner::new();
+        let env = BTreeMap::new();
+        let args: Vec<String> = vec![];
+
+        let ctx = MethodContext {
+            artifact: &artifact,
+            args: &args,
+            env: &env,
+            user: "vscode",
+            cache_root: cache.path(),
+            bin_root: bin.path(),
+            runner: &runner,
+        };
+        run(&ctx).unwrap();
+
+        for name in RUST_BINARIES {
+            let link = bin.path().join(name);
+            assert!(
+                link.is_symlink(),
+                "expected {name} to be symlinked under {}",
+                bin.path().display(),
+            );
+        }
+    }
+
+    #[test]
+    fn run_propagates_runner_failure_as_post_install_failed() {
+        let cache = tempdir().unwrap();
+        let bin = tempdir().unwrap();
+        let tmp = tempdir().unwrap();
+        let artifact = make_artifact(tmp.path());
+        let runner = RecordingRunner::new();
+        runner.set_outcome(
+            "su",
+            CommandOutcome {
+                status: Some(7),
+                stdout: vec![],
+                stderr: b"rustup-init: bad arg".to_vec(),
+            },
+        );
+        let env = BTreeMap::new();
+        let args: Vec<String> = vec![];
+
+        let ctx = MethodContext {
+            artifact: &artifact,
+            args: &args,
+            env: &env,
+            user: "vscode",
+            cache_root: cache.path(),
+            bin_root: bin.path(),
+            runner: &runner,
+        };
+        let err = run(&ctx).unwrap_err();
+        match err {
+            LuggageError::PostInstallFailed { step, message } => {
+                assert_eq!(step, "rustup-init");
+                assert!(message.contains("rustup-init: bad arg"));
+            }
+            other => panic!("expected PostInstallFailed, got {other:?}"),
+        }
+    }
+}

--- a/crates/luggage/src/installer/methods/script_installer.rs
+++ b/crates/luggage/src/installer/methods/script_installer.rs
@@ -143,7 +143,7 @@ fn install_symlinks(
     ))
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
 

--- a/crates/luggage/src/installer/mod.rs
+++ b/crates/luggage/src/installer/mod.rs
@@ -1,0 +1,504 @@
+//! Install execution engine.
+//!
+//! Consumes a [`crate::ResolvedInstall`] and runs the install: idempotency
+//! check, system-package install, download + verification, install-method
+//! execution, post-install steps, validation. Reports success or a typed
+//! [`crate::LuggageError`].
+//!
+//! # Pilot scope
+//!
+//! Issue #405 implements the rust@1.95.0 path end-to-end (rustup-init
+//! script-installer + tier 3 published-checksum verification). Other shapes
+//! return [`crate::LuggageError::NotImplemented`] and ship in follow-ups.
+
+pub mod download;
+pub mod idempotency;
+pub mod logging;
+pub mod methods;
+pub mod post_install;
+pub mod rustup_target;
+pub mod syspackages;
+pub mod template;
+pub mod user;
+pub mod validate;
+pub mod verify;
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use serde::Serialize;
+use tempfile::tempdir_in;
+
+use crate::error::{LuggageError, Result};
+use crate::resolver::ResolvedInstall;
+
+use download::{HttpClient, UreqClient};
+use methods::{CommandRunner, MethodContext, ProcessRunner};
+use rustup_target::rustup_target_for;
+use syspackages::{PackageManager, install_dependencies, translate_dependencies};
+use template::{Substitutions, substitute_url};
+
+/// Installer configuration.
+#[derive(Debug, Clone)]
+pub struct InstallerOptions {
+    /// Skip side-effects; build the plan and return it.
+    pub dry_run: bool,
+    /// Bypass the idempotency check and reinstall regardless.
+    pub force: bool,
+    /// Per-feature log directory (`/var/log/luggage/` in production).
+    pub log_dir: PathBuf,
+    /// Where binaries are symlinked (default `/usr/local/bin`). Tests override.
+    pub bin_root: PathBuf,
+    /// Cache root for tool data (default `/cache`). Tests override.
+    pub cache_root: PathBuf,
+    /// Scratch directory for downloads. Defaults to `/tmp`.
+    pub tmp_root: PathBuf,
+    /// Optional override for the install user; falls back to `$USERNAME`.
+    pub user_override: Option<String>,
+    /// When `true`, the installer also runs `apt-get update && apt-get
+    /// install -y ...` (or distro equivalent) for catalog dependencies.
+    /// Defaults to `true`; tests turn it off to stay hermetic.
+    pub install_system_packages: bool,
+}
+
+impl Default for InstallerOptions {
+    fn default() -> Self {
+        Self {
+            dry_run: false,
+            force: false,
+            log_dir: PathBuf::from("/var/log/luggage"),
+            bin_root: PathBuf::from("/usr/local/bin"),
+            cache_root: PathBuf::from("/cache"),
+            tmp_root: PathBuf::from("/tmp"),
+            user_override: None,
+            install_system_packages: true,
+        }
+    }
+}
+
+/// A fully substituted install plan ready to execute.
+///
+/// Returned by [`Installer::plan`]. With `--dry-run` this is what the CLI
+/// prints; otherwise it is consumed internally by [`Installer::run`].
+#[derive(Debug, Clone, Serialize)]
+pub struct InstallPlan {
+    /// Tool id.
+    pub tool: String,
+    /// Concrete version chosen.
+    pub version: String,
+    /// `install_methods[].name` of the chosen method.
+    pub method_name: String,
+    /// Verification tier (`1`–`4`).
+    pub verification_tier: u8,
+    /// Fully substituted source URL (no `{rustup_target}` placeholders).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_url: Option<String>,
+    /// Fully substituted checksum URL when applicable (tier 3).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checksum_url: Option<String>,
+    /// Installer argv (from `Invoke::args`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub invoke_args: Option<Vec<String>>,
+    /// Catalog `Dependency.tool` ids that will be installed via the host
+    /// package manager, translated to per-distro names.
+    pub system_packages: Vec<String>,
+    /// Number of post-install steps to run.
+    pub post_install_steps: usize,
+    /// User the install will run as.
+    pub user: String,
+}
+
+/// Outcome of a successful install run.
+#[derive(Debug, Clone, Serialize)]
+pub struct InstallReport {
+    /// Tool id.
+    pub tool: String,
+    /// Concrete version installed.
+    pub version: String,
+    /// `true` if the idempotency check skipped the install.
+    pub already_installed: bool,
+    /// Path to the per-feature log file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub log_path: Option<PathBuf>,
+}
+
+/// The install execution engine.
+///
+/// Production callers use [`Installer::with_options`]; tests use
+/// [`Installer::with_runners`] to inject in-process HTTP and command stubs.
+pub struct Installer {
+    options: InstallerOptions,
+    http: Arc<dyn HttpClient>,
+    runner: Arc<dyn CommandRunner>,
+}
+
+impl std::fmt::Debug for Installer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Installer").field("options", &self.options).finish_non_exhaustive()
+    }
+}
+
+impl Installer {
+    /// Build with production HTTP + process runners.
+    #[must_use]
+    pub fn with_options(options: InstallerOptions) -> Self {
+        Self { options, http: Arc::new(UreqClient::default()), runner: Arc::new(ProcessRunner) }
+    }
+
+    /// Build with caller-supplied runners. Used by tests.
+    pub fn with_runners(
+        options: InstallerOptions,
+        http: Arc<dyn HttpClient>,
+        runner: Arc<dyn CommandRunner>,
+    ) -> Self {
+        Self { options, http, runner }
+    }
+
+    /// Borrow the underlying options.
+    #[must_use]
+    pub const fn options(&self) -> &InstallerOptions {
+        &self.options
+    }
+
+    /// Build a plan without performing I/O.
+    ///
+    /// The plan reflects every substituted URL, the per-distro package
+    /// names, and the chosen install user — enough for the CLI's
+    /// `--dry-run` mode to print a complete picture.
+    ///
+    /// # Errors
+    ///
+    /// - [`LuggageError::TemplateMissingKey`] when a URL template
+    ///   references an unsupported placeholder.
+    /// - [`LuggageError::NotImplemented`] when the resolved platform is
+    ///   not in the rustup-target table or the package manager is unknown.
+    pub fn plan(&self, resolved: &ResolvedInstall) -> Result<InstallPlan> {
+        let target = rustup_target_for(&resolved.platform).ok();
+        let subs =
+            Substitutions { version: Some(resolved.version.as_str()), rustup_target: target };
+
+        let source_url = match resolved.source_url_template.as_deref() {
+            Some(t) => Some(substitute_url(t, &subs)?),
+            None => None,
+        };
+        let checksum_url = match resolved.verification.checksum_url_template.as_deref() {
+            Some(t) => Some(substitute_url(t, &subs)?),
+            None => None,
+        };
+        let invoke_args = resolved.invoke.as_ref().and_then(|i| i.args.clone());
+
+        let pkg_mgr = PackageManager::for_platform(&resolved.platform).ok();
+        let system_packages = match (pkg_mgr, resolved.dependencies.as_deref()) {
+            (Some(mgr), Some(deps)) => {
+                translate_dependencies(deps, mgr).into_iter().map(str::to_owned).collect()
+            }
+            _ => Vec::new(),
+        };
+
+        let post_install_steps = resolved.post_install.as_ref().map_or(0, Vec::len);
+        let user = user::resolve_user(self.options.user_override.as_deref());
+
+        Ok(InstallPlan {
+            tool: resolved.tool.clone(),
+            version: resolved.version.clone(),
+            method_name: resolved.method_name.clone(),
+            verification_tier: resolved.verification_tier,
+            source_url,
+            checksum_url,
+            invoke_args,
+            system_packages,
+            post_install_steps,
+            user,
+        })
+    }
+
+    /// Execute the install end-to-end.
+    ///
+    /// Stage order, mirroring `lib/features/rust.sh`:
+    ///
+    /// 1. Idempotency pre-check (skip if `<bin>/<tool> --version` already
+    ///    matches and `force` is false).
+    /// 2. Install system packages (apt/apk/dnf).
+    /// 3. Download the source artifact.
+    /// 4. Verify it via the catalog tier (3 implemented, 1/2/4 deferred).
+    /// 5. Run the install method (only `rustup-init` shape implemented).
+    /// 6. Run post-install steps.
+    /// 7. Validate by re-invoking `<bin>/<tool> --version`.
+    ///
+    /// # Errors
+    ///
+    /// Propagates whatever any stage returns. See module-level docs for
+    /// the full list of variants.
+    pub fn run(&self, resolved: &ResolvedInstall) -> Result<InstallReport> {
+        let logger =
+            logging::FeatureLogger::open(&self.options.log_dir, &resolved.tool, &resolved.version)
+                .ok();
+        if let Some(l) = &logger {
+            l.feature_start(&resolved.tool, &resolved.version);
+        }
+
+        if !self.options.force
+            && idempotency::already_installed(
+                &resolved.tool,
+                &resolved.version,
+                &self.options.bin_root,
+            )
+        {
+            return Ok(Self::report_skipped(resolved, logger));
+        }
+
+        let plan = self.plan(resolved)?;
+        if self.options.dry_run {
+            return Ok(Self::report_dry_run(plan, logger));
+        }
+
+        self.run_stages(resolved, plan, logger.as_ref())?;
+
+        if let Some(l) = &logger {
+            l.feature_end();
+        }
+        Ok(InstallReport {
+            tool: resolved.tool.clone(),
+            version: resolved.version.clone(),
+            already_installed: false,
+            log_path: logger.map(|l| l.path().to_owned()),
+        })
+    }
+
+    fn report_skipped(
+        resolved: &ResolvedInstall,
+        logger: Option<logging::FeatureLogger>,
+    ) -> InstallReport {
+        if let Some(l) = &logger {
+            l.message(&format!(
+                "{}@{} already installed; skipping",
+                resolved.tool, resolved.version
+            ));
+            l.feature_end();
+        }
+        InstallReport {
+            tool: resolved.tool.clone(),
+            version: resolved.version.clone(),
+            already_installed: true,
+            log_path: logger.map(|l| l.path().to_owned()),
+        }
+    }
+
+    fn report_dry_run(plan: InstallPlan, logger: Option<logging::FeatureLogger>) -> InstallReport {
+        if let Some(l) = &logger {
+            l.message("dry-run: stopping after plan");
+            l.feature_end();
+        }
+        InstallReport {
+            tool: plan.tool,
+            version: plan.version,
+            already_installed: false,
+            log_path: logger.map(|l| l.path().to_owned()),
+        }
+    }
+
+    fn run_stages(
+        &self,
+        resolved: &ResolvedInstall,
+        plan: InstallPlan,
+        logger: Option<&logging::FeatureLogger>,
+    ) -> Result<()> {
+        self.stage_system_packages(resolved, logger)?;
+        let bytes = self.stage_download(&plan, logger)?;
+        self.stage_verify(resolved, &bytes, logger)?;
+        fs::create_dir_all(&self.options.tmp_root)
+            .map_err(|e| LuggageError::Io { path: self.options.tmp_root.clone(), source: e })?;
+        let scratch = tempdir_in(&self.options.tmp_root)
+            .map_err(|e| LuggageError::Io { path: self.options.tmp_root.clone(), source: e })?;
+        let source_url = plan.source_url.as_deref().expect("download stage validated source_url");
+        let artifact = scratch.path().join(install_basename(source_url));
+        fs::write(&artifact, &bytes)
+            .map_err(|e| LuggageError::Io { path: artifact.clone(), source: e })?;
+
+        let env_map = invoke_env_map(resolved);
+        let invoke_args = plan.invoke_args.clone().unwrap_or_default();
+        let user = plan.user;
+        self.stage_method(resolved, &artifact, &invoke_args, &env_map, &user, logger)?;
+        self.stage_post_install(resolved, &user, env_map, logger)?;
+        self.stage_validate(resolved, logger)
+    }
+
+    fn stage_system_packages(
+        &self,
+        resolved: &ResolvedInstall,
+        logger: Option<&logging::FeatureLogger>,
+    ) -> Result<()> {
+        if !self.options.install_system_packages {
+            return Ok(());
+        }
+        let Ok(mgr) = PackageManager::for_platform(&resolved.platform) else { return Ok(()) };
+        let Some(deps) = resolved.dependencies.as_deref() else { return Ok(()) };
+        if deps.is_empty() {
+            return Ok(());
+        }
+        if let Some(l) = logger {
+            l.step("install system packages");
+        }
+        install_dependencies(deps, mgr)
+    }
+
+    fn stage_download(
+        &self,
+        plan: &InstallPlan,
+        logger: Option<&logging::FeatureLogger>,
+    ) -> Result<Vec<u8>> {
+        let url = plan.source_url.as_deref().ok_or_else(|| {
+            LuggageError::Catalog(
+                "install method has no source_url_template (cannot download)".into(),
+            )
+        })?;
+        if let Some(l) = logger {
+            l.step(&format!("download {url}"));
+        }
+        self.http.get(url)
+    }
+
+    fn stage_verify(
+        &self,
+        resolved: &ResolvedInstall,
+        bytes: &[u8],
+        logger: Option<&logging::FeatureLogger>,
+    ) -> Result<()> {
+        let target = rustup_target_for(&resolved.platform).ok();
+        let subs =
+            Substitutions { version: Some(resolved.version.as_str()), rustup_target: target };
+        if let Some(l) = logger {
+            l.step(&format!("verify (tier {})", resolved.verification_tier));
+        }
+        verify::dispatch(
+            &resolved.tool,
+            &resolved.version,
+            bytes,
+            &resolved.verification,
+            &subs,
+            self.http.as_ref(),
+        )
+    }
+
+    fn stage_method(
+        &self,
+        resolved: &ResolvedInstall,
+        artifact: &std::path::Path,
+        invoke_args: &[String],
+        env_map: &BTreeMap<String, String>,
+        user: &str,
+        logger: Option<&logging::FeatureLogger>,
+    ) -> Result<()> {
+        if let Some(l) = logger {
+            l.step(&format!("run install method `{}`", resolved.method_name));
+        }
+        methods::dispatch(
+            &resolved.method_name,
+            &MethodContext {
+                artifact,
+                args: invoke_args,
+                env: env_map,
+                user,
+                cache_root: &self.options.cache_root,
+                bin_root: &self.options.bin_root,
+                runner: self.runner.as_ref(),
+            },
+        )
+    }
+
+    fn stage_post_install(
+        &self,
+        resolved: &ResolvedInstall,
+        user: &str,
+        mut env_map: BTreeMap<String, String>,
+        logger: Option<&logging::FeatureLogger>,
+    ) -> Result<()> {
+        // Post-install runs in a fresh `su -` so it needs the same env the
+        // install method exported. If the catalog didn't pin them, add the
+        // pilot defaults under `cache_root`.
+        env_map
+            .entry("CARGO_HOME".to_owned())
+            .or_insert_with(|| self.options.cache_root.join("cargo").display().to_string());
+        env_map
+            .entry("RUSTUP_HOME".to_owned())
+            .or_insert_with(|| self.options.cache_root.join("rustup").display().to_string());
+
+        let Some(steps) = resolved.post_install.as_deref() else { return Ok(()) };
+        if steps.is_empty() {
+            return Ok(());
+        }
+        if let Some(l) = logger {
+            l.step(&format!("post-install ({} steps)", steps.len()));
+        }
+        post_install::run_steps(steps, user, &env_map, self.runner.as_ref())
+    }
+
+    fn stage_validate(
+        &self,
+        resolved: &ResolvedInstall,
+        logger: Option<&logging::FeatureLogger>,
+    ) -> Result<()> {
+        if let Some(l) = logger {
+            l.step("validate");
+        }
+        validate::check(&resolved.tool, &resolved.version, &self.options.bin_root)
+    }
+}
+
+fn invoke_env_map(resolved: &ResolvedInstall) -> BTreeMap<String, String> {
+    resolved
+        .invoke
+        .as_ref()
+        .and_then(|i| i.env.clone())
+        .map(|m| m.into_iter().collect())
+        .unwrap_or_default()
+}
+
+/// Strip the trailing path segment from a URL for use as the on-disk
+/// filename. Falls back to `download` when the URL is path-empty.
+fn install_basename(url: &str) -> String {
+    let trimmed = url.split('?').next().unwrap_or(url);
+    trimmed
+        .rsplit_once('/')
+        .map(|(_, last)| last)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("download")
+        .to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_options_use_production_paths() {
+        let o = InstallerOptions::default();
+        assert_eq!(o.bin_root, PathBuf::from("/usr/local/bin"));
+        assert_eq!(o.cache_root, PathBuf::from("/cache"));
+        assert_eq!(o.log_dir, PathBuf::from("/var/log/luggage"));
+        assert_eq!(o.tmp_root, PathBuf::from("/tmp"));
+        assert!(!o.dry_run);
+        assert!(!o.force);
+        assert!(o.install_system_packages);
+    }
+
+    #[test]
+    fn install_basename_extracts_last_segment() {
+        assert_eq!(
+            install_basename("https://example.test/x86_64-unknown-linux-gnu/rustup-init"),
+            "rustup-init",
+        );
+    }
+
+    #[test]
+    fn install_basename_handles_query_string() {
+        assert_eq!(install_basename("https://example.test/x?token=abc"), "x");
+    }
+
+    #[test]
+    fn install_basename_falls_back_when_path_empty() {
+        assert_eq!(install_basename("https://example.test/"), "download");
+    }
+}

--- a/crates/luggage/src/installer/post_install.rs
+++ b/crates/luggage/src/installer/post_install.rs
@@ -1,0 +1,194 @@
+//! Post-install step execution.
+//!
+//! Wraps the catalog's [`PostInstall`] enum and turns each variant into a
+//! shell invocation under the install user. Mirrors `lib/features/rust.sh`
+//! which calls `rustup component add ...` after the toolchain lands.
+//!
+//! - [`PostInstall::ComponentAdd`] → `rustup component add <component>`
+//! - [`PostInstall::Command`] → `<command> <args...>`
+//! - [`PostInstall::CargoInstall`] → [`crate::LuggageError::NotImplemented`]
+//!   (rust-dev follow-up will wire `cargo install --locked --version`).
+//! - [`PostInstall::Unknown`] → [`crate::LuggageError::PostInstallFailed`]
+
+use std::collections::BTreeMap;
+
+use containers_common::tooldb::PostInstall;
+use shell_words::quote;
+
+use crate::error::{LuggageError, Result};
+use crate::installer::methods::CommandRunner;
+use crate::installer::user::su_command;
+
+/// Execute every step in `steps` in order.
+///
+/// `env` is exported in front of every step so each `rustup` invocation
+/// sees the same `CARGO_HOME` / `RUSTUP_HOME` the install method used.
+///
+/// # Errors
+///
+/// - [`LuggageError::NotImplemented`] for a `CargoInstall` variant.
+/// - [`LuggageError::PostInstallFailed`] for `Unknown` variants and for
+///   any step whose runner returned a non-zero exit status.
+pub fn run_steps(
+    steps: &[PostInstall],
+    user: &str,
+    env: &BTreeMap<String, String>,
+    runner: &dyn CommandRunner,
+) -> Result<()> {
+    for step in steps {
+        run_one(step, user, env, runner)?;
+    }
+    Ok(())
+}
+
+fn run_one(
+    step: &PostInstall,
+    user: &str,
+    env: &BTreeMap<String, String>,
+    runner: &dyn CommandRunner,
+) -> Result<()> {
+    let (step_id, body) = match step {
+        PostInstall::ComponentAdd { component } => (
+            format!("component_add:{component}"),
+            format!("rustup component add {}", quote(component)),
+        ),
+        PostInstall::Command { command, args } => {
+            let mut body = quote(command).into_owned();
+            if let Some(args) = args {
+                for a in args {
+                    body.push(' ');
+                    body.push_str(&quote(a));
+                }
+            }
+            (format!("command:{command}"), body)
+        }
+        PostInstall::CargoInstall { package, version: _ } => {
+            return Err(LuggageError::NotImplemented(
+                "PostInstall::CargoInstall (rust-dev follow-up; needs --locked + --version pin)",
+            ))
+            .inspect_err(|_| {
+                // Carry the package name into the trace for a slightly
+                // friendlier diagnostic when the rust-dev migration runs.
+                tracing::warn!(package = %package, "deferring CargoInstall to follow-up issue");
+            });
+        }
+        PostInstall::Unknown => {
+            return Err(LuggageError::PostInstallFailed {
+                step: "unknown".into(),
+                message: "unrecognized post_install variant in catalog".into(),
+            });
+        }
+    };
+
+    let argv = su_command(user, env, &body);
+    let outcome = runner.run(&argv[0], &argv[1..])?;
+    if outcome.success() {
+        Ok(())
+    } else {
+        Err(LuggageError::PostInstallFailed {
+            step: step_id,
+            message: format!(
+                "exit {:?}: {}",
+                outcome.status,
+                String::from_utf8_lossy(&outcome.stderr).trim_end(),
+            ),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::installer::methods::{CommandOutcome, RecordingRunner};
+
+    #[test]
+    fn component_add_invokes_rustup_under_su() {
+        let runner = RecordingRunner::new();
+        let env = BTreeMap::new();
+        run_steps(
+            &[PostInstall::ComponentAdd { component: "rust-src".into() }],
+            "vscode",
+            &env,
+            &runner,
+        )
+        .unwrap();
+        let calls = runner.calls();
+        assert_eq!(calls.len(), 1);
+        let (prog, args) = &calls[0];
+        assert_eq!(prog, "su");
+        assert_eq!(args[..3], ["-".to_owned(), "vscode".into(), "-c".into()]);
+        assert!(args[3].contains("rustup component add rust-src"));
+    }
+
+    #[test]
+    fn command_step_quotes_and_invokes() {
+        let runner = RecordingRunner::new();
+        let env = BTreeMap::new();
+        run_steps(
+            &[PostInstall::Command { command: "echo".into(), args: Some(vec!["hi there".into()]) }],
+            "vscode",
+            &env,
+            &runner,
+        )
+        .unwrap();
+        let calls = runner.calls();
+        let payload = &calls[0].1[3];
+        assert!(payload.contains("echo"));
+        assert!(payload.contains("'hi there'"));
+    }
+
+    #[test]
+    fn cargo_install_returns_not_implemented() {
+        let runner = RecordingRunner::new();
+        let env = BTreeMap::new();
+        let err = run_steps(
+            &[PostInstall::CargoInstall { package: "ripgrep".into(), version: "14.0.0".into() }],
+            "vscode",
+            &env,
+            &runner,
+        )
+        .unwrap_err();
+        assert!(matches!(err, LuggageError::NotImplemented(_)));
+    }
+
+    #[test]
+    fn unknown_variant_returns_post_install_failed() {
+        let runner = RecordingRunner::new();
+        let env = BTreeMap::new();
+        let err = run_steps(&[PostInstall::Unknown], "vscode", &env, &runner).unwrap_err();
+        assert!(matches!(err, LuggageError::PostInstallFailed { .. }));
+    }
+
+    #[test]
+    fn nonzero_exit_maps_to_post_install_failed() {
+        let runner = RecordingRunner::new();
+        runner.set_outcome(
+            "su",
+            CommandOutcome { status: Some(2), stdout: vec![], stderr: b"oops".to_vec() },
+        );
+        let env = BTreeMap::new();
+        let err = run_steps(
+            &[PostInstall::ComponentAdd { component: "rust-src".into() }],
+            "vscode",
+            &env,
+            &runner,
+        )
+        .unwrap_err();
+        match err {
+            LuggageError::PostInstallFailed { step, message } => {
+                assert_eq!(step, "component_add:rust-src");
+                assert!(message.contains("oops"));
+            }
+            other => panic!("expected PostInstallFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_steps_is_a_noop() {
+        let runner = RecordingRunner::new();
+        let env = BTreeMap::new();
+        run_steps(&[], "vscode", &env, &runner).unwrap();
+        assert!(runner.calls().is_empty());
+    }
+}

--- a/crates/luggage/src/installer/rustup_target.rs
+++ b/crates/luggage/src/installer/rustup_target.rs
@@ -1,0 +1,82 @@
+//! Map a [`crate::Platform`] to a rustup target triple.
+//!
+//! rustup's distribution URLs are keyed by target triples like
+//! `x86_64-unknown-linux-gnu`. The catalog uses the abstract
+//! os/arch vocabulary (`debian`/`amd64` etc.) so this helper bridges the
+//! two for the `{rustup_target}` URL placeholder.
+//!
+//! # Pilot scope
+//!
+//! Only the four combinations rust@1.95.0 supports are wired in. Other
+//! platforms return [`crate::LuggageError::NotImplemented`]; future tools
+//! may need a different mapping function entirely.
+
+use crate::Platform;
+use crate::error::{LuggageError, Result};
+
+/// Pick the rustup target triple for `platform`.
+///
+/// # Errors
+///
+/// - [`LuggageError::NotImplemented`] when the (os, arch) pair has no entry
+///   in the table. Issue follow-ups may extend this.
+pub fn rustup_target_for(platform: &Platform) -> Result<&'static str> {
+    Ok(match (platform.os.as_str(), platform.arch.as_str()) {
+        ("debian" | "ubuntu" | "rhel", "amd64") => "x86_64-unknown-linux-gnu",
+        ("debian" | "ubuntu" | "rhel", "arm64") => "aarch64-unknown-linux-gnu",
+        ("alpine", "amd64") => "x86_64-unknown-linux-musl",
+        ("alpine", "arm64") => "aarch64-unknown-linux-musl",
+        _ => return Err(LuggageError::NotImplemented("rustup_target for this platform")),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(os: &str, arch: &str) -> Platform {
+        Platform { os: os.into(), os_version: None, arch: arch.into() }
+    }
+
+    #[test]
+    fn debian_amd64_maps_to_gnu_triple() {
+        assert_eq!(rustup_target_for(&p("debian", "amd64")).unwrap(), "x86_64-unknown-linux-gnu");
+    }
+
+    #[test]
+    fn debian_arm64_maps_to_gnu_triple() {
+        assert_eq!(rustup_target_for(&p("debian", "arm64")).unwrap(), "aarch64-unknown-linux-gnu");
+    }
+
+    #[test]
+    fn ubuntu_amd64_maps_to_gnu_triple() {
+        assert_eq!(rustup_target_for(&p("ubuntu", "amd64")).unwrap(), "x86_64-unknown-linux-gnu");
+    }
+
+    #[test]
+    fn rhel_arm64_maps_to_gnu_triple() {
+        assert_eq!(rustup_target_for(&p("rhel", "arm64")).unwrap(), "aarch64-unknown-linux-gnu");
+    }
+
+    #[test]
+    fn alpine_amd64_maps_to_musl_triple() {
+        assert_eq!(rustup_target_for(&p("alpine", "amd64")).unwrap(), "x86_64-unknown-linux-musl");
+    }
+
+    #[test]
+    fn alpine_arm64_maps_to_musl_triple() {
+        assert_eq!(rustup_target_for(&p("alpine", "arm64")).unwrap(), "aarch64-unknown-linux-musl");
+    }
+
+    #[test]
+    fn unknown_platform_returns_not_implemented() {
+        let err = rustup_target_for(&p("windows", "amd64")).unwrap_err();
+        assert!(matches!(err, LuggageError::NotImplemented(_)));
+    }
+
+    #[test]
+    fn unknown_arch_returns_not_implemented() {
+        let err = rustup_target_for(&p("debian", "riscv64")).unwrap_err();
+        assert!(matches!(err, LuggageError::NotImplemented(_)));
+    }
+}

--- a/crates/luggage/src/installer/syspackages.rs
+++ b/crates/luggage/src/installer/syspackages.rs
@@ -1,0 +1,275 @@
+//! System-package install dispatch (apt / apk / dnf).
+//!
+//! Catalog `Dependency.tool` entries (e.g. `ca_certificates`, `gcc`,
+//! `libc_dev`) describe abstract system packages that need to be installed
+//! before the tool can run. This module:
+//!
+//! 1. Detects the host's package manager from a [`crate::Platform`].
+//! 2. Maps each abstract `Dependency.tool` id to the per-distro package name.
+//! 3. Shells out to the host's package manager to install them.
+//!
+//! # Pilot scope
+//!
+//! Only the four IDs rust@1.95.0 declares — `ca_certificates`, `gcc`,
+//! `libc_dev`, `musl_dev` — are wired up. Unknown IDs log a warning and
+//! continue rather than fail; future issues will widen the table or move
+//! it into the catalog as a per-tool override.
+
+use std::process::Command;
+
+use containers_common::tooldb::Dependency;
+use tracing::warn;
+
+use crate::Platform;
+use crate::error::{LuggageError, Result};
+
+/// Detected host package manager.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackageManager {
+    /// `apt-get` (debian/ubuntu).
+    Apt,
+    /// `apk` (alpine).
+    Apk,
+    /// `dnf` (rhel/fedora).
+    Dnf,
+}
+
+impl PackageManager {
+    /// Pick the package manager for `platform.os`.
+    ///
+    /// # Errors
+    ///
+    /// - [`LuggageError::NotImplemented`] when the OS does not map to any
+    ///   wired-up package manager.
+    pub fn for_platform(platform: &Platform) -> Result<Self> {
+        Ok(match platform.os.as_str() {
+            "debian" | "ubuntu" => Self::Apt,
+            "alpine" => Self::Apk,
+            "rhel" | "fedora" => Self::Dnf,
+            _ => return Err(LuggageError::NotImplemented("package manager for this platform")),
+        })
+    }
+}
+
+/// Map an abstract `Dependency.tool` id to the per-distro package name.
+///
+/// Returns `None` when the id is unknown to this build of luggage.
+#[must_use]
+pub fn package_name(tool: &str, mgr: PackageManager) -> Option<&'static str> {
+    match (tool, mgr) {
+        ("ca_certificates", _) => Some("ca-certificates"),
+        ("gcc", _) => Some("gcc"),
+        ("libc_dev", PackageManager::Apt) => Some("libc6-dev"),
+        ("libc_dev", PackageManager::Dnf) => Some("glibc-devel"),
+        ("musl_dev", PackageManager::Apk) => Some("musl-dev"),
+        ("pkg_config", _) => Some("pkg-config"),
+        _ => None,
+    }
+}
+
+/// Build the argv that installs `packages` via `mgr`.
+///
+/// Returned as `(program, args)` so callers can inject a different runner
+/// for tests. Returns `None` when `packages` is empty.
+#[must_use]
+pub fn install_argv(mgr: PackageManager, packages: &[&str]) -> Option<(&'static str, Vec<String>)> {
+    if packages.is_empty() {
+        return None;
+    }
+    let owned: Vec<String> = packages.iter().map(|p| (*p).to_owned()).collect();
+    Some(match mgr {
+        PackageManager::Apt => {
+            let mut args =
+                vec!["install".to_owned(), "-y".to_owned(), "--no-install-recommends".to_owned()];
+            args.extend(owned);
+            ("apt-get", args)
+        }
+        PackageManager::Apk => {
+            let mut args = vec!["add".to_owned(), "--no-cache".to_owned()];
+            args.extend(owned);
+            ("apk", args)
+        }
+        PackageManager::Dnf => {
+            let mut args = vec!["install".to_owned(), "-y".to_owned()];
+            args.extend(owned);
+            ("dnf", args)
+        }
+    })
+}
+
+/// Translate `dependencies` into per-distro package names.
+///
+/// Unknown `Dependency.tool` ids emit a `tracing::warn!` and are skipped.
+/// This is intentional: the rust pilot's catalog has been hand-audited but
+/// catalogs scanned in by future automation may carry IDs we haven't wired
+/// yet, and a single unrecognised dep should not block the entire install.
+pub fn translate_dependencies(deps: &[Dependency], mgr: PackageManager) -> Vec<&'static str> {
+    let mut out = Vec::new();
+    for dep in deps {
+        if let Some(name) = package_name(&dep.tool, mgr) {
+            out.push(name);
+        } else {
+            warn!(
+                tool = %dep.tool,
+                manager = ?mgr,
+                "no system-package mapping; skipping (catalog may need an update)",
+            );
+        }
+    }
+    out
+}
+
+/// Install `dependencies` on the host via `mgr`.
+///
+/// Skips the call when no dependencies translate to packages. Errors map
+/// to [`LuggageError::PackageManagerFailed`] with the package manager's
+/// stderr in the message body for diagnostics.
+///
+/// # Errors
+///
+/// - [`LuggageError::PackageManagerFailed`] when the package manager exits
+///   non-zero or fails to launch.
+pub fn install_dependencies(deps: &[Dependency], mgr: PackageManager) -> Result<()> {
+    let names = translate_dependencies(deps, mgr);
+    let Some((program, args)) = install_argv(mgr, &names) else {
+        return Ok(());
+    };
+    if matches!(mgr, PackageManager::Apt) {
+        let update = Command::new("apt-get").arg("update").output().map_err(|e| {
+            LuggageError::PackageManagerFailed {
+                message: format!("apt-get update failed to launch: {e}"),
+            }
+        })?;
+        if !update.status.success() {
+            return Err(LuggageError::PackageManagerFailed {
+                message: format!(
+                    "apt-get update exited {}: {}",
+                    update.status,
+                    String::from_utf8_lossy(&update.stderr).trim_end(),
+                ),
+            });
+        }
+    }
+    let out = Command::new(program).args(&args).output().map_err(|e| {
+        LuggageError::PackageManagerFailed { message: format!("{program} failed to launch: {e}") }
+    })?;
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(LuggageError::PackageManagerFailed {
+            message: format!(
+                "{program} exited {}: {}",
+                out.status,
+                String::from_utf8_lossy(&out.stderr).trim_end(),
+            ),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(os: &str) -> Platform {
+        Platform { os: os.into(), os_version: None, arch: "amd64".into() }
+    }
+
+    #[test]
+    fn detects_apt_for_debian_and_ubuntu() {
+        assert_eq!(PackageManager::for_platform(&p("debian")).unwrap(), PackageManager::Apt);
+        assert_eq!(PackageManager::for_platform(&p("ubuntu")).unwrap(), PackageManager::Apt);
+    }
+
+    #[test]
+    fn detects_apk_for_alpine() {
+        assert_eq!(PackageManager::for_platform(&p("alpine")).unwrap(), PackageManager::Apk);
+    }
+
+    #[test]
+    fn detects_dnf_for_rhel_and_fedora() {
+        assert_eq!(PackageManager::for_platform(&p("rhel")).unwrap(), PackageManager::Dnf);
+        assert_eq!(PackageManager::for_platform(&p("fedora")).unwrap(), PackageManager::Dnf);
+    }
+
+    #[test]
+    fn unknown_os_returns_not_implemented() {
+        let err = PackageManager::for_platform(&p("haiku")).unwrap_err();
+        assert!(matches!(err, LuggageError::NotImplemented(_)));
+    }
+
+    #[test]
+    fn package_name_known_mappings() {
+        assert_eq!(package_name("gcc", PackageManager::Apt), Some("gcc"));
+        assert_eq!(package_name("libc_dev", PackageManager::Apt), Some("libc6-dev"));
+        assert_eq!(package_name("musl_dev", PackageManager::Apk), Some("musl-dev"));
+        assert_eq!(package_name("ca_certificates", PackageManager::Apk), Some("ca-certificates"));
+        assert_eq!(package_name("pkg_config", PackageManager::Dnf), Some("pkg-config"));
+    }
+
+    #[test]
+    fn package_name_unknown_returns_none() {
+        assert_eq!(package_name("frobnicator", PackageManager::Apt), None);
+        // Wrong-distro mapping (e.g. musl_dev on apt) also returns None;
+        // catalog entries should never produce this combination, but if they
+        // do, we'd rather skip than install something wrong.
+        assert_eq!(package_name("musl_dev", PackageManager::Apt), None);
+    }
+
+    #[test]
+    fn install_argv_apt_includes_no_install_recommends() {
+        let (prog, args) = install_argv(PackageManager::Apt, &["gcc", "libc6-dev"]).unwrap();
+        assert_eq!(prog, "apt-get");
+        assert_eq!(args, vec!["install", "-y", "--no-install-recommends", "gcc", "libc6-dev"]);
+    }
+
+    #[test]
+    fn install_argv_apk_uses_no_cache() {
+        let (prog, args) = install_argv(PackageManager::Apk, &["musl-dev"]).unwrap();
+        assert_eq!(prog, "apk");
+        assert_eq!(args, vec!["add", "--no-cache", "musl-dev"]);
+    }
+
+    #[test]
+    fn install_argv_dnf_uses_minus_y() {
+        let (prog, args) = install_argv(PackageManager::Dnf, &["gcc"]).unwrap();
+        assert_eq!(prog, "dnf");
+        assert_eq!(args, vec!["install", "-y", "gcc"]);
+    }
+
+    #[test]
+    fn install_argv_returns_none_when_no_packages() {
+        assert!(install_argv(PackageManager::Apt, &[]).is_none());
+    }
+
+    #[test]
+    fn translate_dependencies_skips_unknown() {
+        let deps = vec![
+            Dependency {
+                tool: "ca_certificates".into(),
+                version: None,
+                version_constraint: None,
+                purpose: None,
+                required: None,
+                platforms: None,
+            },
+            Dependency {
+                tool: "frobnicator".into(),
+                version: None,
+                version_constraint: None,
+                purpose: None,
+                required: None,
+                platforms: None,
+            },
+            Dependency {
+                tool: "gcc".into(),
+                version: None,
+                version_constraint: None,
+                purpose: None,
+                required: None,
+                platforms: None,
+            },
+        ];
+        let pkgs = translate_dependencies(&deps, PackageManager::Apt);
+        assert_eq!(pkgs, vec!["ca-certificates", "gcc"]);
+    }
+}

--- a/crates/luggage/src/installer/template.rs
+++ b/crates/luggage/src/installer/template.rs
@@ -1,0 +1,135 @@
+//! URL template substitution.
+//!
+//! Catalog `source_url_template` and `verification.checksum_url_template`
+//! values carry placeholders like `{rustup_target}` and `{version}`. This
+//! module fills them in from a [`Substitutions`] table.
+//!
+//! Unknown placeholders return [`crate::LuggageError::TemplateMissingKey`]
+//! rather than silently leaving them in the output, so a misconfigured
+//! catalog fails fast.
+
+use crate::error::{LuggageError, Result};
+
+/// Substitution table.
+///
+/// All fields are optional; a placeholder referenced from a template that
+/// has no matching field returns [`LuggageError::TemplateMissingKey`].
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Substitutions<'a> {
+    /// Substituted for `{version}`.
+    pub version: Option<&'a str>,
+    /// Substituted for `{rustup_target}`.
+    pub rustup_target: Option<&'a str>,
+}
+
+impl<'a> Substitutions<'a> {
+    /// Build a substitution table with both fields set.
+    #[must_use]
+    pub const fn new(version: &'a str, rustup_target: &'a str) -> Self {
+        Self { version: Some(version), rustup_target: Some(rustup_target) }
+    }
+
+    /// Look up the value for a placeholder name.
+    fn get(&self, key: &str) -> Option<&'a str> {
+        match key {
+            "version" => self.version,
+            "rustup_target" => self.rustup_target,
+            _ => None,
+        }
+    }
+}
+
+/// Substitute every `{key}` in `template` from `subs`.
+///
+/// Placeholders use a single-pass curly-brace syntax. Brace literals are
+/// not supported (the catalog never needs them); a stray `{` without a
+/// matching `}` is treated as literal text.
+///
+/// # Errors
+///
+/// - [`LuggageError::TemplateMissingKey`] if `template` references a key
+///   not present in `subs`.
+pub fn substitute_url(template: &str, subs: &Substitutions<'_>) -> Result<String> {
+    let mut out = String::with_capacity(template.len());
+    let mut rest = template;
+    while let Some(start) = rest.find('{') {
+        out.push_str(&rest[..start]);
+        let after = &rest[start + 1..];
+        let Some(end_rel) = after.find('}') else {
+            // No closing brace — treat the rest as literal.
+            out.push('{');
+            out.push_str(after);
+            return Ok(out);
+        };
+        let key = &after[..end_rel];
+        match subs.get(key) {
+            Some(value) => out.push_str(value),
+            None => return Err(LuggageError::TemplateMissingKey(key.to_owned())),
+        }
+        rest = &after[end_rel + 1..];
+    }
+    out.push_str(rest);
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_placeholders_returns_input_verbatim() {
+        let s = substitute_url("https://example.test/static", &Substitutions::default()).unwrap();
+        assert_eq!(s, "https://example.test/static");
+    }
+
+    #[test]
+    fn substitutes_single_placeholder() {
+        let subs = Substitutions { rustup_target: Some("x86_64-unknown-linux-gnu"), version: None };
+        let s = substitute_url(
+            "https://static.rust-lang.org/rustup/dist/{rustup_target}/rustup-init",
+            &subs,
+        )
+        .unwrap();
+        assert_eq!(
+            s,
+            "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init",
+        );
+    }
+
+    #[test]
+    fn substitutes_multiple_placeholders() {
+        let subs = Substitutions::new("1.95.0", "x86_64-unknown-linux-gnu");
+        let s = substitute_url("base/{version}/{rustup_target}/x", &subs).unwrap();
+        assert_eq!(s, "base/1.95.0/x86_64-unknown-linux-gnu/x");
+    }
+
+    #[test]
+    fn missing_key_returns_template_missing_key() {
+        let err = substitute_url("base/{rustup_target}", &Substitutions::default()).unwrap_err();
+        match err {
+            LuggageError::TemplateMissingKey(key) => assert_eq!(key, "rustup_target"),
+            other => panic!("expected TemplateMissingKey, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_key_returns_template_missing_key() {
+        let subs = Substitutions::new("1.95.0", "x86_64-unknown-linux-gnu");
+        let err = substitute_url("base/{frobnicator}", &subs).unwrap_err();
+        assert!(matches!(err, LuggageError::TemplateMissingKey(_)));
+    }
+
+    #[test]
+    fn unclosed_brace_is_treated_as_literal() {
+        let subs = Substitutions::default();
+        let s = substitute_url("path/{unclosed", &subs).unwrap();
+        assert_eq!(s, "path/{unclosed");
+    }
+
+    #[test]
+    fn back_to_back_placeholders() {
+        let subs = Substitutions::new("1.95.0", "x86_64-unknown-linux-gnu");
+        let s = substitute_url("{version}{rustup_target}", &subs).unwrap();
+        assert_eq!(s, "1.95.0x86_64-unknown-linux-gnu");
+    }
+}

--- a/crates/luggage/src/installer/user.rs
+++ b/crates/luggage/src/installer/user.rs
@@ -1,0 +1,111 @@
+//! Resolve the target install user and build `su -c` invocations.
+//!
+//! Container builds run as root but rust toolchains live under
+//! `$USERNAME` so cargo's per-user state ends up in the right place.
+//! `lib/features/rust.sh` uses `su - "${USERNAME}" -c "..."`. This module
+//! reproduces that pattern in Rust.
+//!
+//! The username is read from `$USERNAME` (set by the Dockerfile) with a
+//! `vscode` fallback that matches the default user across the build matrix.
+
+use std::collections::BTreeMap;
+use std::env;
+use std::fmt::Write as _;
+
+use shell_words::quote;
+
+/// Default install user when `$USERNAME` is unset. Matches the Dockerfile
+/// default and the user `lib/features/rust.sh` falls back to.
+pub const DEFAULT_USERNAME: &str = "vscode";
+
+/// Pick the install user from an explicit override or `$USERNAME`.
+///
+/// `override_value` (typically a `--user` CLI flag) wins when set. With no
+/// override, we read the live `$USERNAME` and fall back to
+/// [`DEFAULT_USERNAME`] when unset or empty. Threaded through the
+/// installer rather than read inside it so test fixtures can pin a value
+/// without mutating process env (which would conflict with the workspace's
+/// `unsafe_code = "forbid"`).
+#[must_use]
+pub fn resolve_user(override_value: Option<&str>) -> String {
+    if let Some(s) = override_value
+        && !s.is_empty()
+    {
+        return s.to_owned();
+    }
+    env::var("USERNAME")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| DEFAULT_USERNAME.to_owned())
+}
+
+/// Build a `su - <user> -c "<payload>"` argv.
+///
+/// `env` entries are emitted as `export KEY=<quoted-value>` lines before
+/// the body so the spawned shell sees them. `body` is inserted verbatim;
+/// callers must already have shell-quoted arguments inside it.
+#[must_use]
+pub fn su_command(user: &str, env: &BTreeMap<String, String>, body: &str) -> Vec<String> {
+    let mut payload = String::new();
+    for (k, v) in env {
+        let _ = write!(payload, "export {k}={}; ", quote(v));
+    }
+    payload.push_str(body);
+    vec!["su".into(), "-".into(), user.into(), "-c".into(), payload]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn override_wins_when_set() {
+        assert_eq!(resolve_user(Some("alice")), "alice");
+    }
+
+    #[test]
+    fn empty_override_falls_back_to_env_or_default() {
+        // We can't mutate $USERNAME here (workspace forbids unsafe), so
+        // both outcomes — env-set or default — are accepted. The contract
+        // is "non-empty result"; the value depends on whether the test
+        // harness inherited a USERNAME from the parent shell.
+        let r = resolve_user(Some(""));
+        assert!(!r.is_empty());
+    }
+
+    #[test]
+    fn no_override_returns_non_empty_string() {
+        let r = resolve_user(None);
+        assert!(!r.is_empty());
+    }
+
+    #[test]
+    fn su_command_emits_user_and_payload() {
+        let argv = su_command("vscode", &BTreeMap::new(), "echo hi");
+        assert_eq!(argv, vec!["su", "-", "vscode", "-c", "echo hi"]);
+    }
+
+    #[test]
+    fn su_command_exports_env_in_sorted_order() {
+        let mut env = BTreeMap::new();
+        env.insert("CARGO_HOME".to_owned(), "/cache/cargo".to_owned());
+        env.insert("RUSTUP_HOME".to_owned(), "/cache/rustup".to_owned());
+        let argv = su_command("vscode", &env, "rustup-init -y");
+        let payload = &argv[4];
+        // BTreeMap iterates in sorted order — CARGO_HOME comes before RUSTUP_HOME.
+        let cargo_idx = payload.find("CARGO_HOME").unwrap();
+        let rustup_idx = payload.find("RUSTUP_HOME").unwrap();
+        assert!(cargo_idx < rustup_idx);
+        assert!(payload.contains("export CARGO_HOME=/cache/cargo"));
+        assert!(payload.contains("export RUSTUP_HOME=/cache/rustup"));
+        assert!(payload.contains("rustup-init -y"));
+    }
+
+    #[test]
+    fn su_command_quotes_env_values_with_spaces() {
+        let mut env = BTreeMap::new();
+        env.insert("WEIRD".to_owned(), "value with spaces".to_owned());
+        let argv = su_command("vscode", &env, "true");
+        assert!(argv[4].contains("'value with spaces'"));
+    }
+}

--- a/crates/luggage/src/installer/validate.rs
+++ b/crates/luggage/src/installer/validate.rs
@@ -1,0 +1,112 @@
+//! Post-install validation.
+//!
+//! After running an install method + post-install steps, validate the
+//! end-state by invoking `<bin_root>/<tool> --version` and confirming the
+//! output contains the target version. Mirrors the bash feature scripts'
+//! `<tool> --version | grep -q $VERSION` smoke check.
+//!
+//! Same scope/limitation as the idempotency check (issue #404 will
+//! generalise this via catalog `validation_tiers`).
+
+use std::path::Path;
+use std::process::Command;
+
+use crate::error::{LuggageError, Result};
+use crate::installer::idempotency::primary_binary;
+
+/// Confirm that `tool` reports `version` from `<bin_root>/<binary> --version`,
+/// where `binary` is [`primary_binary`] of `tool`.
+///
+/// # Errors
+///
+/// - [`LuggageError::ValidationFailed`] when the binary is missing, the
+///   command fails to launch, the exit status is non-zero, or the output
+///   doesn't mention the target version.
+pub fn check(tool: &str, version: &str, bin_root: &Path) -> Result<()> {
+    let binary = bin_root.join(primary_binary(tool));
+    if !binary.exists() {
+        return Err(LuggageError::ValidationFailed {
+            tool: tool.to_owned(),
+            version: version.to_owned(),
+            message: format!("binary not found at {}", binary.display()),
+        });
+    }
+    let output = Command::new(&binary).arg("--version").output().map_err(|e| {
+        LuggageError::ValidationFailed {
+            tool: tool.to_owned(),
+            version: version.to_owned(),
+            message: format!("failed to launch `{} --version`: {e}", binary.display()),
+        }
+    })?;
+    if !output.status.success() {
+        return Err(LuggageError::ValidationFailed {
+            tool: tool.to_owned(),
+            version: version.to_owned(),
+            message: format!(
+                "`{} --version` exited {}: {}",
+                binary.display(),
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim_end(),
+            ),
+        });
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if stdout.contains(version) || stderr.contains(version) {
+        Ok(())
+    } else {
+        Err(LuggageError::ValidationFailed {
+            tool: tool.to_owned(),
+            version: version.to_owned(),
+            message: format!("expected version `{version}` in output, got: {}", stdout.trim_end()),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt as _;
+
+    use tempfile::tempdir;
+
+    #[cfg(unix)]
+    fn write_shim(dir: &Path, name: &str, line: &str) {
+        let path = dir.join(name);
+        fs::write(&path, format!("#!/bin/sh\necho '{line}'\n")).unwrap();
+        let mut perms = fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&path, perms).unwrap();
+    }
+
+    #[test]
+    fn missing_binary_returns_validation_failed() {
+        let dir = tempdir().unwrap();
+        let err = check("rustc", "1.95.0", dir.path()).unwrap_err();
+        assert!(matches!(err, LuggageError::ValidationFailed { .. }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn matching_output_passes() {
+        let dir = tempdir().unwrap();
+        write_shim(dir.path(), "rustc", "rustc 1.95.0 (abcdef0)");
+        check("rustc", "1.95.0", dir.path()).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn mismatched_output_returns_validation_failed() {
+        let dir = tempdir().unwrap();
+        write_shim(dir.path(), "rustc", "rustc 1.84.0");
+        let err = check("rustc", "1.95.0", dir.path()).unwrap_err();
+        match err {
+            LuggageError::ValidationFailed { message, .. } => {
+                assert!(message.contains("1.95.0"));
+            }
+            other => panic!("expected ValidationFailed, got {other:?}"),
+        }
+    }
+}

--- a/crates/luggage/src/installer/verify/mod.rs
+++ b/crates/luggage/src/installer/verify/mod.rs
@@ -1,0 +1,173 @@
+//! 4-tier verification dispatch.
+//!
+//! Catalog `verification.tier` ranges over `1..=4`:
+//!
+//! - **tier 1** — signatures (GPG / sigstore). Strongest. *Deferred to a
+//!   follow-up issue.*
+//! - **tier 2** — pinned in-repo checksum. *Deferred.*
+//! - **tier 3** — publisher-served checksum file. **Implemented** — this
+//!   is what rust@1.95.0 uses and the only path the pilot needs.
+//! - **tier 4** — TOFU (trust on first use). *Deferred.*
+//!
+//! Any other tier value is a catalog error.
+
+pub mod sha;
+pub mod tier3;
+
+use containers_common::tooldb::Verification;
+
+use crate::error::{LuggageError, Result};
+use crate::installer::download::HttpClient;
+use crate::installer::template::Substitutions;
+
+/// Dispatch verification by tier.
+///
+/// `bytes` is the artifact under test; `tool` and `version` are used in
+/// error messages. `http` is only consumed by tier 3 (and any future tier
+/// that fetches over the network).
+///
+/// # Errors
+///
+/// - [`LuggageError::NotImplemented`] for tiers 1, 2, 4 — these will be
+///   wired up in follow-up issues.
+/// - [`LuggageError::Catalog`] when `verification.tier` is not in `1..=4`.
+/// - The same errors tier 3 raises (see [`tier3::verify`]) for tier 3.
+pub fn dispatch(
+    tool: &str,
+    version: &str,
+    bytes: &[u8],
+    verification: &Verification,
+    subs: &Substitutions<'_>,
+    http: &dyn HttpClient,
+) -> Result<()> {
+    match verification.tier {
+        1 => Err(LuggageError::NotImplemented("tier 1 GPG/sigstore verification")),
+        2 => Err(LuggageError::NotImplemented("tier 2 pinned-checksum verification")),
+        3 => tier3::verify(tool, version, bytes, verification, subs, http),
+        4 => Err(LuggageError::NotImplemented("tier 4 TOFU verification")),
+        other => Err(LuggageError::Catalog(format!("unknown verification tier {other}"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    use containers_common::tooldb::Verification;
+
+    use super::*;
+    use crate::installer::download::HttpClient;
+    use crate::installer::template::Substitutions;
+
+    struct DeadClient;
+    impl HttpClient for DeadClient {
+        fn get(&self, url: &str) -> Result<Vec<u8>> {
+            Err(LuggageError::DownloadFailed {
+                url: url.to_owned(),
+                attempts: 1,
+                message: "dead client".into(),
+            })
+        }
+    }
+
+    fn verification(tier: u8) -> Verification {
+        Verification {
+            tier,
+            algorithm: None,
+            pinned_checksum: None,
+            checksum_url_template: None,
+            gpg_key_url: None,
+            signature_url_template: None,
+            sigstore_identity: None,
+            sigstore_issuer: None,
+            tofu: None,
+        }
+    }
+
+    #[test]
+    fn tier_1_returns_not_implemented() {
+        let err = dispatch(
+            "rust",
+            "1.95.0",
+            b"x",
+            &verification(1),
+            &Substitutions::default(),
+            &DeadClient,
+        )
+        .unwrap_err();
+        assert!(matches!(err, LuggageError::NotImplemented(_)));
+    }
+
+    #[test]
+    fn tier_2_returns_not_implemented() {
+        let err = dispatch(
+            "rust",
+            "1.95.0",
+            b"x",
+            &verification(2),
+            &Substitutions::default(),
+            &DeadClient,
+        )
+        .unwrap_err();
+        assert!(matches!(err, LuggageError::NotImplemented(_)));
+    }
+
+    #[test]
+    fn tier_4_returns_not_implemented() {
+        let err = dispatch(
+            "rust",
+            "1.95.0",
+            b"x",
+            &verification(4),
+            &Substitutions::default(),
+            &DeadClient,
+        )
+        .unwrap_err();
+        assert!(matches!(err, LuggageError::NotImplemented(_)));
+    }
+
+    #[test]
+    fn unknown_tier_returns_catalog_error() {
+        let err = dispatch(
+            "rust",
+            "1.95.0",
+            b"x",
+            &verification(9),
+            &Substitutions::default(),
+            &DeadClient,
+        )
+        .unwrap_err();
+        assert!(matches!(err, LuggageError::Catalog(_)));
+    }
+
+    /// Through-the-front-door check that tier 3 actually executes when
+    /// dispatched (the deeper tier-3 cases live in `tier3::tests`).
+    #[test]
+    fn tier_3_executes_via_dispatch() {
+        struct OkClient;
+        impl HttpClient for OkClient {
+            fn get(&self, _url: &str) -> Result<Vec<u8>> {
+                let digest = super::sha::digest_hex(Some("sha256"), b"hello").unwrap();
+                Ok(format!("{digest}  rustup-init\n").into_bytes())
+            }
+        }
+        let v = Verification {
+            tier: 3,
+            algorithm: Some("sha256".into()),
+            pinned_checksum: None,
+            checksum_url_template: Some("https://example.test/{rustup_target}/x.sha256".into()),
+            gpg_key_url: None,
+            signature_url_template: None,
+            sigstore_identity: None,
+            sigstore_issuer: None,
+            tofu: None,
+        };
+        let subs = Substitutions::new("1.95.0", "x86_64-unknown-linux-gnu");
+        dispatch("rust", "1.95.0", b"hello", &v, &subs, &OkClient).unwrap();
+        // Suppress unused-warning for `Mutex`/`HashMap` imports above (kept
+        // to mirror the tier3 test fixture style).
+        let _: HashMap<&str, &str> = HashMap::new();
+        let _: Mutex<()> = Mutex::new(());
+    }
+}

--- a/crates/luggage/src/installer/verify/sha.rs
+++ b/crates/luggage/src/installer/verify/sha.rs
@@ -1,0 +1,129 @@
+//! Hash digest helpers used by tier 2 / tier 3 verification.
+//!
+//! The catalog declares the algorithm name (`sha256` / `sha512`) as a free
+//! string in `Verification.algorithm`; this module is the single place
+//! where that string is decoded into a digest computation. Adding a new
+//! algorithm is a one-line change here.
+//!
+//! Output is lowercase hex with no separator — the format publishers use in
+//! `*.sha256` / `*.sha512` files.
+
+use sha2::{Digest as _, Sha256, Sha512};
+
+use crate::error::{LuggageError, Result};
+
+/// Default algorithm when [`containers_common::tooldb::Verification::algorithm`]
+/// is `None`. Matches the publishers' historical default.
+pub const DEFAULT_ALGORITHM: &str = "sha256";
+
+/// Compute a hex digest over `bytes` using the named algorithm.
+///
+/// `algorithm` is matched case-insensitively. Pass `None` to use
+/// [`DEFAULT_ALGORITHM`].
+///
+/// # Errors
+///
+/// - [`LuggageError::NotImplemented`] when the algorithm is recognized as a
+///   valid SHA-family name we haven't wired up yet.
+/// - [`LuggageError::Catalog`] when the algorithm is unrecognized.
+pub fn digest_hex(algorithm: Option<&str>, bytes: &[u8]) -> Result<String> {
+    let algo = algorithm.unwrap_or(DEFAULT_ALGORITHM).to_ascii_lowercase();
+    match algo.as_str() {
+        "sha256" => Ok(hex_lower(&Sha256::digest(bytes))),
+        "sha512" => Ok(hex_lower(&Sha512::digest(bytes))),
+        // Likely-correct future hash-family names get a clear NotImplemented
+        // so a catalog upgrade fails fast without falling through to a
+        // generic Catalog error.
+        "sha384" | "sha224" | "blake3" => {
+            Err(LuggageError::NotImplemented("digest algorithm not wired (only sha256/sha512)"))
+        }
+        _ => Err(LuggageError::Catalog(format!("unrecognised digest algorithm `{algo}`"))),
+    }
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        use std::fmt::Write as _;
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+/// Constant-time-ish comparison of two hex digest strings.
+///
+/// Both inputs are folded to lowercase before comparison. Returns `true`
+/// only when the strings have equal length and equal contents.
+#[must_use]
+pub fn digests_equal(a: &str, b: &str) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.bytes().zip(b.bytes()) {
+        diff |= x.to_ascii_lowercase() ^ y.to_ascii_lowercase();
+    }
+    diff == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // RFC 6234 / NIST test vectors for "abc".
+    const ABC_SHA256: &str = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+    const ABC_SHA512: &str = "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f";
+
+    #[test]
+    fn sha256_of_abc_matches_test_vector() {
+        let hex = digest_hex(Some("sha256"), b"abc").unwrap();
+        assert_eq!(hex, ABC_SHA256);
+    }
+
+    #[test]
+    fn sha512_of_abc_matches_test_vector() {
+        let hex = digest_hex(Some("sha512"), b"abc").unwrap();
+        assert_eq!(hex, ABC_SHA512);
+    }
+
+    #[test]
+    fn default_algorithm_is_sha256() {
+        let hex = digest_hex(None, b"abc").unwrap();
+        assert_eq!(hex, ABC_SHA256);
+    }
+
+    #[test]
+    fn algorithm_match_is_case_insensitive() {
+        let hex = digest_hex(Some("SHA256"), b"abc").unwrap();
+        assert_eq!(hex, ABC_SHA256);
+    }
+
+    #[test]
+    fn unsupported_sha_family_returns_not_implemented() {
+        let err = digest_hex(Some("sha384"), b"abc").unwrap_err();
+        assert!(matches!(err, LuggageError::NotImplemented(_)));
+    }
+
+    #[test]
+    fn unrecognised_algorithm_returns_catalog_error() {
+        let err = digest_hex(Some("md5"), b"abc").unwrap_err();
+        assert!(matches!(err, LuggageError::Catalog(_)));
+    }
+
+    #[test]
+    fn digests_equal_handles_case_difference() {
+        assert!(digests_equal(ABC_SHA256, &ABC_SHA256.to_ascii_uppercase()));
+    }
+
+    #[test]
+    fn digests_equal_rejects_different_lengths() {
+        assert!(!digests_equal("aa", "aaaa"));
+    }
+
+    #[test]
+    fn digests_equal_rejects_one_bit_difference() {
+        let mut wrong = ABC_SHA256.to_owned();
+        wrong.replace_range(0..1, "c"); // flip first nybble
+        assert!(!digests_equal(ABC_SHA256, &wrong));
+    }
+}

--- a/crates/luggage/src/installer/verify/tier3.rs
+++ b/crates/luggage/src/installer/verify/tier3.rs
@@ -208,7 +208,7 @@ mod tests {
     }
 
     #[test]
-    fn unparseable_response_returns_verification_failed() {
+    fn unparsable_response_returns_verification_failed() {
         let url = "https://example.test/x86_64-unknown-linux-gnu/rustup-init.sha256";
         let stub = StubClient::with(url, b"not a hex digest at all\n");
         let v = verification("https://example.test/{rustup_target}/rustup-init.sha256");

--- a/crates/luggage/src/installer/verify/tier3.rs
+++ b/crates/luggage/src/installer/verify/tier3.rs
@@ -1,0 +1,245 @@
+//! Tier 3 — published-checksum verification.
+//!
+//! The catalog points at a checksum file the publisher hosts (e.g.
+//! `https://static.rust-lang.org/rustup/dist/{rustup_target}/rustup-init.sha256`).
+//! Tier 3 fetches that file, parses out the expected digest, computes the
+//! same digest over the downloaded artifact, and compares.
+//!
+//! This is "trust the publisher's TLS endpoint" — weaker than tier 1
+//! (signatures) and tier 2 (pinned in-repo checksum) but stronger than
+//! tier 4 (TOFU). It is what rust@1.95.0 uses.
+
+use containers_common::tooldb::Verification;
+
+use super::sha::{digest_hex, digests_equal};
+use crate::error::{LuggageError, Result};
+use crate::installer::download::HttpClient;
+use crate::installer::template::{Substitutions, substitute_url};
+
+/// Verify `bytes` against the publisher-served checksum URL in `verification`.
+///
+/// `subs` is used to substitute placeholders (e.g. `{rustup_target}`) into
+/// the checksum URL template before fetching. `tool` and `version` are
+/// only used for error message context.
+///
+/// # Errors
+///
+/// - [`LuggageError::Catalog`] when `verification.checksum_url_template` is
+///   missing — required for tier 3.
+/// - [`LuggageError::TemplateMissingKey`] when the checksum URL template
+///   references an unknown placeholder.
+/// - [`LuggageError::DownloadFailed`] when the checksum file cannot be
+///   fetched.
+/// - [`LuggageError::VerificationFailed`] when the expected digest cannot
+///   be parsed out of the response or does not match the bytes' digest.
+pub fn verify(
+    tool: &str,
+    version: &str,
+    bytes: &[u8],
+    verification: &Verification,
+    subs: &Substitutions<'_>,
+    http: &dyn HttpClient,
+) -> Result<()> {
+    let template = verification.checksum_url_template.as_deref().ok_or_else(|| {
+        LuggageError::Catalog(
+            "tier 3 verification requires `checksum_url_template` in catalog".to_owned(),
+        )
+    })?;
+    let url = substitute_url(template, subs)?;
+
+    let body = http.get(&url)?;
+    let body_str = std::str::from_utf8(&body).map_err(|_| LuggageError::VerificationFailed {
+        tool: tool.to_owned(),
+        version: version.to_owned(),
+        tier: 3,
+        reason: format!("checksum file at {url} is not valid UTF-8"),
+    })?;
+
+    let expected =
+        parse_checksum_field(body_str).ok_or_else(|| LuggageError::VerificationFailed {
+            tool: tool.to_owned(),
+            version: version.to_owned(),
+            tier: 3,
+            reason: format!("could not parse a digest out of {url}"),
+        })?;
+
+    let actual = digest_hex(verification.algorithm.as_deref(), bytes)?;
+
+    if digests_equal(&actual, expected) {
+        Ok(())
+    } else {
+        Err(LuggageError::VerificationFailed {
+            tool: tool.to_owned(),
+            version: version.to_owned(),
+            tier: 3,
+            reason: format!("digest mismatch: expected {expected}, computed {actual}"),
+        })
+    }
+}
+
+/// Pull the digest token out of a publisher-style checksum response.
+///
+/// Accepts the two common shapes:
+///
+/// - `<hex>` (digest only, optional trailing newline)
+/// - `<hex>  <filename>` (sha256sum/coreutils format)
+fn parse_checksum_field(body: &str) -> Option<&str> {
+    let line = body.lines().next()?.trim();
+    let token = line.split_whitespace().next()?;
+    if token.is_empty() {
+        return None;
+    }
+    if !token.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    Some(token)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    use containers_common::tooldb::Verification;
+
+    use crate::installer::download::HttpClient;
+    use crate::installer::template::Substitutions;
+    use crate::installer::verify::sha::digest_hex;
+
+    /// Deterministic in-memory HTTP stub.
+    struct StubClient {
+        responses: Mutex<HashMap<String, Vec<u8>>>,
+    }
+
+    impl StubClient {
+        fn with(url: &str, body: &[u8]) -> Self {
+            let mut m = HashMap::new();
+            m.insert(url.to_owned(), body.to_vec());
+            Self { responses: Mutex::new(m) }
+        }
+    }
+
+    impl HttpClient for StubClient {
+        fn get(&self, url: &str) -> Result<Vec<u8>> {
+            self.responses.lock().unwrap().get(url).cloned().ok_or_else(|| {
+                LuggageError::DownloadFailed {
+                    url: url.to_owned(),
+                    attempts: 1,
+                    message: "stub: no response wired".into(),
+                }
+            })
+        }
+    }
+
+    fn verification(template: &str) -> Verification {
+        Verification {
+            tier: 3,
+            algorithm: Some("sha256".into()),
+            pinned_checksum: None,
+            checksum_url_template: Some(template.into()),
+            gpg_key_url: None,
+            signature_url_template: None,
+            sigstore_identity: None,
+            sigstore_issuer: None,
+            tofu: None,
+        }
+    }
+
+    #[test]
+    fn matching_digest_passes() {
+        let bytes = b"hello rustup-init body";
+        let digest = digest_hex(Some("sha256"), bytes).unwrap();
+        let url = "https://example.test/x86_64-unknown-linux-gnu/rustup-init.sha256";
+        let stub = StubClient::with(url, format!("{digest}  rustup-init\n").as_bytes());
+        let v = verification("https://example.test/{rustup_target}/rustup-init.sha256");
+        let subs = Substitutions::new("1.95.0", "x86_64-unknown-linux-gnu");
+        verify("rust", "1.95.0", bytes, &v, &subs, &stub).unwrap();
+    }
+
+    #[test]
+    fn digest_only_response_is_accepted() {
+        let bytes = b"x";
+        let digest = digest_hex(Some("sha256"), bytes).unwrap();
+        let url = "https://example.test/x86_64-unknown-linux-gnu/rustup-init.sha256";
+        let stub = StubClient::with(url, digest.as_bytes());
+        let v = verification("https://example.test/{rustup_target}/rustup-init.sha256");
+        let subs = Substitutions::new("1.95.0", "x86_64-unknown-linux-gnu");
+        verify("rust", "1.95.0", bytes, &v, &subs, &stub).unwrap();
+    }
+
+    #[test]
+    fn mismatched_digest_returns_verification_failed() {
+        let url = "https://example.test/x86_64-unknown-linux-gnu/rustup-init.sha256";
+        let bogus = "0".repeat(64);
+        let stub = StubClient::with(url, format!("{bogus}  rustup-init\n").as_bytes());
+        let v = verification("https://example.test/{rustup_target}/rustup-init.sha256");
+        let subs = Substitutions::new("1.95.0", "x86_64-unknown-linux-gnu");
+        let err = verify("rust", "1.95.0", b"different bytes", &v, &subs, &stub).unwrap_err();
+        match err {
+            LuggageError::VerificationFailed { tier, tool, version, reason } => {
+                assert_eq!(tier, 3);
+                assert_eq!(tool, "rust");
+                assert_eq!(version, "1.95.0");
+                assert!(reason.contains("digest mismatch"));
+            }
+            other => panic!("expected VerificationFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_template_is_catalog_error() {
+        let v = Verification {
+            tier: 3,
+            algorithm: Some("sha256".into()),
+            pinned_checksum: None,
+            checksum_url_template: None,
+            gpg_key_url: None,
+            signature_url_template: None,
+            sigstore_identity: None,
+            sigstore_issuer: None,
+            tofu: None,
+        };
+        let stub = StubClient::with("ignored", b"");
+        let subs = Substitutions::default();
+        let err = verify("rust", "1.95.0", b"x", &v, &subs, &stub).unwrap_err();
+        assert!(matches!(err, LuggageError::Catalog(_)));
+    }
+
+    #[test]
+    fn unparseable_response_returns_verification_failed() {
+        let url = "https://example.test/x86_64-unknown-linux-gnu/rustup-init.sha256";
+        let stub = StubClient::with(url, b"not a hex digest at all\n");
+        let v = verification("https://example.test/{rustup_target}/rustup-init.sha256");
+        let subs = Substitutions::new("1.95.0", "x86_64-unknown-linux-gnu");
+        let err = verify("rust", "1.95.0", b"x", &v, &subs, &stub).unwrap_err();
+        match err {
+            LuggageError::VerificationFailed { tier: 3, reason, .. } => {
+                assert!(reason.contains("could not parse"));
+            }
+            other => panic!("expected VerificationFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_checksum_field_handles_digest_with_filename() {
+        let token = parse_checksum_field("abcdef0123  rustup-init\n").unwrap();
+        assert_eq!(token, "abcdef0123");
+    }
+
+    #[test]
+    fn parse_checksum_field_handles_bare_digest() {
+        assert_eq!(parse_checksum_field("abcdef0123\n").unwrap(), "abcdef0123");
+    }
+
+    #[test]
+    fn parse_checksum_field_rejects_non_hex() {
+        assert!(parse_checksum_field("garbage line\n").is_none());
+    }
+
+    #[test]
+    fn parse_checksum_field_rejects_empty() {
+        assert!(parse_checksum_field("").is_none());
+    }
+}

--- a/crates/luggage/src/lib.rs
+++ b/crates/luggage/src/lib.rs
@@ -27,12 +27,14 @@
 
 pub mod catalog;
 pub mod error;
+pub mod installer;
 pub mod platform;
 pub mod policy;
 pub mod resolver;
 
 pub use catalog::{Catalog, CatalogSource};
 pub use error::{LuggageError, Result};
+pub use installer::{InstallPlan, InstallReport, Installer, InstallerOptions};
 pub use platform::Platform;
 pub use policy::{PolicyPreset, ResolutionPolicy};
 pub use resolver::{ResolutionWarning, ResolvedInstall, VersionSpec};

--- a/crates/luggage/tests/install_rust.rs
+++ b/crates/luggage/tests/install_rust.rs
@@ -18,6 +18,11 @@
 //! - Symlinks for the rust binary set land in `bin_root`.
 //! - `--dry-run` performs no HTTP and no command execution.
 //! - A bytes-vs-checksum mismatch produces a tier-3 `VerificationFailed`.
+//!
+//! Unix-only: the install method itself is unix-only (catalog marks rust
+//! on Windows as `unsupported`), so the integration test follows.
+
+#![cfg(unix)]
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;

--- a/crates/luggage/tests/install_rust.rs
+++ b/crates/luggage/tests/install_rust.rs
@@ -1,0 +1,266 @@
+//! Hermetic end-to-end test for `luggage install rust@1.95.0`.
+//!
+//! Drives the installer with a stubbed HTTP client and a recording command
+//! runner, so we exercise the full pipeline (resolve → plan → download →
+//! verify → install method → post-install) without touching the network or
+//! the host package manager / filesystem.
+//!
+//! Invariants we lock in:
+//!
+//! - Source URL gets `{rustup_target}` substituted from the resolved
+//!   platform.
+//! - Tier 3 verification fetches the checksum URL via `HttpClient` and
+//!   matches it against the artifact's sha256.
+//! - The install method runs as `su - <user> -c "..."` with `CARGO_HOME` /
+//!   `RUSTUP_HOME` exported and the catalog's invoke args.
+//! - All four `post_install` `ComponentAdd` steps run as `rustup component
+//!   add <name>` under the same `su -` plumbing.
+//! - Symlinks for the rust binary set land in `bin_root`.
+//! - `--dry-run` performs no HTTP and no command execution.
+//! - A bytes-vs-checksum mismatch produces a tier-3 `VerificationFailed`.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use luggage::installer::download::{HttpClient, MockHttpClient};
+use luggage::installer::methods::RecordingRunner;
+use luggage::installer::methods::script_installer::RUST_BINARIES;
+use luggage::installer::verify::sha::digest_hex;
+use luggage::{
+    Catalog, CatalogSource, Installer, InstallerOptions, LuggageError, Platform, VersionSpec,
+};
+use sha2::{Digest as _, Sha256};
+use tempfile::TempDir;
+
+const RUSTUP_INIT_BODY: &[u8] = b"#!/bin/sh\necho stub rustup-init\nexit 0\n";
+const SOURCE_URL: &str =
+    "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init";
+const CHECKSUM_URL: &str =
+    "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init.sha256";
+
+fn testdata_catalog() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("testdata").join("catalog")
+}
+
+fn debian_amd64() -> Platform {
+    Platform { os: "debian".into(), os_version: Some("13".into()), arch: "amd64".into() }
+}
+
+/// Build a `MockHttpClient` wired with the rustup-init body and a
+/// matching tier-3 checksum file. `body_override` lets a single test inject
+/// a corruption while keeping every other URL stub identical.
+fn mock_with(body_override: Option<&[u8]>) -> MockHttpClient {
+    let body = body_override.unwrap_or(RUSTUP_INIT_BODY);
+    let digest = digest_hex(Some("sha256"), RUSTUP_INIT_BODY).unwrap();
+    let checksum = format!("{digest}  rustup-init\n");
+    let mock = MockHttpClient::new();
+    mock.insert(SOURCE_URL, body.to_vec());
+    mock.insert(CHECKSUM_URL, checksum.into_bytes());
+    mock
+}
+
+/// Hermetic [`InstallerOptions`] — every path lives under `roots`, no
+/// system packages, no host writes. Returned alongside the `TempDir` so
+/// callers can keep it alive for the duration of the test.
+fn options_in(roots: &TempDir) -> InstallerOptions {
+    InstallerOptions {
+        dry_run: false,
+        force: false,
+        log_dir: roots.path().join("log"),
+        bin_root: roots.path().join("bin"),
+        cache_root: roots.path().join("cache"),
+        tmp_root: roots.path().join("tmp"),
+        user_override: Some("vscode".to_owned()),
+        install_system_packages: false,
+    }
+}
+
+/// Resolve `rust@1.95.0` for debian/amd64 against the in-tree testdata
+/// catalog. Centralised so every test exercises the same plan.
+fn resolve_rust() -> luggage::ResolvedInstall {
+    let catalog = Catalog::load(CatalogSource::LocalPath(testdata_catalog())).unwrap();
+    catalog
+        .resolve("rust", &VersionSpec::Exact("1.95.0".into()), &debian_amd64())
+        .expect("resolve rust@1.95.0")
+}
+
+#[test]
+fn install_rust_runs_full_pipeline() {
+    let roots = TempDir::new().unwrap();
+    let resolved = resolve_rust();
+    let mock = Arc::new(mock_with(None));
+    let runner = Arc::new(RecordingRunner::new());
+
+    // Populate cache/cargo/bin with shims so the symlink stage has real
+    // targets and so the post-install validation step (which runs
+    // `<bin>/rustc --version` after symlinks land) sees the right version.
+    let cargo_bin = roots.path().join("cache").join("cargo").join("bin");
+    std::fs::create_dir_all(&cargo_bin).unwrap();
+    write_version_shim(&cargo_bin.join("rustc"), "rustc 1.95.0 (stub)");
+    for name in RUST_BINARIES {
+        if *name != "rustc" {
+            std::fs::write(cargo_bin.join(name), b"#!/bin/sh\necho stub\n").unwrap();
+        }
+    }
+
+    let installer = Installer::with_runners(
+        options_in(&roots),
+        mock as Arc<dyn HttpClient>,
+        runner.clone() as Arc<dyn luggage::installer::methods::CommandRunner>,
+    );
+    let report = installer.run(&resolved).expect("install should succeed");
+
+    assert!(!report.already_installed, "first install should not skip");
+    assert_eq!(report.tool, "rust");
+    assert_eq!(report.version, "1.95.0");
+
+    // The rustup-init invocation goes through `su` with the catalog's args.
+    let calls = runner.calls();
+    let su_calls: Vec<_> = calls.iter().filter(|(p, _)| p == "su").collect();
+    assert!(
+        su_calls.len() >= 5,
+        "expected ≥5 su calls (1 install + 4 component_add), got {}",
+        su_calls.len(),
+    );
+    let install_payload = &su_calls[0].1[3];
+    assert!(install_payload.contains("CARGO_HOME"));
+    assert!(install_payload.contains("RUSTUP_HOME"));
+    assert!(install_payload.contains("--default-toolchain"));
+    assert!(install_payload.contains("1.95.0"));
+    assert!(install_payload.contains("--profile"));
+
+    // Each ComponentAdd post-install step lands as `rustup component add <name>`.
+    for component in ["rust-src", "rust-analyzer", "clippy", "rustfmt"] {
+        let needle = format!("rustup component add {component}");
+        assert!(
+            calls.iter().any(|(p, args)| p == "su" && args[3].contains(&needle)),
+            "expected a su call running `{needle}`",
+        );
+    }
+}
+
+#[test]
+fn dry_run_performs_no_http_or_command_io() {
+    let roots = TempDir::new().unwrap();
+    let resolved = resolve_rust();
+    // Empty mock — any HTTP attempt would fail with DownloadFailed.
+    let mock = Arc::new(MockHttpClient::new());
+    let runner = Arc::new(RecordingRunner::new());
+
+    let mut opts = options_in(&roots);
+    opts.dry_run = true;
+    let installer = Installer::with_runners(
+        opts,
+        mock as Arc<dyn HttpClient>,
+        runner.clone() as Arc<dyn luggage::installer::methods::CommandRunner>,
+    );
+
+    installer.run(&resolved).expect("dry-run should succeed");
+    assert!(runner.calls().is_empty(), "dry-run should not invoke any commands");
+}
+
+#[test]
+fn corrupt_artifact_returns_tier_3_verification_failed() {
+    let roots = TempDir::new().unwrap();
+    let resolved = resolve_rust();
+    // The mock serves a tampered body but the checksum URL still points at
+    // the original digest — exactly the failure mode tier 3 detects.
+    let mock = Arc::new(mock_with(Some(b"this is not rustup-init")));
+    let runner = Arc::new(RecordingRunner::new());
+
+    let installer = Installer::with_runners(
+        options_in(&roots),
+        mock as Arc<dyn HttpClient>,
+        runner as Arc<dyn luggage::installer::methods::CommandRunner>,
+    );
+
+    let err = installer.run(&resolved).expect_err("verification should fail");
+    match err {
+        LuggageError::VerificationFailed { tier, tool, version, reason } => {
+            assert_eq!(tier, 3);
+            assert_eq!(tool, "rust");
+            assert_eq!(version, "1.95.0");
+            assert!(reason.contains("digest mismatch"), "reason was: {reason}");
+        }
+        other => panic!("expected VerificationFailed, got {other:?}"),
+    }
+}
+
+#[test]
+fn idempotent_skip_when_rustc_already_at_target_version() {
+    let roots = TempDir::new().unwrap();
+    let resolved = resolve_rust();
+    let mock = Arc::new(MockHttpClient::new());
+    let runner = Arc::new(RecordingRunner::new());
+
+    let bin_root = roots.path().join("bin");
+    std::fs::create_dir_all(&bin_root).unwrap();
+    write_version_shim(&bin_root.join("rustc"), "rustc 1.95.0 (preinstalled)");
+
+    let installer = Installer::with_runners(
+        options_in(&roots),
+        mock as Arc<dyn HttpClient>,
+        runner.clone() as Arc<dyn luggage::installer::methods::CommandRunner>,
+    );
+    let report = installer.run(&resolved).expect("idempotency check should pass");
+    assert!(report.already_installed, "should report already_installed");
+    assert!(runner.calls().is_empty(), "no commands should run on the idempotent path");
+}
+
+#[test]
+fn force_reruns_install_even_when_idempotent_check_matches() {
+    let roots = TempDir::new().unwrap();
+    let resolved = resolve_rust();
+    let mock = Arc::new(mock_with(None));
+    let runner = Arc::new(RecordingRunner::new());
+
+    let bin_root = roots.path().join("bin");
+    std::fs::create_dir_all(&bin_root).unwrap();
+    write_version_shim(&bin_root.join("rustc"), "rustc 1.95.0 (preinstalled)");
+
+    // Populate cargo bin with shims so the symlink stage has real targets.
+    // The bin_root rustc above will be replaced by a symlink to this shim
+    // by the install method's symlink stage; we keep the same version line
+    // so post-install validation still passes.
+    let cargo_bin = roots.path().join("cache").join("cargo").join("bin");
+    std::fs::create_dir_all(&cargo_bin).unwrap();
+    write_version_shim(&cargo_bin.join("rustc"), "rustc 1.95.0 (rebuilt)");
+    for name in RUST_BINARIES {
+        if *name != "rustc" {
+            std::fs::write(cargo_bin.join(name), b"#!/bin/sh\necho stub\n").unwrap();
+        }
+    }
+
+    let mut opts = options_in(&roots);
+    opts.force = true;
+    let installer = Installer::with_runners(
+        opts,
+        mock as Arc<dyn HttpClient>,
+        runner.clone() as Arc<dyn luggage::installer::methods::CommandRunner>,
+    );
+    let report = installer.run(&resolved).expect("force install should succeed");
+    assert!(!report.already_installed);
+    assert!(!runner.calls().is_empty(), "force should invoke commands");
+}
+
+#[test]
+fn computed_digest_matches_published_checksum_format() {
+    // Belt-and-suspenders: confirm the mock server's checksum file matches
+    // what the installer would compute. A test that fails here would expose
+    // a subtle bug in either `digest_hex` or the test fixture itself.
+    let mut hasher = Sha256::new();
+    hasher.update(RUSTUP_INIT_BODY);
+    let direct = format!("{:x}", hasher.finalize());
+    let via_helper = digest_hex(Some("sha256"), RUSTUP_INIT_BODY).unwrap();
+    assert_eq!(direct, via_helper);
+}
+
+/// Write an executable shim at `path` that prints `line` to stdout.
+fn write_version_shim(path: &Path, line: &str) {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt as _;
+    fs::write(path, format!("#!/bin/sh\necho '{line}'\n")).unwrap();
+    let mut perms = fs::metadata(path).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).unwrap();
+}

--- a/deny.toml
+++ b/deny.toml
@@ -37,6 +37,8 @@ confidence-threshold = 0.8
 exceptions = [
   # Mozilla root CA bundle pulled in via rustls-platform-verifier.
   { allow = ["CDLA-Permissive-2.0"], crate = "webpki-root-certs" },
+  # Mozilla root CA bundle pulled in via ureq's TLS feature (luggage HTTP).
+  { allow = ["CDLA-Permissive-2.0"], crate = "webpki-roots" },
 ]
 
 [bans]

--- a/tests/integration/builds/luggage_rust/Dockerfile.luggage-rust
+++ b/tests/integration/builds/luggage_rust/Dockerfile.luggage-rust
@@ -1,0 +1,64 @@
+# syntax=docker/dockerfile:1.7
+# Minimal fixture for the luggage parity test (issue #405).
+#
+# Builds luggage from the in-tree workspace, then runs
+# `luggage install rust@<RUST_VERSION>` against the in-tree testdata
+# catalog. The end-state should match what `lib/features/rust.sh`
+# produces; the parity test driver runs identical assertions against
+# both images.
+#
+# Build context is the repo root (`BUILD_CONTEXT=$CONTAINERS_DIR`), so
+# every COPY here is repo-root-relative.
+
+ARG RUST_VERSION=1.95.0
+
+# ─── Stage 1: compile the luggage binary ───
+FROM rust:1.95-slim-trixie AS builder
+
+WORKDIR /workspace
+COPY Cargo.toml Cargo.lock ./
+COPY crates ./crates
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/workspace/target \
+    cargo build --release -p luggage --bin luggage \
+    && cp target/release/luggage /tmp/luggage
+
+# ─── Stage 2: install rust via luggage on a fresh debian ───
+FROM debian:trixie-slim AS runtime
+
+ARG RUST_VERSION
+
+# luggage shells out to `su` and `apt-get`; the slim image has the
+# former but needs adduser to create the install user.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends adduser ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Match the production user setup.
+RUN adduser --disabled-password --gecos '' --shell /bin/bash vscode \
+    && mkdir -p /cache /var/log/luggage \
+    && chown -R vscode:vscode /cache /var/log/luggage
+ENV USERNAME=vscode
+
+# Bring the luggage binary and the testdata catalog into the image.
+COPY --from=builder /tmp/luggage /usr/local/bin/luggage
+COPY crates/luggage/testdata/catalog /opt/containers-db
+
+# Run the install. `--catalog` points at the in-tree testdata catalog —
+# the same one the resolver tests use — so this build is reproducible
+# from a single Cargo.lock without depending on the live containers-db
+# repo.
+RUN /usr/local/bin/luggage install "rust@${RUST_VERSION}" \
+    --catalog /opt/containers-db \
+    --os debian --os-version 13 --arch amd64 \
+    --user vscode
+
+# Sanity touchstone for the parity test driver.
+ENV CARGO_HOME=/cache/cargo \
+    RUSTUP_HOME=/cache/rustup \
+    PATH="/cache/cargo/bin:/usr/local/bin:${PATH}"
+
+USER vscode
+WORKDIR /home/vscode
+CMD ["bash"]

--- a/tests/integration/builds/test_luggage_rust.sh
+++ b/tests/integration/builds/test_luggage_rust.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Parity test: `luggage install rust@1.95.0` vs `lib/features/rust.sh`.
+#
+# Issue #405 — verifies the new Rust executor produces the same observable
+# end-state (rustc/cargo/rustup on PATH, matching version, CARGO_HOME and
+# RUSTUP_HOME pinned to /cache) as the bash feature script. Closes the
+# acceptance criterion: "integration test compares luggage-installed vs
+# bash-installed rust toolchain".
+#
+# Strategy:
+#  - Image A is built via the main `Dockerfile` with INCLUDE_RUST=true.
+#    This is the same path lefthook & CI exercise; it proves the bash
+#    feature script's end-state without us re-creating `lib/base/*`.
+#  - Image B is built via a minimal fixture Dockerfile next to this test.
+#    It compiles luggage from source, then runs `luggage install rust@1.95.0`.
+#  - The same assertion suite runs against both images. Any drift fails.
+#
+# Both builds touch the network (rustup-init download). Run via:
+#   just test-integration-one luggage_rust
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../framework.sh
+source "$SCRIPT_DIR/../../framework.sh"
+
+init_test_framework
+
+CONTAINERS_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+export BUILD_CONTEXT="$CONTAINERS_DIR"
+
+LUGGAGE_FIXTURE="$SCRIPT_DIR/luggage_rust/Dockerfile.luggage-rust"
+RUST_VERSION="1.95.0"
+
+test_suite "luggage install rust@${RUST_VERSION} parity"
+
+LUGGAGE_IMAGE="test-luggage-rust-$$"
+BASH_IMAGE="test-bash-rust-$$"
+
+# Build image A — production Dockerfile with INCLUDE_RUST=true.
+build_bash_image() {
+    if [ -n "${IMAGE_TO_TEST:-}" ]; then
+        BASH_IMAGE="$IMAGE_TO_TEST"
+        return 0
+    fi
+    assert_build_succeeds "Dockerfile" \
+        --build-arg PROJECT_PATH=. \
+        --build-arg PROJECT_NAME=parity-bash \
+        --build-arg INCLUDE_RUST=true \
+        --build-arg RUST_VERSION="$RUST_VERSION" \
+        -t "$BASH_IMAGE"
+}
+
+# Build image B — minimal fixture that runs `luggage install`.
+build_luggage_image() {
+    if [ -n "${IMAGE_TO_TEST:-}" ]; then
+        LUGGAGE_IMAGE="$IMAGE_TO_TEST"
+        return 0
+    fi
+    assert_build_succeeds "$LUGGAGE_FIXTURE" \
+        --build-arg RUST_VERSION="$RUST_VERSION" \
+        -t "$LUGGAGE_IMAGE"
+}
+
+# Same assertion bundle runs against both images. Any drift surfaces here.
+assert_rust_endstate() {
+    local image="$1"
+    assert_executable_in_path "$image" "rustc"
+    assert_executable_in_path "$image" "cargo"
+    assert_executable_in_path "$image" "rustup"
+    assert_command_in_container "$image" "rustc --version" "$RUST_VERSION"
+    assert_command_in_container "$image" "cargo --version" "cargo"
+    # CARGO_HOME / RUSTUP_HOME pinned to /cache in both paths.
+    assert_command_in_container "$image" \
+        'rustup show home 2>/dev/null || echo "${RUSTUP_HOME:-not-set}"' "/cache/rustup"
+}
+
+test_bash_path_endstate() {
+    build_bash_image
+    assert_rust_endstate "$BASH_IMAGE"
+}
+
+test_luggage_path_endstate() {
+    build_luggage_image
+    assert_rust_endstate "$LUGGAGE_IMAGE"
+}
+
+# Compare the X.Y.Z version literal across both images. Catalog and
+# RUST_VERSION build-arg both pin "1.95.0"; if either path drifts, the
+# diff shows up here rather than in a downstream consumer.
+test_versions_match() {
+    local bash_v luggage_v
+    bash_v=$(docker run --rm "$BASH_IMAGE" rustc --version 2>/dev/null | command awk '{print $2}')
+    luggage_v=$(docker run --rm "$LUGGAGE_IMAGE" rustc --version 2>/dev/null | command awk '{print $2}')
+    if [ "$bash_v" = "$luggage_v" ]; then
+        return 0
+    fi
+    tf_fail_assertion "rustc versions should match across installers" \
+        "bash:    $bash_v" \
+        "luggage: $luggage_v"
+}
+
+run_test test_bash_path_endstate "lib/features/rust.sh produces a working rust toolchain"
+run_test test_luggage_path_endstate "luggage install produces a working rust toolchain"
+run_test test_versions_match "rustc version matches across both installers"
+
+generate_report


### PR DESCRIPTION
## Summary

Pilot-scope implementation of `luggage install <tool>[@<version>]` — the executor side of the v5 build engine. Mirrors `lib/features/rust.sh` for `rust@1.95.0` via the rustup-init script-installer method, gated behind the existing 4-tier verification model (tier 3 implemented; 1/2/4 deferred).

`Installer::run` (in `crates/luggage/src/installer/mod.rs`) runs seven stages, each in its own private method:

1. **idempotency** — skip when `<bin>/<binary> --version` already matches
2. **syspackages** — apt/apk/dnf dispatch for catalog `Dependency` entries
3. **download** — `ureq`-backed `HttpClient` (trait-wrapped for tests)
4. **verify** — tier 3 published-checksum (1/2/4 return `NotImplemented`)
5. **method** — rustup-init / rustup-init-musl shape
6. **post-install** — `ComponentAdd` / `Command` (`CargoInstall` deferred)
7. **validate** — re-invoke `<bin>/<binary> --version`

CLI: `luggage install <tool>[@<version>]` with `--dry-run`, `--force`, `--bin-root`, `--cache-root`, `--log-dir`, `--user`, `--skip-system-packages`. Shared `CommonArgs` flatten between `resolve` and `install` so flag semantics stay in lockstep.

## Test plan

- [x] `just test SCOPE=luggage` — 144 unit + 6 hermetic integration + 11 CLI + 8 policy tests pass
- [x] `just lint` — every hook green (clippy, hadolint, shellcheck, conform, taplo, gitleaks, …)
- [x] `just test` — 2,951 / 2,951 unit tests pass
- [x] Hermetic integration (`crates/luggage/tests/install_rust.rs`) — full pipeline, `--dry-run` no-I/O, tier-3 verification mismatch, idempotency skip, `--force` reinstall, sha256 round-trip
- [x] Manual `--dry-run` smoke test against testdata catalog produces correct substituted plan JSON
- [ ] Bash parity test (`tests/integration/builds/test_luggage_rust.sh`) — runs under `just test-integration-one luggage_rust`; not gated on this PR (Docker-dependent, runs in CI)

## Deferred (NotImplemented, follow-ups)

- Tier 1 verification (GPG / sigstore)
- Tier 2 verification (pinned in-repo checksum)
- Tier 4 verification (TOFU)
- Install methods other than rustup-init shape (binary-tarball, package-manager, source-build)
- `PostInstall::CargoInstall` (rust-dev migration follow-up)

These match the issue's own decomposition note. Each will be filed as a separate issue when the next pilot tool needs them.

Closes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)