### PR TITLE
fix(skills): suppress false-positive missing-test findings

### DIFF
--- a/lib/features/templates/claude/skills/next-issue-ship/pre-review-gates.sh
+++ b/lib/features/templates/claude/skills/next-issue-ship/pre-review-gates.sh
@@ -265,6 +265,14 @@ scan_missing_tests() {
                 "${dirname}/${name_no_ext}_test.py"; do
                 [ -f "$test_path" ] && return
             done
+            # Repo-rooted tests/ tree (pytest / Django / SciPy convention):
+            # source at <root>/<seg>/.../<name>.py with test under
+            # <root>/tests/.../test_<name>.py at any depth.
+            if [ -n "$_PROJECT_ROOT" ] && [ -d "${_PROJECT_ROOT}/tests" ]; then
+                /usr/bin/find "${_PROJECT_ROOT}/tests" \
+                    -name "test_${name_no_ext}.py" \
+                    -print -quit 2>/dev/null | /usr/bin/grep -q . && return
+            fi
             ;;
         ts | js | tsx | jsx)
             for suffix in "test" "spec"; do
@@ -280,6 +288,19 @@ scan_missing_tests() {
             [ -f "${dirname}/${name_no_ext}_test.go" ] && return
             ;;
         rs)
+            # mod.rs aggregator: only mod/pub use/doc/attribute lines, no
+            # top-level definitions. Re-exports submodules whose own files
+            # carry the tests, so flagging them is shipping-time noise.
+            if [ "$basename" = "mod.rs" ]; then
+                # `\b` won't match after `!` (both `!` and the following
+                # space are non-word), so `macro_rules!` is anchored on its
+                # own without a trailing boundary.
+                if ! /usr/bin/grep -qE \
+                    '^[[:space:]]*((pub[[:space:]]+)?(fn|impl|struct|enum|trait)\b|macro_rules!)' \
+                    "$file" 2>/dev/null; then
+                    return
+                fi
+            fi
             /usr/bin/grep -q '#\[cfg(test)\]' "$file" 2>/dev/null && return
             [ -d "${dirname}/../tests" ] && return
             ;;

--- a/tests/unit/claude/test_pre_review_gates.sh
+++ b/tests/unit/claude/test_pre_review_gates.sh
@@ -141,6 +141,143 @@ test_python_missing_test_high() {
 run_test test_python_missing_test_high "Python file without tests is HIGH severity"
 
 # ===========================================================================
+# Python: repo-rooted tests/ tree (pytest / Django / SciPy convention)
+# Source at <root>/scripts/arch_check/checks/unwrapped_fn.py with test at
+# <root>/tests/arch_check/test_unwrapped_fn.py — segments don't align with
+# the four near-source paths, so this only passes via the find-under-root.
+# ===========================================================================
+test_python_repo_rooted_tests_tree() {
+    local proj
+    proj=$(setup_project)
+    /usr/bin/mkdir -p "${proj}/scripts/arch_check/checks" "${proj}/tests/arch_check"
+    # Private helper (`_check`) so `scan_untested_public_api` (separate
+    # scanner, out of scope for this fix) doesn't fire on the fixture.
+    /usr/bin/printf 'def _check():\n    pass\n' >"${proj}/scripts/arch_check/checks/unwrapped_fn.py"
+    /usr/bin/printf 'def test_check():\n    pass\n' >"${proj}/tests/arch_check/test_unwrapped_fn.py"
+    /usr/bin/printf '%s\n' "${proj}/scripts/arch_check/checks/unwrapped_fn.py" >"${proj}/filelist.txt"
+
+    run_gates "$proj" "${proj}/filelist.txt"
+    assert_equals "0" "$TEST_EXIT_CODE" "exit code"
+    assert_empty "$TEST_OUTPUT" "test under <root>/tests/<mirror>/ should be discovered"
+
+    /usr/bin/rm -rf "$proj"
+}
+run_test test_python_repo_rooted_tests_tree "Python test under <root>/tests tree (cross-tree mirror) is found"
+
+test_python_repo_rooted_tests_tree_negative() {
+    local proj
+    proj=$(setup_project)
+    /usr/bin/mkdir -p "${proj}/scripts/arch_check/checks" "${proj}/tests/arch_check"
+    /usr/bin/printf 'def _check():\n    pass\n' >"${proj}/scripts/arch_check/checks/unwrapped_fn.py"
+    # Test exists but for a DIFFERENT source basename — must not match
+    /usr/bin/printf 'def test_other():\n    pass\n' >"${proj}/tests/arch_check/test_other_thing.py"
+    /usr/bin/printf '%s\n' "${proj}/scripts/arch_check/checks/unwrapped_fn.py" >"${proj}/filelist.txt"
+
+    run_gates "$proj" "${proj}/filelist.txt"
+    assert_equals "0" "$TEST_EXIT_CODE" "exit code"
+    local cert
+    cert=$(certainty_for_file "missing-test-file")
+    assert_equals "HIGH" "$cert" "missing test under <root>/tests should still be HIGH"
+
+    /usr/bin/rm -rf "$proj"
+}
+run_test test_python_repo_rooted_tests_tree_negative "Python find-under-root does not match wrong basename"
+
+# ===========================================================================
+# Rust: mod.rs aggregator (only mod/pub use lines) is skipped
+# ===========================================================================
+test_rust_mod_rs_aggregator_skipped() {
+    local proj
+    proj=$(setup_project)
+    /usr/bin/mkdir -p "${proj}/src/foo"
+    /usr/bin/cat >"${proj}/src/foo/mod.rs" <<'EOF'
+//! foo aggregator
+pub mod bar;
+pub mod baz;
+pub use bar::*;
+pub use baz::*;
+EOF
+    /usr/bin/printf '%s\n' "${proj}/src/foo/mod.rs" >"${proj}/filelist.txt"
+
+    run_gates "$proj" "${proj}/filelist.txt"
+    assert_equals "0" "$TEST_EXIT_CODE" "exit code"
+    assert_empty "$TEST_OUTPUT" "pure-aggregator mod.rs should produce no findings"
+
+    /usr/bin/rm -rf "$proj"
+}
+run_test test_rust_mod_rs_aggregator_skipped "Rust mod.rs aggregator (no fn/impl/struct/enum/trait/macro) is skipped"
+
+# ===========================================================================
+# Rust: mod.rs with a `pub fn` is still flagged (regression on heuristic)
+# ===========================================================================
+test_rust_mod_rs_with_fn_flagged() {
+    local proj
+    proj=$(setup_project)
+    /usr/bin/mkdir -p "${proj}/src/foo"
+    /usr/bin/cat >"${proj}/src/foo/mod.rs" <<'EOF'
+pub mod bar;
+pub fn helper() -> u32 { 42 }
+EOF
+    /usr/bin/printf '%s\n' "${proj}/src/foo/mod.rs" >"${proj}/filelist.txt"
+
+    run_gates "$proj" "${proj}/filelist.txt"
+    assert_equals "0" "$TEST_EXIT_CODE" "exit code"
+    local cert
+    cert=$(certainty_for_file "missing-test-file")
+    assert_equals "HIGH" "$cert" "mod.rs with pub fn should still be HIGH"
+
+    /usr/bin/rm -rf "$proj"
+}
+run_test test_rust_mod_rs_with_fn_flagged "Rust mod.rs with pub fn is still flagged"
+
+# ===========================================================================
+# Rust: mod.rs with macro_rules! is still flagged (testable code)
+# ===========================================================================
+test_rust_mod_rs_with_macro_flagged() {
+    local proj
+    proj=$(setup_project)
+    /usr/bin/mkdir -p "${proj}/src/foo"
+    /usr/bin/cat >"${proj}/src/foo/mod.rs" <<'EOF'
+pub mod bar;
+macro_rules! greet { () => { println!("hi") }; }
+EOF
+    /usr/bin/printf '%s\n' "${proj}/src/foo/mod.rs" >"${proj}/filelist.txt"
+
+    run_gates "$proj" "${proj}/filelist.txt"
+    assert_equals "0" "$TEST_EXIT_CODE" "exit code"
+    local cert
+    cert=$(certainty_for_file "missing-test-file")
+    assert_equals "HIGH" "$cert" "mod.rs with macro_rules! should still be HIGH"
+
+    /usr/bin/rm -rf "$proj"
+}
+run_test test_rust_mod_rs_with_macro_flagged "Rust mod.rs with macro_rules! is still flagged"
+
+# ===========================================================================
+# Rust: aggregator heuristic must not bleed onto non-mod.rs files.
+# A lib.rs with no definitions and no inline tests should still be flagged.
+# ===========================================================================
+test_rust_non_mod_rs_unaffected() {
+    local proj
+    proj=$(setup_project)
+    /usr/bin/mkdir -p "${proj}/src"
+    /usr/bin/cat >"${proj}/src/lib.rs" <<'EOF'
+//! crate root with no definitions yet
+pub mod foo;
+EOF
+    /usr/bin/printf '%s\n' "${proj}/src/lib.rs" >"${proj}/filelist.txt"
+
+    run_gates "$proj" "${proj}/filelist.txt"
+    assert_equals "0" "$TEST_EXIT_CODE" "exit code"
+    local cert
+    cert=$(certainty_for_file "missing-test-file")
+    assert_equals "HIGH" "$cert" "non-mod.rs Rust file must still be flagged"
+
+    /usr/bin/rm -rf "$proj"
+}
+run_test test_rust_non_mod_rs_unaffected "Aggregator heuristic does not affect non-mod.rs files"
+
+# ===========================================================================
 # Unknown extension not in skip policy → MEDIUM
 # ===========================================================================
 test_unknown_extension_medium() {


### PR DESCRIPTION
## Summary

`pre-review-gates.sh::scan_missing_tests` was emitting HIGH-certainty
`missing-test-file` findings on two conventions where no real problem
exists. Two targeted heuristics, both purely textual:

- **Rust `mod.rs` aggregators** — files containing only `mod foo;` /
  `pub use foo::*;` get skipped. A `mod.rs` is treated as a pure
  aggregator if `grep` finds no top-level definition keyword
  (`fn`, `impl`, `struct`, `enum`, `trait`, `macro_rules!`). Subtle:
  `\b` won't anchor `macro_rules!` because both `!` and the following
  space are non-word characters, so it's matched as a literal without
  a trailing word boundary. Non-aggregator `mod.rs` falls through to
  the existing `#[cfg(test)]` and `../tests` checks unchanged.

- **Repo-rooted Python `tests/` trees** — pytest/Django/SciPy
  projects often put tests at `<root>/tests/<sub>/test_<name>.py`,
  which doesn't align with any of the four near-source paths the
  scanner already checks. Append `find <root>/tests -name test_<name>.py
  -print -quit` after the existing lookups. Reuses `_PROJECT_ROOT`
  already populated by `load_test_skip_policy` before the extension
  switch runs.

## Test plan

- [x] `bash tests/unit/claude/test_pre_review_gates.sh` — 19/19 pass
  (6 new + 13 existing)
- [x] `just test` — 2969/2969 pass
- [x] Manual smoke: octarine-style `pub mod foo; pub use foo::*;`
  aggregator emits zero `missing-test-file` findings

## Pre-review findings

The pre-ship scanner reported 3 `ai-slop` HIGH findings on
`pre-review-gates.sh` itself — all false positives where the scanner
matched its own pattern strings ("hedging phrase", "buzzword
inflation", etc.) inside its own `grep -E` patterns. Pre-existing,
unrelated to this fix.

## Notes

- `test-skip-patterns.default` reviewed: no `**/mod.rs` or similar
  entries exist today, so nothing to drop. The new heuristics replace
  the need for project-level skip patterns entries that were drifting
  in repos like octarine.
- Out of scope (issue's optional follow-up): general-purpose grep-walk
  Python lookup. File a separate issue if desired.

Closes #424