### PR TITLE
feat(containers-common): add zed_extensions field to Feature registry

### DIFF
--- a/crates/containers-common/src/feature/mod.rs
+++ b/crates/containers-common/src/feature/mod.rs
@@ -68,6 +68,9 @@ pub struct Feature {
 
     /// VS Code extension IDs to recommend.
     pub vscode_extensions: Vec<String>,
+
+    /// Zed extension IDs to recommend.
+    pub zed_extensions: Vec<String>,
 }
 
 impl Default for Feature {
@@ -87,6 +90,7 @@ impl Default for Feature {
             base_lang: None,
             cache_volumes: Vec::new(),
             vscode_extensions: Vec::new(),
+            zed_extensions: Vec::new(),
         }
     }
 }

--- a/crates/containers-common/src/feature/registry.rs
+++ b/crates/containers-common/src/feature/registry.rs
@@ -154,6 +154,7 @@ impl Registry {
             env_file: Some("ruby.env".into()),
             requires: vec!["ruby".into()],
             vscode_extensions: vec!["shopify.ruby-lsp".into()],
+            zed_extensions: vec!["ruby".into()],
             ..Feature::default()
         });
 
@@ -386,6 +387,7 @@ impl Registry {
             category: Category::Cloud,
             env_file: Some("terraform.env".into()),
             vscode_extensions: vec!["hashicorp.terraform".into()],
+            zed_extensions: vec!["terraform".into()],
             ..Feature::default()
         });
         r.add(Feature {

--- a/crates/containers-common/src/template/context.rs
+++ b/crates/containers-common/src/template/context.rs
@@ -29,6 +29,9 @@ pub struct RenderContext {
     /// Deduplicated, sorted list of VS Code extension IDs.
     pub vscode_extensions: Vec<String>,
 
+    /// Deduplicated, sorted list of Zed extension IDs.
+    pub zed_extensions: Vec<String>,
+
     /// True when bindfs is selected (needs `cap_add` + device).
     pub needs_bindfs: bool,
 
@@ -67,6 +70,7 @@ impl RenderContext {
             versions,
             cache_volumes: Vec::new(),
             vscode_extensions: Vec::new(),
+            zed_extensions: Vec::new(),
             needs_bindfs: selection.has("bindfs"),
             needs_docker: selection.has("docker"),
             agents,
@@ -108,6 +112,16 @@ impl RenderContext {
         }
         ctx.vscode_extensions = ext_set.into_iter().collect();
         ctx.vscode_extensions.sort();
+
+        // Collect Zed extensions (deduplicated, sorted).
+        let mut zed_set = HashSet::new();
+        for f in &ctx.enabled_features {
+            for e in &f.zed_extensions {
+                zed_set.insert(e.clone());
+            }
+        }
+        ctx.zed_extensions = zed_set.into_iter().collect();
+        ctx.zed_extensions.sort();
 
         ctx
     }

--- a/crates/containers-common/src/template/renderer.rs
+++ b/crates/containers-common/src/template/renderer.rs
@@ -118,6 +118,7 @@ impl Renderer {
             build_arg_groups => build_arg_groups,
             cache_volumes => cache_volumes,
             vscode_extensions => &ctx.vscode_extensions,
+            zed_extensions => &ctx.zed_extensions,
             needs_bindfs => ctx.needs_bindfs,
             needs_docker => ctx.needs_docker,
             worktree_mounts => &ctx.worktree_mounts,

--- a/crates/containers-common/src/template/tests.rs
+++ b/crates/containers-common/src/template/tests.rs
@@ -331,3 +331,65 @@ fn agents_shared_volumes_explicit_preserved() {
 
     assert_eq!(ctx.agents.shared_volumes, vec!["custom-vol:/custom"]);
 }
+
+#[test]
+fn zed_extensions_aggregated_dedup_sorted() {
+    let reg = Registry::new();
+    let sel = resolve(&make_explicit(&["ruby", "ruby_dev", "terraform"]), &reg);
+
+    let ctx = RenderContext::new(
+        ProjectConfig {
+            name: "test".into(),
+            username: "dev".into(),
+            base_image: "debian:trixie-slim".into(),
+            ..ProjectConfig::default()
+        },
+        "containers",
+        &sel,
+        &reg,
+        BTreeMap::new(),
+        AgentConfig::default(),
+    );
+
+    assert_eq!(
+        ctx.zed_extensions,
+        vec!["ruby".to_string(), "terraform".to_string()],
+        "zed_extensions should be sorted, deduplicated, and pulled from the registry"
+    );
+
+    // No regression in vscode_extensions aggregation.
+    assert!(
+        ctx.vscode_extensions.contains(&"shopify.ruby-lsp".to_string()),
+        "vscode_extensions should still include shopify.ruby-lsp"
+    );
+    assert!(
+        ctx.vscode_extensions.contains(&"hashicorp.terraform".to_string()),
+        "vscode_extensions should still include hashicorp.terraform"
+    );
+}
+
+#[test]
+fn zed_extensions_empty_when_no_zed_aware_features() {
+    let reg = Registry::new();
+    // python_dev has no zed_extensions; expect empty aggregation.
+    let sel = resolve(&make_explicit(&["python", "python_dev"]), &reg);
+
+    let ctx = RenderContext::new(
+        ProjectConfig {
+            name: "test".into(),
+            username: "dev".into(),
+            base_image: "debian:trixie-slim".into(),
+            ..ProjectConfig::default()
+        },
+        "containers",
+        &sel,
+        &reg,
+        BTreeMap::new(),
+        AgentConfig::default(),
+    );
+
+    assert!(
+        ctx.zed_extensions.is_empty(),
+        "zed_extensions should be empty when no enabled feature contributes any"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `zed_extensions: Vec<String>` to the `Feature` struct (peer to `vscode_extensions`), defaulting to empty
- Populate conservatively per the issue's mapping policy: `terraform` → `["terraform"]`, `ruby_dev` → `["ruby"]`. Everything else inherits the empty default — Zed has built-in support for Python/Rust/TS/Go, and there's no first-party extension for the rest yet
- Mirror the existing `vscode_extensions` aggregation in `RenderContext` (HashSet dedup + sort) and pass through to the renderer
- No template/golden file changes — `devcontainer.json.j2` doesn't reference `zed_extensions` yet (that's #440)

This is the foundational data layer for Zed parity (epic #438). Without it, #440 (template emit), #441 (repo dogfood), and #442 (compose volume) have nothing to render.

## Test plan

- [x] New unit tests in `template/tests.rs`:
  - `zed_extensions_aggregated_dedup_sorted` — verifies aggregation from `terraform` + `ruby_dev`, sorted output, and that `vscode_extensions` behavior is unchanged
  - `zed_extensions_empty_when_no_zed_aware_features` — verifies empty aggregation for Python (which has no `zed_extensions`)
- [x] `cargo test -p containers-common` — all tests pass
- [x] `just test` — full unit suite (2,973 tests) passes
- [x] `just lint` — all hooks green
- [x] Golden files unchanged (verified — templates don't reference `zed_extensions` yet)

Closes #439