### PR TITLE
feat(containers-common): emit customizations.zed.extensions in devcontainer template

### DIFF
--- a/crates/containers-common/src/template/sources/devcontainer.json.j2
+++ b/crates/containers-common/src/template/sources/devcontainer.json.j2
@@ -29,7 +29,14 @@
           }
         }
       }
-    }
+    }{% if zed_extensions %},
+    "zed": {
+      "extensions": [
+{%- for ext in zed_extensions %}
+        "{{ ext }}"{% if not loop.last %},{% endif %}
+{%- endfor %}
+      ]
+    }{% endif %}
   },
   "remoteUser": "{{ username }}"
 }

--- a/crates/containers-common/src/template/tests.rs
+++ b/crates/containers-common/src/template/tests.rs
@@ -369,6 +369,67 @@ fn zed_extensions_aggregated_dedup_sorted() {
 }
 
 #[test]
+fn devcontainer_emits_zed_block_when_zed_extensions_present() {
+    let reg = Registry::new();
+    let sel = resolve(&make_explicit(&["terraform"]), &reg);
+
+    let ctx = RenderContext::new(
+        ProjectConfig {
+            name: "test".into(),
+            username: "dev".into(),
+            base_image: "debian:trixie-slim".into(),
+            ..ProjectConfig::default()
+        },
+        "containers",
+        &sel,
+        &reg,
+        BTreeMap::new(),
+        AgentConfig::default(),
+    );
+
+    let renderer = Renderer::new().unwrap();
+    let output = renderer.render("devcontainer.json.tmpl", &ctx).unwrap();
+
+    assert!(
+        output.contains("\"zed\": {"),
+        "devcontainer.json should contain a zed customizations block when zed_extensions is non-empty"
+    );
+    assert!(
+        output.contains("\"terraform\""),
+        "devcontainer.json zed block should list the terraform extension"
+    );
+}
+
+#[test]
+fn devcontainer_omits_zed_block_when_no_zed_extensions() {
+    let reg = Registry::new();
+    // python+python_dev has no zed_extensions in the registry.
+    let sel = resolve(&make_explicit(&["python", "python_dev"]), &reg);
+
+    let ctx = RenderContext::new(
+        ProjectConfig {
+            name: "test".into(),
+            username: "dev".into(),
+            base_image: "debian:trixie-slim".into(),
+            ..ProjectConfig::default()
+        },
+        "containers",
+        &sel,
+        &reg,
+        BTreeMap::new(),
+        AgentConfig::default(),
+    );
+
+    let renderer = Renderer::new().unwrap();
+    let output = renderer.render("devcontainer.json.tmpl", &ctx).unwrap();
+
+    assert!(
+        !output.contains("\"zed\""),
+        "devcontainer.json should not contain a zed customizations block when zed_extensions is empty"
+    );
+}
+
+#[test]
 fn zed_extensions_empty_when_no_zed_aware_features() {
     let reg = Registry::new();
     // python_dev has no zed_extensions; expect empty aggregation.

--- a/crates/containers-common/testdata/golden/fullstack/devcontainer.json.tmpl.golden
+++ b/crates/containers-common/testdata/golden/fullstack/devcontainer.json.tmpl.golden
@@ -38,6 +38,11 @@
           }
         }
       }
+    },
+    "zed": {
+      "extensions": [
+        "terraform"
+      ]
     }
   },
   "remoteUser": "dev"


### PR DESCRIPTION
## Summary

- Add a conditional `customizations.zed.extensions` block to `devcontainer.json.j2`, mirroring the existing vscode extension-loop pattern
- Block is emitted only when `zed_extensions` is non-empty — projects with no Zed-mapped languages get no `zed` key (avoids `"extensions": []` artifact, per the issue)
- Regenerate the fullstack golden — gains a `"zed": { "extensions": ["terraform"] }` block, validating end-to-end wiring through #439's data layer
- Minimal golden stays byte-identical (python+python_dev contributes no `zed_extensions`)
- Two new structural assertion tests catch the "always emit zed block" regression even if both goldens drift together

This is the second sub-issue of the Zed parity epic (#438). #441 (repo dogfood) and #442 (compose volume) build on this.

## Test plan

- [x] `cargo test -p containers-common --lib renderer_` — both renderer goldens match
- [x] `cargo test -p containers-common --lib devcontainer_` — new emit/omit assertions pass
- [x] `cargo test -p containers-common` — full crate suite passes (no other goldens affected)
- [x] `just test` — full unit suite (2,973 tests) passes
- [x] `just lint` — all hooks green
- [x] Verified non-regenerated goldens keep byte-identical content (only fullstack devcontainer.json.tmpl.golden is touched)

Closes #440