### PR TITLE
feat(devcontainer): add zed customizations to repo .devcontainer/devcontainer.json

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -4,3 +4,4 @@
 - [Minimal build philosophy](minimal-build-philosophy.md) — Install minimal package sets; clean up build artifacts
 - [Use file-issue skill](use-file-issue-skill.md) — Always file new issues via `/file-issue`, not raw `gh issue create`
 - [Prefer just recipes](prefer-just-recipes.md) — Use `just <recipe>` over bare cargo/shell when one exists
+- [PR merge + prune is the default ship](feedback_pr_merge_default.md) — `/next-issue-ship` Option 1 ends at merged + branch deleted, not at "PR open"

--- a/.claude/memory/feedback_pr_merge_default.md
+++ b/.claude/memory/feedback_pr_merge_default.md
@@ -1,0 +1,25 @@
+---
+name: PR merge + branch prune is the default ship outcome
+description: When a /next-issue-ship PR reaches green CI, merge it (squash) and prune the branch — don't stop at "PR open"
+type: feedback
+originSessionId: 3d724f14-9967-4620-bd7d-cf0435383b5c
+---
+
+When shipping via `/next-issue-ship` Option 1 (Branch + PR), don't stop at PR
+creation + labeling. The intended end state is: PR merged to main, local +
+remote feature branch deleted.
+
+**Why:** Stated explicitly while shipping #424/PR #437. The user doesn't want
+PRs sitting open waiting for a second prompt — once CI is green, merging is
+the assumed next step.
+
+**How to apply:**
+
+- After the CI-wait loop returns "all green", proceed to
+  `gh pr merge <num> --squash --delete-branch` (squash matches the auto-merge
+  fast path's choice and the single-issue PR shape)
+- After merge: `git checkout main && git pull --ff-only && git branch -D <feature>`
+- If CI is red and unfixable, stop and report — don't merge
+- Equivalent to running with `AUTOMERGE=1` after CI confirms, except merging
+  is done explicitly rather than queued
+- Skip the "PR open" celebratory stop; only stop after the branch is gone

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -49,6 +49,13 @@
           }
         }
       }
+    },
+    "zed": {
+      "extensions": [
+        "dockerfile",
+        "dprint",
+        "terraform"
+      ]
     }
   },
 


### PR DESCRIPTION
## Summary

- Add a `customizations.zed.extensions` block to this repo's hand-maintained `.devcontainer/devcontainer.json`, parallel to the existing `vscode` block, so opening the repo in Zed 0.231.1+ pre-installs the same tooling VS Code users already get
- Dogfooding step for the Zed parity epic (#438) — builds on #448 (`zed_extensions` field on `Feature`) and #449 (template emits the block); this PR is the local mirror for the repo's own non-templated devcontainer

## Slug verification

Cross-checked the issue's proposed list against the canonical `zed-industries/extensions` registry (source of truth for slugs). Final sorted list: `dockerfile`, `dprint`, `terraform`. Dropped from the issue's list:

- `anthropic-claude-code` — not in the registry; Claude Code is built into Zed natively via the agent panel
- `toml` — not a separate extension; TOML support is built into Zed core

The list can grow later — the structural change is what unblocks the rest of #438.

## Test plan

- [x] `dprint check .devcontainer/devcontainer.json` — passes
- [x] Pre-commit hooks pass on the staged file (gitleaks, conform commit-msg, etc.)
- [x] VS Code block, settings, terminal config, and `remoteUser` unchanged (diff is +7 lines, no deletions)
- [ ] Manual smoke (deferred — needs Zed 0.231.1+ on a maintainer machine): open the repo in Zed, confirm the devcontainer prompt appears and the three extensions install inside the container

Closes #441