### PR TITLE
feat(containers-common): broaden Zed extensions on dev_tools and docker

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -57,7 +57,10 @@
       "extensions": [
         "dockerfile",
         "dprint",
-        "terraform"
+        "env",
+        "just",
+        "terraform",
+        "toml"
       ]
     }
   },

--- a/crates/containers-common/src/feature/registry.rs
+++ b/crates/containers-common/src/feature/registry.rs
@@ -304,6 +304,7 @@ impl Registry {
                 "usernamehw.errorlens".into(),
                 "wayou.vscode-todo-highlight".into(),
             ],
+            zed_extensions: vec!["dprint".into(), "env".into(), "just".into(), "toml".into()],
             ..Feature::default()
         });
         r.add(Feature {
@@ -314,6 +315,7 @@ impl Registry {
             category: Category::Tool,
             env_file: Some("docker.env".into()),
             vscode_extensions: vec!["ms-azuretools.vscode-docker".into()],
+            zed_extensions: vec!["dockerfile".into()],
             ..Feature::default()
         });
         r.add(Feature {

--- a/crates/containers-common/testdata/golden/fullstack/devcontainer.json.tmpl.golden
+++ b/crates/containers-common/testdata/golden/fullstack/devcontainer.json.tmpl.golden
@@ -45,7 +45,12 @@
     },
     "zed": {
       "extensions": [
-        "terraform"
+        "dockerfile",
+        "dprint",
+        "env",
+        "just",
+        "terraform",
+        "toml"
       ]
     }
   },


### PR DESCRIPTION
## Summary

Adds Zed extension recommendations that match the existing VS Code DX:

| Feature | Zed extensions added |
| --- | --- |
| `dev_tools` | `dprint`, `env`, `just`, `toml` (taplo) |
| `docker` | `dockerfile` |

Also adds the same four to this repo's `.devcontainer/devcontainer.json` so the canonical container picks them up under Zed today — it's hand-edited, not generated from the template.

## Rationale

- **`just`** — justfile is the project's canonical task runner; current Zed users get no highlighting or LSP.
- **`toml`** (taplo) — `Cargo.toml` × 4 plus `taplo.toml`, `deny.toml`, `cliff.toml`, `clippy.toml`, etc.
- **`env`** — repo ships `examples/env/*.env` and projects scaffolded with stibbons can carry their own.
- **`dprint`** — already used as the JSON/YAML formatter (and lefthook runs it); having the LSP in-editor matches the VS Code setup.
- **`dockerfile`** — matches the existing `ms-azuretools.vscode-docker` recommendation on the `docker` feature.

## Scope

- Fullstack golden updated (enables `dev_tools` + `docker` + `terraform` → six Zed extensions).
- Minimal golden unchanged (neither `dev_tools` nor `docker` selected).
- Existing extensions (`ruby` on `ruby_dev`, `terraform` on `terraform`) are unchanged.

## Test plan

- [x] `cargo test -p containers-common` — 81 + auxiliary passed (golden diff verified)
- [x] Local lefthook pre-commit hooks pass (cargo-lint, fmt, gitleaks, conform)
- [ ] CI to verify across platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)