### PR TITLE
fix(dev-tools): point Zed dprint/taplo extensions at system binaries

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,23 @@
+{
+  // LSP binary overrides for Zed extensions whose own binary fetch races
+  // their postinstall (toast: "failed to start language server <name>").
+  // The matching binaries ship in this container via the dev-tools feature;
+  // redirecting here skips the per-extension npm install / download entirely.
+  //
+  // Mirrored at the container level by:
+  //   lib/features/lib/dev-tools/zed-lsp-config-first-startup.sh
+  "lsp": {
+    "dprint": {
+      "binary": {
+        "path": "/usr/local/bin/dprint",
+        "arguments": ["lsp"]
+      }
+    },
+    "taplo": {
+      "binary": {
+        "path": "/usr/local/bin/taplo",
+        "arguments": ["lsp", "stdio"]
+      }
+    }
+  }
+}

--- a/lib/features/dev-tools.sh
+++ b/lib/features/dev-tools.sh
@@ -288,6 +288,21 @@ log_command "Setting dev-tools bashrc script permissions" \
     chmod 755 /etc/bashrc.d/80-dev-tools.sh
 
 # ============================================================================
+# Zed LSP Overrides
+# ============================================================================
+# Ship a first-startup script that bootstraps ~/.config/zed/settings.json
+# with LSP binary overrides for Zed extensions whose own binary fetch races
+# their postinstall (dprint, taplo). No-op outside Zed envs.
+log_message "Installing Zed LSP override bootstrap script..."
+
+log_command "Creating container first-startup directory" \
+    mkdir -p /etc/container/first-startup
+
+install -m 755 \
+    /tmp/build-scripts/features/lib/dev-tools/zed-lsp-config-first-startup.sh \
+    /etc/container/first-startup/40-zed-lsp-config.sh
+
+# ============================================================================
 # Verification Script
 # ============================================================================
 log_message "Creating dev tools verification script..."

--- a/lib/features/lib/dev-tools/zed-lsp-config-first-startup.sh
+++ b/lib/features/lib/dev-tools/zed-lsp-config-first-startup.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Bootstrap ~/.config/zed/settings.json with LSP overrides that point Zed
+# extensions at the system binaries this container already ships.
+#
+# Why: several Zed extensions bundle or npm-install their own copy of a
+# language server on first connect — racing the postinstall and surfacing
+# sticky "failed to start language server" toasts. We already ship the
+# matching binaries via dev-tools (dprint, taplo), so pointing the
+# extensions at /usr/local/bin/* avoids the race entirely.
+#
+# Runs in first-startup so we never clobber a user who has written their
+# own settings.json (keymaps, themes, AI provider configs, etc.). Users
+# with pre-existing settings can paste the printed override block into
+# their settings.json manually.
+#
+# VS Code / JetBrains envs ignore ~/.config/zed/, so this is a no-op
+# outside Zed.
+
+set -euo pipefail
+
+ZED_SETTINGS_DIR="${HOME}/.config/zed"
+ZED_SETTINGS_FILE="${ZED_SETTINGS_DIR}/settings.json"
+
+read -r -d '' ZED_LSP_OVERRIDES <<'JSON' || true
+{
+  // LSP binary overrides for Zed extensions whose own binary fetch races
+  // their postinstall (toast: "failed to start language server <name>").
+  // The matching binaries ship in this container; redirecting here skips
+  // the per-extension npm install / download entirely.
+  "lsp": {
+    "dprint": {
+      "binary": {
+        "path": "/usr/local/bin/dprint",
+        "arguments": ["lsp"]
+      }
+    },
+    "taplo": {
+      "binary": {
+        "path": "/usr/local/bin/taplo",
+        "arguments": ["lsp", "stdio"]
+      }
+    }
+  }
+}
+JSON
+
+if [ -f "$ZED_SETTINGS_FILE" ]; then
+    echo "[zed-lsp-config] $ZED_SETTINGS_FILE already exists; leaving it alone."
+    echo "  To skip the per-extension LSP install race, merge this into your settings.json:"
+    echo "$ZED_LSP_OVERRIDES" | command sed 's/^/    /'
+    exit 0
+fi
+
+mkdir -p "$ZED_SETTINGS_DIR"
+printf '%s\n' "$ZED_LSP_OVERRIDES" >"$ZED_SETTINGS_FILE"
+
+echo "[zed-lsp-config] wrote default $ZED_SETTINGS_FILE with dprint + taplo overrides"

--- a/tests/unit/features/dev-tools.sh
+++ b/tests/unit/features/dev-tools.sh
@@ -819,5 +819,29 @@ test_supervisord_config_installed_by_script() {
 run_test test_supervisord_config_shipped "supervisord.conf shipped for non-root execution"
 run_test test_supervisord_config_installed_by_script "dev-tools.sh installs shipped supervisord.conf"
 
+# Test: the Zed LSP override first-startup script ships with the expected
+# redirections to system binaries. Regression guard against the dprint
+# extension's npm-install race (see commit history).
+test_zed_lsp_config_script_shipped() {
+    local script="$PROJECT_ROOT/lib/features/lib/dev-tools/zed-lsp-config-first-startup.sh"
+    assert_file_exists "$script" "zed-lsp-config-first-startup.sh shipped under lib/features/lib/dev-tools/"
+    assert_file_contains "$script" '"path": "/usr/local/bin/dprint"' "dprint override targets system binary"
+    assert_file_contains "$script" '"path": "/usr/local/bin/taplo"' "taplo override targets system binary"
+    assert_file_contains "$script" '"lsp", "stdio"' "taplo invoked with 'lsp stdio'"
+    assert_file_contains "$script" 'if [ -f "$ZED_SETTINGS_FILE" ]' "script skips when settings.json already exists"
+}
+
+# Test: dev-tools.sh installs the Zed LSP override script into first-startup.
+test_zed_lsp_config_installed_by_script() {
+    local source_file="$PROJECT_ROOT/lib/features/dev-tools.sh"
+    assert_file_contains "$source_file" "features/lib/dev-tools/zed-lsp-config-first-startup.sh" \
+        "dev-tools.sh references shipped zed-lsp-config script"
+    assert_file_contains "$source_file" "/etc/container/first-startup/40-zed-lsp-config.sh" \
+        "dev-tools.sh installs to /etc/container/first-startup with the expected name"
+}
+
+run_test test_zed_lsp_config_script_shipped "zed-lsp-config-first-startup.sh shipped with system-binary overrides"
+run_test test_zed_lsp_config_installed_by_script "dev-tools.sh installs zed-lsp-config first-startup script"
+
 # Generate test report
 generate_report


### PR DESCRIPTION
## Summary

- The Zed `dprint` extension npm-installs its own copy of dprint on first remote connect and races the postinstall — Zed tries to spawn the LSP from `~/.local/share/zed/remote_extensions/work/dprint/node_modules/.bin/dprint` *before* the binary lands, producing a sticky **"failed to start language server dprint"** toast (`No such file or directory (os error 2)`).
- `dev-tools` already ships `/usr/local/bin/dprint` and `/usr/local/bin/taplo`. Override the extensions' binary paths via `~/.config/zed/settings.json` and skip the per-extension install entirely.
- Adds a first-startup script that bootstraps `~/.config/zed/settings.json` **only when missing** — no clobbering of existing keymaps/themes/AI-provider configs. On a hit it prints the override snippet for users to paste manually.
- No-op outside Zed: VS Code and JetBrains ignore `~/.config/zed/`. No feature toggle needed.

## Why dprint + taplo and not the rest

Surveyed every Zed extension in `crates/containers-common/src/feature/registry.rs` (`dprint`, `env`, `just`, `toml`, `dockerfile`, `terraform`, `ruby`). Only `dprint` and `taplo` (used by the `toml` extension) cleanly map to an already-shipped system binary. Others (`just-lsp`, `terraform-ls`, `docker-language-server`, `ruby-lsp`) would require installing a new binary in their respective feature first — out of scope here.

## Existing containers

The `~/.container-initialized` marker means first-startup won't re-run on existing containers. Mitigation: rebuild, delete the marker, or paste the snippet from `.zed/settings.json` manually. New containers pick it up automatically.

## Files

- `lib/features/lib/dev-tools/zed-lsp-config-first-startup.sh` (new) — bootstraps `~/.config/zed/settings.json`
- `lib/features/dev-tools.sh` — installs the script to `/etc/container/first-startup/40-zed-lsp-config.sh`
- `tests/unit/features/dev-tools.sh` — two regression tests
- `.zed/settings.json` — same overrides at the project level for anyone working in this repo before the rebuild lands

## Test plan

- [x] `bash tests/unit/features/dev-tools.sh` — 59/59 pass (incl. the 2 new tests)
- [x] `shellcheck --severity=warning` clean on all touched shell files
- [x] `shfmt -d -i 4 -ci` clean on touched files
- [x] `dprint check .zed/settings.json` passes
- [x] Manual: ran the first-startup script with a fresh `$HOME` and confirmed it writes correctly; re-ran and confirmed it leaves the existing file alone and prints the merge snippet
- [x] Manual: copied the file to `~/.config/zed/settings.json` in the live container; ready to verify in Zed that the dprint LSP starts from `/usr/local/bin/dprint` instead of the npm path (next Zed connect / LSP restart)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)