### PR TITLE
fix(luggage): serialize shim-writing idempotency tests to close fork/exec race

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,6 +934,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,6 +1632,7 @@ dependencies = [
  "containers-common",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2 0.10.9",
  "shell-words",
  "tempfile",
@@ -2421,6 +2433,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2434,6 +2455,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "secrecy"
@@ -2540,6 +2567,32 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/luggage/Cargo.toml
+++ b/crates/luggage/Cargo.toml
@@ -25,4 +25,5 @@ tracing-subscriber = { workspace = true }
 ureq = { version = "2", default-features = false, features = ["tls"] }
 
 [dev-dependencies]
+serial_test = "3"
 tempfile = { workspace = true }

--- a/crates/luggage/src/installer/idempotency.rs
+++ b/crates/luggage/src/installer/idempotency.rs
@@ -73,6 +73,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    #[serial_test::serial]
     fn matching_version_returns_true() {
         let dir = tempdir().unwrap();
         write_shim(dir.path(), "rustc", "rustc 1.95.0 (abcdef0)");
@@ -81,6 +82,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    #[serial_test::serial]
     fn nonmatching_version_returns_false() {
         let dir = tempdir().unwrap();
         write_shim(dir.path(), "rustc", "rustc 1.84.0 (abcdef0)");
@@ -89,6 +91,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    #[serial_test::serial]
     fn rust_tool_id_resolves_to_rustc_binary() {
         let dir = tempdir().unwrap();
         write_shim(dir.path(), "rustc", "rustc 1.95.0 (abcdef0)");


### PR DESCRIPTION
## Summary

- Adds `serial_test = \"3\"` to `crates/luggage` `[dev-dependencies]`.
- Marks the three shim-writing tests in `crates/luggage/src/installer/idempotency.rs` (`matching_version_returns_true`, `nonmatching_version_returns_false`, `rust_tool_id_resolves_to_rustc_binary`) with `#[serial_test::serial]`.
- Closes the parallel-`cargo test` fork/exec race ([rust-lang/rust#100904](https://github.com/rust-lang/rust/issues/100904)) where an in-flight `fs::write` FD raised the inode's `i_writecount` while another thread `fork()`+`execve()`'d a shim — child got `ETXTBSY`. CI run [25649484773](https://github.com/joshjhall/containers/actions/runs/25649484773) caught one variant on `main` post-#453.

The two tests that don't write a shim (`missing_binary_returns_false`, `primary_binary_defaults_to_tool_id`) are left parallel — they don't participate in the race. Production code (`already_installed`, `primary_binary`) is unchanged.

## Test plan

- [x] `cargo test -p luggage --lib installer::idempotency` — 25 consecutive iterations, all green
- [x] `cargo test -p luggage` — full crate suite green (lib + integration + doc)
- [x] `cargo clippy -p luggage --tests -- -D warnings` — clean
- [x] Pre-commit hooks (cargo-lint, cargo-deny, osv-scanner, cargo-test, taplo, gitleaks, conform) — all green
- [ ] CI `Rust Tests (stibbons) — ubuntu-latest` green on this PR
- [ ] (Post-merge AC) Three consecutive `main` runs green to confirm

Closes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)