### PR TITLE
refactor(rust): delegate toolchain install to luggage CLI shim

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -151,11 +151,14 @@ yarn-error.log*
 .eslintcache
 .node_repl_history
 
-# Rust workspace (not needed in container builds)
-Cargo.toml
-Cargo.lock
-crates/
+# Rust workspace
+# Cargo.toml / Cargo.lock / crates/ ARE needed at build time: the
+# luggage-builder Dockerfile stage compiles `luggage` from this workspace
+# (issue #407), and the base stage vendors crates/luggage/testdata/catalog
+# at /opt/containers-db so feature scripts can shell out to `luggage install`.
+# Only the cargo build output directories stay out of the context.
 target/
+**/target/
 **/*.rs.bk
 
 # Go

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,23 @@
 
 # Build arguments for base image selection
 ARG BASE_IMAGE=debian:trixie-slim
+
+# ============================================================================
+# Luggage Builder — compile the install engine once, reuse in the base stage
+# ============================================================================
+# The base stage shells out to `luggage install <tool>@<version>` from feature
+# scripts (see lib/features/rust.sh). Building luggage here keeps the rust
+# toolchain out of the runtime image while still bundling a reproducible
+# binary built from the in-tree workspace.
+FROM rust:1.95-slim-trixie AS luggage-builder
+WORKDIR /workspace
+COPY Cargo.toml Cargo.lock ./
+COPY crates ./crates
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/workspace/target \
+    cargo build --release -p luggage --bin luggage \
+    && cp target/release/luggage /tmp/luggage
+
 FROM ${BASE_IMAGE} AS base
 
 # Path to the project root relative to the containers directory
@@ -122,6 +139,19 @@ RUN chmod 755 /tmp/build-scripts/features/*.sh /tmp/build-scripts/base/*.sh
 RUN RESTRICT_SHELLS=${RESTRICT_SHELLS} \
     PRODUCTION_MODE=${PRODUCTION_MODE} \
     /tmp/build-scripts/base/shell-hardening.sh
+
+# ============================================================================
+# Luggage install engine + catalog snapshot
+# ============================================================================
+# Feature scripts (starting with lib/features/rust.sh, issue #407) delegate
+# toolchain installation to `luggage install <tool>@<version>`. The catalog
+# is vendored from crates/luggage/testdata/catalog so builds stay
+# reproducible from Cargo.lock with no build-time network fetch; a pinned
+# containers-db checkout will replace this once that workflow lands.
+COPY --from=luggage-builder /tmp/luggage /usr/local/bin/luggage
+COPY crates/luggage/testdata/catalog /opt/containers-db
+ENV CONTAINERS_DB=/opt/containers-db
+RUN mkdir -p /var/log/luggage && chmod 755 /var/log/luggage
 
 # ============================================================================
 # LANGUAGE INSTALLATIONS - Grouped with their development tools

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -25,6 +25,8 @@ the container build system.
 
 - [**Version Resolution**](version-resolution.md) - Partial version resolution
   system (e.g., `3.3` → `3.3.10`)
+- [**Luggage Migration**](luggage-migration.md) - Playbook for porting
+  `lib/features/*.sh` scripts to delegate install logic to the luggage CLI
 
 ### Future Design
 

--- a/docs/architecture/luggage-migration.md
+++ b/docs/architecture/luggage-migration.md
@@ -1,0 +1,93 @@
+# Luggage Migration Playbook
+
+The bash feature scripts in `lib/features/*.sh` duplicate installer logic that
+now lives in [`crates/luggage/`](../../crates/luggage/) plus the
+[`containers-db`](https://github.com/joshjhall/containers-db) tool catalog.
+This document is the recipe for porting a feature script to the luggage shim.
+Pilot port: `lib/features/rust.sh` (issue #407).
+
+For the why and the locked design choices, see
+`.claude/memory/luggage-tooldb-design.md`. For the install engine internals,
+see `crates/luggage/src/installer/`.
+
+## What moves to luggage
+
+- Upstream download URL templating
+- Checksum fetch + tier-3 verification
+- Installer execution under the target user (`su` wrapping)
+- Catalog-declared `post_install` steps (e.g., `rustup component add` for rust)
+- System-package dependency installation (the catalog's `dependencies[]`)
+
+## What stays in bash
+
+- Cache directory creation and ownership (`/cache/<tool>`)
+- `bashrc.d/` fragments that export tool environment for runtime shells
+- `/etc/environment` PATH contributions (`add_to_system_path`)
+- `cargo install --locked` of dev tools — they're not in the catalog yet
+- `apt_install` of build-time dependencies the catalog doesn't declare
+  (e.g., `build-essential pkg-config` for cargo to link rust binaries)
+- Feature logging (`log_feature_start`, `log_feature_summary`, `log_feature_end`)
+- Final ownership fix-up and `log_feature_instructions`
+
+The split is deliberate: luggage owns "what version of tool X installs and how
+to verify it"; bash owns "how this image wires the tool into the shell
+environment." The boundary stays at the install method's exit.
+
+## Catalog source (interim)
+
+Production builds copy `crates/luggage/testdata/catalog` into the image at
+`/opt/containers-db` via `COPY` from the `luggage-builder` stage. This keeps
+builds reproducible from `Cargo.lock` with no build-time network fetch.
+
+A follow-up issue will swap this for a pinned `containers-db@vX.Y.Z` snapshot
+(per the design memo's "main repo pins a snapshot SHA" decision). Until then,
+the testdata is load-bearing for production — update it whenever a feature
+needs a version the testdata doesn't list.
+
+## Porting recipe
+
+For each feature script (e.g. `node.sh`, `python.sh`):
+
+1. **Verify catalog coverage.** Confirm `tools/<id>/index.json` and at least
+   one `versions/<v>.json` exist in `crates/luggage/testdata/catalog/`, that
+   the requested version is in `available[]`, and that `post_install[]`
+   covers every component the bash script currently adds explicitly.
+2. **Confirm install method support.** Check `install_methods[].platform`
+   matches the target distros, and that `installer/methods/<kind>.rs`
+   implements the variant. Rust used `script-installer` (rustup-init); other
+   features may need `tarball-extract` or `apt-deb`. If the variant isn't
+   implemented yet, that's a luggage-side issue, not a port.
+3. **Strip the inline install.** Remove from the bash script: source lines
+   for `checksum-fetch.sh` / `download-verify.sh` / `checksum-verification.sh`
+   (no longer needed in this script), the download `curl` invocation, the
+   `verify_download_or_fail` call, the installer `su -c` block, and any
+   explicit component-add lines covered by catalog `post_install`.
+4. **Add the luggage call.** Replace with one invocation:
+
+   ```bash
+   log_command "luggage install <tool>@${TOOL_VERSION}" \
+       /usr/local/bin/luggage install "<tool>@${TOOL_VERSION}" \
+           --catalog "${CONTAINERS_DB:-/opt/containers-db}" \
+           --user "${USERNAME}" \
+           --cache-root /cache \
+           --log-dir /var/log/luggage
+   ```
+
+   Handle channel names (`stable`/`beta`/`nightly`) with a separate branch
+   that uses `--channel "$value"` and bare `<tool>`. `set -euo pipefail`
+   already gives fail-fast on luggage's non-zero exit — do not add `|| true`.
+5. **Run the smoke and production tests.**
+   - `just test-integration-one luggage_rust` — the fixture-only luggage
+     smoke test (renamed for each feature once you add yours).
+   - `just test-integration-one <feature>` — the production-path
+     integration test that exercises the real `Dockerfile` build.
+6. **Update this doc.** Add the feature to the "Ported features" list below.
+   If the port surfaced a luggage-side limitation (channel resolution,
+   unsupported install method, missing post_install variant), file a
+   follow-up issue and link it.
+
+## Ported features
+
+| Feature | Issue | Notes |
+| --- | --- | --- |
+| `rust.sh` | #407 | Pilot. Channels (`stable`/`beta`/`nightly`) route through `--channel`. cargo dev tools (cargo-watch, mdbook suite) remain in bash. |

--- a/lib/features/rust.sh
+++ b/lib/features/rust.sh
@@ -2,30 +2,31 @@
 # Rust Programming Language - Toolchain and development tools
 #
 # Description:
-#   Installs the Rust programming language toolchain via rustup with essential
-#   development tools. Configures cache directories for optimal container usage.
+#   Delegates toolchain installation to `luggage install rust@${RUST_VERSION}`
+#   and adds cargo-installed development tools on top. See
+#   docs/architecture/luggage-migration.md for the migration playbook.
 #
 # Features:
-#   - Rust toolchain installed via rustup (stable by default)
+#   - Rust toolchain installed via luggage (rustup-init under the hood)
 #   - Essential components: rust-src, rust-analyzer, clippy, rustfmt
+#     (applied by catalog `post_install` steps)
 #   - Development tools: cargo-watch (auto-rebuild)
 #   - Documentation: mdbook, mdbook-mermaid, mdbook-toc, mdbook-admonish
-#
-# Note: cargo-edit is no longer needed as cargo add/remove are built into Cargo 1.62+
 #
 # Cache Strategy:
 #   - Uses /cache/cargo and /cache/rustup for consistent caching
 #   - Allows volume mounting for persistent caches across container rebuilds
 #
 # Environment Variables:
-#   - RUST_VERSION: Toolchain version specification (default: 1.88.0)
-#     * Major.minor only (e.g., "1.84"): Resolves to latest 1.84.x
+#   - RUST_VERSION: Toolchain version specification (default: 1.95.0)
 #     * Specific version (e.g., "1.84.1"): Uses exact version
-#     * Can also be: stable, beta, nightly
+#     * Major.minor only (e.g., "1.84"): Resolves to latest patch
+#     * Channel names (stable, beta, nightly): Passed to luggage --channel
 #
 # Note:
-#   - rustup-init is verified using Tier 3 (published checksums from rust-lang.org)
-#   - Rust toolchains are verified by rustup's built-in verification system
+#   - rustup-init is verified by luggage's tier-3 verifier
+#     (published sha256 from static.rust-lang.org)
+#   - Rust toolchains remain verified by rustup's built-in system
 #
 set -euo pipefail
 
@@ -41,14 +42,6 @@ source /tmp/build-scripts/base/version-validation.sh
 # Source version resolution for partial version support
 source /tmp/build-scripts/base/version-resolution.sh
 
-# Source checksum utilities for secure binary downloads
-source /tmp/build-scripts/base/checksum-fetch.sh
-
-# Source download verification utilities
-source /tmp/build-scripts/base/download-verify.sh
-
-# Source 4-tier checksum verification system
-source /tmp/build-scripts/base/checksum-verification.sh
 source /tmp/build-scripts/base/cache-utils.sh
 source /tmp/build-scripts/base/path-utils.sh
 
@@ -111,79 +104,36 @@ log_command "Setting cache directory ownership" \
     chown -R "${USER_UID}:${USER_GID}" "${CARGO_HOME}" "${RUSTUP_HOME}"
 
 # ============================================================================
-# Rust Toolchain Installation (Secure with Checksum Verification)
+# Rust Toolchain Installation (delegated to luggage)
 # ============================================================================
-log_message "Installing Rust toolchain..."
+# luggage downloads + tier-3-verifies rustup-init, runs it under ${USERNAME},
+# and applies the rust-src/rust-analyzer/clippy/rustfmt component_add
+# post_install steps from the catalog. Channel names (stable/beta/nightly)
+# route through `--channel`; semver-shaped values use `tool@<version>`.
+log_message "Installing Rust toolchain via luggage..."
 
-# Determine rustup target triple based on architecture
-RUSTUP_TARGET=$(map_arch "x86_64-unknown-linux-gnu" "aarch64-unknown-linux-gnu")
+# Export CARGO_HOME/RUSTUP_HOME so luggage's post-install validation step —
+# which runs `rustc --version` via the rustup proxy — can locate the
+# toolchain it just installed. Without these, the proxy looks at
+# `$HOME/.rustup` and reports "no default toolchain configured".
+export CARGO_HOME RUSTUP_HOME
 
-log_message "Installing rustup for ${RUSTUP_TARGET}..."
-
-# Define download URLs
-RUSTUP_URL="https://static.rust-lang.org/rustup/dist/${RUSTUP_TARGET}/rustup-init"
-
-# Register Tier 3 fetcher for rustup-init (published checksum from rust-lang.org)
-_fetch_rustup_init_checksum() {
-    local _version="$1"
-    local _arch="$2"
-    local _target
-    case "$_arch" in
-        amd64) _target="x86_64-unknown-linux-gnu" ;;
-        arm64) _target="aarch64-unknown-linux-gnu" ;;
-        *) _target="$_arch" ;;
-    esac
-    local _url="https://static.rust-lang.org/rustup/dist/${_target}/rustup-init.sha256"
-    command curl -fsSL "$_url" 2>/dev/null | command awk '{print $1}'
-}
-register_tool_checksum_fetcher "rustup-init" "_fetch_rustup_init_checksum"
-
-# Download rustup-init
-BUILD_TEMP=$(create_secure_temp_dir)
-cd "$BUILD_TEMP"
-log_message "Downloading rustup-init..."
-if ! command curl -L -f --retry 8 --retry-delay 10 --retry-all-errors --progress-bar -o "rustup-init" "$RUSTUP_URL"; then
-    log_error "Failed to download rustup-init"
-    log_feature_end
-    exit 1
+if [[ "$RUST_VERSION" =~ ^(stable|beta|nightly)$ ]]; then
+    log_command "luggage install rust --channel ${RUST_VERSION}" \
+        /usr/local/bin/luggage install rust \
+        --channel "${RUST_VERSION}" \
+        --catalog "${CONTAINERS_DB:-/opt/containers-db}" \
+        --user "${USERNAME}" \
+        --cache-root /cache \
+        --log-dir /var/log/luggage
+else
+    log_command "luggage install rust@${RUST_VERSION}" \
+        /usr/local/bin/luggage install "rust@${RUST_VERSION}" \
+        --catalog "${CONTAINERS_DB:-/opt/containers-db}" \
+        --user "${USERNAME}" \
+        --cache-root /cache \
+        --log-dir /var/log/luggage
 fi
-
-# Run 4-tier verification
-ARCH_DEB=$(dpkg --print-architecture)
-verify_download_or_fail "tool" "rustup-init" "$RUST_VERSION" "rustup-init" "$ARCH_DEB" || {
-    log_feature_end
-    exit 1
-}
-
-# Make executable
-log_command "Making rustup-init executable" \
-    chmod +x rustup-init
-
-# Run rustup-init as the target user with verified binary
-log_command "Installing Rust via verified rustup" \
-    su - "${USERNAME}" -c "
-    export CARGO_HOME='${CARGO_HOME}'
-    export RUSTUP_HOME='${RUSTUP_HOME}'
-
-    # Run verified rustup installer
-    ${BUILD_TEMP}/rustup-init -y \
-        --default-toolchain ${RUST_VERSION} \
-        --profile default
-
-    # Source cargo environment to make rustup/cargo available
-    source ${CARGO_HOME}/env
-
-    # Add essential Rust components
-    # - rust-src: Rust standard library source (needed by rust-analyzer)
-    # - rust-analyzer: Official LSP for IDE support
-    # - clippy: Linting tool for common mistakes and style
-    # - rustfmt: Code formatter
-    rustup component add rust-src rust-analyzer clippy rustfmt
-"
-
-cd /
-log_command "Cleaning up build directory" \
-    command rm -rf "$BUILD_TEMP"
 
 # Install additional Cargo tools
 # These enhance the development experience but aren't required for basic Rust usage

--- a/tests/integration/builds/luggage_rust/Dockerfile.luggage-rust
+++ b/tests/integration/builds/luggage_rust/Dockerfile.luggage-rust
@@ -35,9 +35,12 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends adduser ca-certificates curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Match the production user setup.
+# Match the production user setup. lib/features/rust.sh pre-creates the
+# cargo/rustup cache subdirs and chowns them to the install user before
+# invoking luggage; the fixture mirrors that so `su -c rustup-init` can
+# write `/cache/rustup/settings.toml` without a permission error.
 RUN adduser --disabled-password --gecos '' --shell /bin/bash vscode \
-    && mkdir -p /cache /var/log/luggage \
+    && mkdir -p /cache/cargo /cache/rustup /var/log/luggage \
     && chown -R vscode:vscode /cache /var/log/luggage
 ENV USERNAME=vscode
 
@@ -48,16 +51,21 @@ COPY crates/luggage/testdata/catalog /opt/containers-db
 # Run the install. `--catalog` points at the in-tree testdata catalog —
 # the same one the resolver tests use — so this build is reproducible
 # from a single Cargo.lock without depending on the live containers-db
-# repo.
+# repo. Platform is auto-detected from /etc/os-release + ARCH so the
+# fixture works on amd64 and arm64 build hosts alike.
+#
+# CARGO_HOME / RUSTUP_HOME are exported so luggage's post-install
+# validation (`rustc --version` via the rustup proxy) can locate the
+# toolchain — without them the proxy reports "no default toolchain".
+ENV CARGO_HOME=/cache/cargo \
+    RUSTUP_HOME=/cache/rustup
 RUN /usr/local/bin/luggage install "rust@${RUST_VERSION}" \
     --catalog /opt/containers-db \
-    --os debian --os-version 13 --arch amd64 \
     --user vscode
 
-# Sanity touchstone for the parity test driver.
-ENV CARGO_HOME=/cache/cargo \
-    RUSTUP_HOME=/cache/rustup \
-    PATH="/cache/cargo/bin:/usr/local/bin:${PATH}"
+# Sanity touchstone for the smoke test driver. CARGO_HOME / RUSTUP_HOME
+# are already set above for the install RUN; here we just add the PATH.
+ENV PATH="/cache/cargo/bin:/usr/local/bin:${PATH}"
 
 USER vscode
 WORKDIR /home/vscode

--- a/tests/integration/builds/test_luggage_rust.sh
+++ b/tests/integration/builds/test_luggage_rust.sh
@@ -1,21 +1,17 @@
 #!/usr/bin/env bash
-# Parity test: `luggage install rust@1.95.0` vs `lib/features/rust.sh`.
+# Smoke test: `luggage install rust@<RUST_VERSION>` end-state.
 #
-# Issue #405 — verifies the new Rust executor produces the same observable
-# end-state (rustc/cargo/rustup on PATH, matching version, CARGO_HOME and
-# RUSTUP_HOME pinned to /cache) as the bash feature script. Closes the
-# acceptance criterion: "integration test compares luggage-installed vs
-# bash-installed rust toolchain".
+# Issue #407 — once lib/features/rust.sh delegates to luggage, the
+# previous bash-vs-luggage parity comparison becomes self-comparison.
+# What still earns its keep is a single-image build that verifies the
+# luggage path produces a working rust toolchain in isolation from
+# lib/base/* and lib/features/*. The fixture catches catalog-format
+# regressions and installer-engine bugs before they reach the
+# production-path test (test_rust_golang.sh).
 #
-# Strategy:
-#  - Image A is built via the main `Dockerfile` with INCLUDE_RUST=true.
-#    This is the same path lefthook & CI exercise; it proves the bash
-#    feature script's end-state without us re-creating `lib/base/*`.
-#  - Image B is built via a minimal fixture Dockerfile next to this test.
-#    It compiles luggage from source, then runs `luggage install rust@1.95.0`.
-#  - The same assertion suite runs against both images. Any drift fails.
+# See docs/architecture/luggage-migration.md for the migration playbook.
 #
-# Both builds touch the network (rustup-init download). Run via:
+# This build touches the network (rustup-init download). Run via:
 #   just test-integration-one luggage_rust
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -30,26 +26,11 @@ export BUILD_CONTEXT="$CONTAINERS_DIR"
 LUGGAGE_FIXTURE="$SCRIPT_DIR/luggage_rust/Dockerfile.luggage-rust"
 RUST_VERSION="1.95.0"
 
-test_suite "luggage install rust@${RUST_VERSION} parity"
+test_suite "luggage install rust@${RUST_VERSION} smoke"
 
 LUGGAGE_IMAGE="test-luggage-rust-$$"
-BASH_IMAGE="test-bash-rust-$$"
 
-# Build image A — production Dockerfile with INCLUDE_RUST=true.
-build_bash_image() {
-    if [ -n "${IMAGE_TO_TEST:-}" ]; then
-        BASH_IMAGE="$IMAGE_TO_TEST"
-        return 0
-    fi
-    assert_build_succeeds "Dockerfile" \
-        --build-arg PROJECT_PATH=. \
-        --build-arg PROJECT_NAME=parity-bash \
-        --build-arg INCLUDE_RUST=true \
-        --build-arg RUST_VERSION="$RUST_VERSION" \
-        -t "$BASH_IMAGE"
-}
-
-# Build image B — minimal fixture that runs `luggage install`.
+# Build the minimal fixture that runs `luggage install` directly.
 build_luggage_image() {
     if [ -n "${IMAGE_TO_TEST:-}" ]; then
         LUGGAGE_IMAGE="$IMAGE_TO_TEST"
@@ -60,7 +41,6 @@ build_luggage_image() {
         -t "$LUGGAGE_IMAGE"
 }
 
-# Same assertion bundle runs against both images. Any drift surfaces here.
 assert_rust_endstate() {
     local image="$1"
     assert_executable_in_path "$image" "rustc"
@@ -68,14 +48,9 @@ assert_rust_endstate() {
     assert_executable_in_path "$image" "rustup"
     assert_command_in_container "$image" "rustc --version" "$RUST_VERSION"
     assert_command_in_container "$image" "cargo --version" "cargo"
-    # CARGO_HOME / RUSTUP_HOME pinned to /cache in both paths.
+    # CARGO_HOME / RUSTUP_HOME pinned to /cache.
     assert_command_in_container "$image" \
         'rustup show home 2>/dev/null || echo "${RUSTUP_HOME:-not-set}"' "/cache/rustup"
-}
-
-test_bash_path_endstate() {
-    build_bash_image
-    assert_rust_endstate "$BASH_IMAGE"
 }
 
 test_luggage_path_endstate() {
@@ -83,23 +58,6 @@ test_luggage_path_endstate() {
     assert_rust_endstate "$LUGGAGE_IMAGE"
 }
 
-# Compare the X.Y.Z version literal across both images. Catalog and
-# RUST_VERSION build-arg both pin "1.95.0"; if either path drifts, the
-# diff shows up here rather than in a downstream consumer.
-test_versions_match() {
-    local bash_v luggage_v
-    bash_v=$(docker run --rm "$BASH_IMAGE" rustc --version 2>/dev/null | command awk '{print $2}')
-    luggage_v=$(docker run --rm "$LUGGAGE_IMAGE" rustc --version 2>/dev/null | command awk '{print $2}')
-    if [ "$bash_v" = "$luggage_v" ]; then
-        return 0
-    fi
-    tf_fail_assertion "rustc versions should match across installers" \
-        "bash:    $bash_v" \
-        "luggage: $luggage_v"
-}
-
-run_test test_bash_path_endstate "lib/features/rust.sh produces a working rust toolchain"
 run_test test_luggage_path_endstate "luggage install produces a working rust toolchain"
-run_test test_versions_match "rustc version matches across both installers"
 
 generate_report

--- a/tests/unit/features/rust.sh
+++ b/tests/unit/features/rust.sh
@@ -352,11 +352,15 @@ run_test_with_setup() {
 }
 
 # ============================================================================
-# Checksum Verification Tests
+# Luggage Migration Tests (issue #407)
 # ============================================================================
+# Rust.sh delegates toolchain installation to `luggage install`. The bash
+# script no longer downloads rustup-init or runs the legacy 4-tier
+# verification helpers — those moved into the luggage installer engine.
+# See docs/architecture/luggage-migration.md.
 
-# Test: rust.sh sources checksum libraries
-test_checksum_libraries_sourced() {
+# Test: rust.sh delegates the toolchain install to luggage
+test_luggage_invocation() {
     local rust_script="$PROJECT_ROOT/lib/features/rust.sh"
 
     if ! [ -f "$rust_script" ]; then
@@ -364,23 +368,23 @@ test_checksum_libraries_sourced() {
         return
     fi
 
-    # Check for checksum-fetch.sh
-    if command grep -q "source.*checksum-fetch.sh" "$rust_script"; then
-        assert_true true "checksum-fetch.sh library is sourced"
+    if command grep -qE '/usr/local/bin/luggage install ("rust@|rust )' "$rust_script"; then
+        assert_true true "rust.sh invokes /usr/local/bin/luggage install for rust"
     else
-        assert_true false "checksum-fetch.sh library not sourced"
+        assert_true false "rust.sh does not invoke luggage install for rust"
     fi
 
-    # Check for download-verify.sh
-    if command grep -q "source.*download-verify.sh" "$rust_script"; then
-        assert_true true "download-verify.sh library is sourced"
+    # The shim must point at the vendored catalog so production builds work
+    # without a sibling containers-db checkout.
+    if command grep -q 'CONTAINERS_DB:-/opt/containers-db' "$rust_script"; then
+        assert_true true "luggage call defaults to /opt/containers-db catalog"
     else
-        assert_true false "download-verify.sh library not sourced"
+        assert_true false "luggage call missing /opt/containers-db default"
     fi
 }
 
-# Test: rust.sh uses register_tool_checksum_fetcher for rustup
-test_rustup_checksum_fetching() {
+# Test: rust.sh no longer ships the inline rustup-init install path
+test_no_inline_rustup_install() {
     local rust_script="$PROJECT_ROOT/lib/features/rust.sh"
 
     if ! [ -f "$rust_script" ]; then
@@ -388,16 +392,15 @@ test_rustup_checksum_fetching() {
         return
     fi
 
-    # Check for register_tool_checksum_fetcher usage for rustup-init
-    if command grep -q 'register_tool_checksum_fetcher.*rustup' "$rust_script"; then
-        assert_true true "Uses register_tool_checksum_fetcher for rustup"
+    if command grep -qE 'curl[^\n]+rustup-init|register_tool_checksum_fetcher|verify_download_or_fail' "$rust_script"; then
+        assert_true false "rust.sh still contains inline rustup-init install logic"
     else
-        assert_true false "Does not use register_tool_checksum_fetcher for rustup"
+        assert_true true "rust.sh no longer contains inline rustup-init install logic"
     fi
 }
 
-# Test: rust.sh uses verify_download
-test_download_verification() {
+# Test: rust.sh still handles channel names (stable/beta/nightly) explicitly
+test_channel_routing() {
     local rust_script="$PROJECT_ROOT/lib/features/rust.sh"
 
     if ! [ -f "$rust_script" ]; then
@@ -405,11 +408,13 @@ test_download_verification() {
         return
     fi
 
-    # Check for verify_download usage (4-tier verification)
-    if command grep -q "verify_download" "$rust_script"; then
-        assert_true true "Uses verify_download for checksum verification"
+    # Channel names must route through `--channel` so the catalog resolver
+    # picks the highest version in that channel rather than treating the
+    # name as a partial version literal.
+    if command grep -qE '(stable\|beta\|nightly).*--channel|--channel.*RUST_VERSION' "$rust_script"; then
+        assert_true true "Channel names route through luggage --channel"
     else
-        assert_true false "Does not use verify_download"
+        assert_true false "Channel names not routed through luggage --channel"
     fi
 }
 
@@ -425,10 +430,10 @@ run_test_with_setup test_cargo_toml_detection "Cargo.toml detection works"
 run_test_with_setup test_rust_permissions "Rust directories have correct permissions"
 run_test_with_setup test_rust_verification "Rust verification script works"
 
-# Checksum verification tests
-run_test test_checksum_libraries_sourced "Checksum libraries are sourced"
-run_test test_rustup_checksum_fetching "Rustup register_tool_checksum_fetcher is used"
-run_test test_download_verification "Download verification is used"
+# Luggage migration tests
+run_test test_luggage_invocation "rust.sh delegates toolchain install to luggage"
+run_test test_no_inline_rustup_install "rust.sh strips inline rustup-init download/verify logic"
+run_test test_channel_routing "Channel names (stable/beta/nightly) route through --channel"
 
 # Generate test report
 generate_report


### PR DESCRIPTION
## Summary

Pilot port of the bash→luggage migration. `lib/features/rust.sh` stops
downloading + verifying + running rustup-init inline and instead shells out
to `luggage install rust@${RUST_VERSION}` (catalog lives in
`/opt/containers-db`, vendored from `crates/luggage/testdata/catalog` by the
new `luggage-builder` Dockerfile stage). The feature script keeps the parts
that wire rust into the image — cache dirs, cargo-tool installs, symlinks,
bashrc fragment, PATH contribution, ownership — and drops everything that
moved into the luggage installer engine.

Channel names (`stable`/`beta`/`nightly`) route through `--channel`;
semver-shaped values use `rust@<v>`.

## Test plan

- [x] Unit suite: `./tests/run_unit_tests.sh` — 2977/2977 pass, including 3
  new luggage-migration assertions in `tests/unit/features/rust.sh`
- [x] Repurposed luggage smoke: `just test-integration-one luggage_rust` —
  single-image `luggage install rust@1.95.0` end-state check passes on arm64
- [x] Production-path: `just test-integration-one rust_golang` — full
  `Dockerfile` build with `INCLUDE_RUST_DEV=true` + Go, 8/8 assertions pass
- [x] Lint: hadolint exit 0, shellcheck clean on all modified scripts

## Notable side fixes

Two pre-existing luggage gaps surfaced while validating the smoke fixture on
arm64; both worked around here and worth filing as follow-ups against the
luggage crate:

1. `installer/script_installer.rs` `create_dir_all`s the cache subdirs as
   root, then `su -c rustup-init` runs as vscode and can't write
   `/cache/rustup/settings.toml`. The smoke fixture now pre-creates the
   subdirs with vscode ownership, matching what `lib/features/rust.sh`
   already does in the production path.
2. `installer/validate.rs` runs `<bin_root>/<tool> --version` without
   propagating `CARGO_HOME` / `RUSTUP_HOME`, so the rustup proxy can't find
   the toolchain it just installed. `rust.sh` now `export`s both before the
   luggage call.

The smoke test itself goes from "bash-vs-luggage parity" to a single-image
end-state check — once the production path *is* luggage, the comparison is
self-comparison.

## Docs

New `docs/architecture/luggage-migration.md` is the playbook for porting the
next feature script (split of what stays in bash vs moves to luggage, the
catalog-vendoring choice, the per-feature recipe).

Closes #407