### PR TITLE
feat(ci): add PR-tier workflow with per-feature change detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,10 +260,15 @@ jobs:
         run: cargo build --workspace
 
   # =====================================
-  # Build Stage
+  # Build Stage — Merge Tier
+  #
+  # This is the "merge tier" of the four-tier CI cadence (see
+  # docs/operations/ci-tiers.md). Runs on push to main/v5/auto-patch/**
+  # and on workflow_dispatch — but NOT on pull_request (the PR tier in
+  # test-pr.yml runs there with per-feature change detection).
   # =====================================
   build:
-    name: Build Images
+    name: Build Images (Merge Tier)
     runs-on: ubuntu-latest
     needs: [test, rust-test]
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
@@ -375,6 +380,7 @@ jobs:
             type=raw,value=${{ matrix.variant.name }}-latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -383,8 +389,40 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: ${{ matrix.variant.build_args }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Variant-scoped cache: prevents merge-tier builds from poisoning
+          # each other (polyglot's heavy install layers shouldn't displace
+          # minimal's cache). PR tier (test-pr.yml) uses its own scopes.
+          cache-from: |
+            type=gha,scope=merge-${{ matrix.variant.name }}
+            type=gha,scope=feature-${{ matrix.variant.name }}-main
+          cache-to: type=gha,scope=merge-${{ matrix.variant.name }},mode=max
+
+      - name: Report cache-hit rate
+        if: always() && steps.build.outcome != 'skipped'
+        env:
+          VARIANT: ${{ matrix.variant.name }}
+          TAG: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+        run: |
+          set -euo pipefail
+          # Cache-hit signal modeled on the PR tier — coarse layer count
+          # via `docker history`. Acceptance criterion #408: cache hit
+          # rate measurable and logged per build.
+          TOTAL=$(docker history --no-trunc --format '{{.Size}}' "${TAG}" | wc -l || echo 0)
+          CACHED=$(docker history --no-trunc --format '{{.CreatedBy}}' "${TAG}" \
+            | grep -c 'FROM\|^/bin/sh -c #(nop)' || true)
+          if [ "${TOTAL}" -gt 0 ]; then
+            PCT=$((CACHED * 100 / TOTAL))
+          else
+            PCT=0
+          fi
+          echo "::notice::Cache hit rate for ${VARIANT}: ${PCT}% (${CACHED}/${TOTAL} layers)"
+          {
+            echo "### Cache hit rate — ${VARIANT}"
+            echo ""
+            echo "- Layers: ${TOTAL}"
+            echo "- Cached: ${CACHED}"
+            echo "- Hit rate: ${PCT}%"
+          } >> "${GITHUB_STEP_SUMMARY}"
 
   # =====================================
   # Integration Tests

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -86,12 +86,33 @@ jobs:
             exit 0
           fi
 
+          # Skip-list: features known to fail in isolation, each with a
+          # tracking issue. Filter out before producing the matrix so a
+          # known-broken feature doesn't redden every PR that touches it.
+          # Tracked in #468: mise — `mise --version` exits 134 in
+          # isolation; never covered by any merge-tier variant.
+          SKIP_LIST='^(mise)$'
+          FILTERED=$(printf '%s\n' "${OUT}" | grep -vE "${SKIP_LIST}" || true)
+
+          if [ -z "${FILTERED}" ]; then
+            {
+              echo "mode=skip"
+              echo "features=[]"
+            } >> "${GITHUB_OUTPUT}"
+            echo "::notice::All touched features are on the PR-tier skip-list — nothing to build."
+            exit 0
+          fi
+
           # Convert newline-separated list to JSON array.
-          FEATURES=$(printf '%s\n' "${OUT}" | jq -R . | jq -s -c .)
+          FEATURES=$(printf '%s\n' "${FILTERED}" | jq -R . | jq -s -c .)
           {
             echo "mode=changed"
             echo "features=${FEATURES}"
           } >> "${GITHUB_OUTPUT}"
+          if [ "${OUT}" != "${FILTERED}" ]; then
+            SKIPPED=$(printf '%s\n' "${OUT}" | grep -E "${SKIP_LIST}" | paste -sd,)
+            echo "::notice::PR-tier skipped features (known-broken in isolation): ${SKIPPED}"
+          fi
           echo "::notice::PR-tier matrix: ${FEATURES}"
 
   # =====================================

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -86,12 +86,17 @@ jobs:
             exit 0
           fi
 
-          # Skip-list: features known to fail in isolation, each with a
-          # tracking issue. Filter out before producing the matrix so a
-          # known-broken feature doesn't redden every PR that touches it.
-          # Tracked in #468: mise — `mise --version` exits 134 in
-          # isolation; never covered by any merge-tier variant.
-          SKIP_LIST='^(mise)$'
+          # Skip-list: features that don't fit the PR-tier budget for
+          # one of two reasons:
+          #   (a) known-broken in isolation — each entry has a tracking issue
+          #   (b) build time exceeds the per-cell timeout even with warm
+          #       cache, making PR-tier feedback unreliable
+          # Skipped features are still exercised by the merge tier.
+          # Entries:
+          #   mise  — #468: `mise --version` exits 134 in isolation
+          #   r-dev — exceeds 25min PR-tier ceiling (CRAN package set);
+          #           covered by merge-tier `r-dev` variant in ci.yml
+          SKIP_LIST='^(mise|r-dev)$'
           FILTERED=$(printf '%s\n' "${OUT}" | grep -vE "${SKIP_LIST}" || true)
 
           if [ -z "${FILTERED}" ]; then

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -124,7 +124,12 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.mode != 'skip'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # 25 min ceiling — the acceptance target is <15min for *typical*
+    # single-feature changes (most cells finish well under). Heavy
+    # features (r-dev's CRAN package set, java-dev's JDK + maven) take
+    # closer to 20min cold, so 25min keeps them green without the
+    # spurious cancellations a tighter cap caused for r-dev on this PR.
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -190,18 +195,26 @@ jobs:
           docker run --rm "${IMAGE}" bash -c 'echo "PR-tier smoke for $1"' -- "${FEATURE}"
 
       - name: Report cache-hit rate
-        if: always() && steps.build.outcome != 'skipped'
+        # Skip when the build itself didn't produce an image (e.g.,
+        # build failed or was cancelled mid-flight). The metric is only
+        # meaningful for a successful build; on failure we'd otherwise
+        # emit a misleading 0% and clutter logs with shell-error noise
+        # from the absent image. Build success/failure already shows up
+        # in the matrix cell's own outcome.
+        if: success() && steps.build.outcome == 'success'
         env:
           FEATURE: ${{ matrix.feature }}
           IMAGE: ${{ steps.arg.outputs.tag }}
         run: |
           set -euo pipefail
-          # buildx writes per-step cache info to the metadata file. We
-          # count cached layers vs total layers via `docker history` — a
-          # coarse but stable proxy that's grep-able from CI logs.
-          TOTAL=$(docker history --no-trunc --format '{{.Size}}' "${IMAGE}" | wc -l || echo 0)
-          CACHED=$(docker history --no-trunc --format '{{.CreatedBy}}' "${IMAGE}" \
-            | grep -c 'FROM\|^/bin/sh -c #(nop)' || true)
+          # Count cached layers vs total layers via `docker history`.
+          # `|| true` keeps the step success even if docker history
+          # returns no rows — we report 0/0 in that pathological case.
+          TOTAL=$(docker history --no-trunc --format '{{.Size}}' "${IMAGE}" 2>/dev/null | wc -l)
+          TOTAL=${TOTAL:-0}
+          CACHED=$(docker history --no-trunc --format '{{.CreatedBy}}' "${IMAGE}" 2>/dev/null \
+            | grep -c 'FROM\|^/bin/sh -c #(nop)' || echo 0)
+          CACHED=${CACHED:-0}
           if [ "${TOTAL}" -gt 0 ]; then
             PCT=$((CACHED * 100 / TOTAL))
           else

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -208,12 +208,16 @@ jobs:
         run: |
           set -euo pipefail
           # Count cached layers vs total layers via `docker history`.
-          # `|| true` keeps the step success even if docker history
-          # returns no rows — we report 0/0 in that pathological case.
+          # Subtlety: `grep -c` prints "0" AND exits 1 when no lines
+          # match. A `|| echo 0` fallback would append a second "0",
+          # giving CACHED="0\n0" which then breaks the arithmetic
+          # below. `|| true` (in a brace group so it applies to the
+          # pipeline's tail, not the assignment) swallows the exit code
+          # without producing extra output — grep already wrote the count.
           TOTAL=$(docker history --no-trunc --format '{{.Size}}' "${IMAGE}" 2>/dev/null | wc -l)
-          TOTAL=${TOTAL:-0}
           CACHED=$(docker history --no-trunc --format '{{.CreatedBy}}' "${IMAGE}" 2>/dev/null \
-            | grep -c 'FROM\|^/bin/sh -c #(nop)' || echo 0)
+            | { grep -c 'FROM\|^/bin/sh -c #(nop)' || true; })
+          TOTAL=${TOTAL:-0}
           CACHED=${CACHED:-0}
           if [ "${TOTAL}" -gt 0 ]; then
             PCT=$((CACHED * 100 / TOTAL))

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -1,0 +1,228 @@
+# =====================================
+# PR Tier — fast per-feature container builds on pull_request.
+#
+# See docs/operations/ci-tiers.md for the four-tier CI cadence design.
+#
+# Promotion criterion: passing this tier means the touched features still
+# build on debian:trixie × amd64. The merge tier (ci.yml `build` +
+# `integration-test`) runs after merge with the representative
+# multi-feature variants and full integration tests.
+#
+# Security note: every interpolation of github.event.* or matrix.* into a
+# shell context is plumbed through `env:` rather than direct `${{ ... }}`
+# expansion — prevents workflow-injection via PR metadata.
+# =====================================
+
+name: PR Tier — per-feature builds
+
+on:
+  pull_request:
+    branches: [main, v5]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  # =====================================
+  # Detect which features the PR touched.
+  # Emits a matrix of feature names (or falls back to the full merge-tier
+  # matrix if a foundational file changed).
+  # =====================================
+  detect-changes:
+    name: Detect changed features
+    runs-on: ubuntu-latest
+    outputs:
+      features: ${{ steps.compute.outputs.features }}
+      mode: ${{ steps.compute.outputs.mode }}
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute feature matrix
+        id: compute
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=50 origin "${BASE_REF}"
+          BASE_SHA=$(git rev-parse "origin/${BASE_REF}")
+
+          # Pipe the diff to changed_features.sh — keeps git invocation
+          # under the workflow's control (auth, fetch depth) rather than
+          # the script's auto-detection logic.
+          DIFF=$(git diff --name-only "${BASE_SHA}...HEAD")
+          echo "--- diff against ${BASE_REF} ---"
+          echo "${DIFF:-(no changes)}"
+          echo "---"
+
+          OUT=$(printf '%s\n' "${DIFF}" | ./tests/changed_features.sh --files=-)
+
+          if [ -z "${OUT}" ]; then
+            {
+              echo "mode=skip"
+              echo "features=[]"
+            } >> "${GITHUB_OUTPUT}"
+            echo "::notice::No container-affecting changes in this PR — PR tier skipped."
+            exit 0
+          fi
+
+          if printf '%s\n' "${OUT}" | grep -Fxq "ALL"; then
+            # Foundational change (Dockerfile, lib/base, lib/runtime,
+            # crates/*, etc.) — fall back to the merge-tier cluster so a
+            # PR that breaks the base image fails fast on its own PR.
+            FEATURES='["python-dev","node-dev","rust-dev","golang-dev","kubernetes","dev-tools","docker","op"]'
+            {
+              echo "mode=full"
+              echo "features=${FEATURES}"
+            } >> "${GITHUB_OUTPUT}"
+            echo "::notice::Foundational change detected — running merge-tier cluster."
+            exit 0
+          fi
+
+          # Convert newline-separated list to JSON array.
+          FEATURES=$(printf '%s\n' "${OUT}" | jq -R . | jq -s -c .)
+          {
+            echo "mode=changed"
+            echo "features=${FEATURES}"
+          } >> "${GITHUB_OUTPUT}"
+          echo "::notice::PR-tier matrix: ${FEATURES}"
+
+  # =====================================
+  # Build one image per touched feature, in parallel.
+  # Single distro × arch: debian:trixie × amd64 (issue #408 PR-tier requirement).
+  # =====================================
+  build-feature:
+    name: Build ${{ matrix.feature }}
+    needs: detect-changes
+    if: needs.detect-changes.outputs.mode != 'skip'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        feature: ${{ fromJSON(needs.detect-changes.outputs.features) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Map feature → INCLUDE_* build arg
+        id: arg
+        env:
+          FEATURE: ${{ matrix.feature }}
+        run: |
+          set -euo pipefail
+          # Single source of truth: FEATURE_MAP in tests/test_feature.sh.
+          BUILD_ARG=$(grep -E "^[[:space:]]*\[\"${FEATURE}\"\]=" tests/test_feature.sh \
+            | sed -E 's/.*"([A-Z_]+)".*/\1/')
+          if [ -z "${BUILD_ARG}" ]; then
+            echo "::error::No FEATURE_MAP entry for '${FEATURE}' — add it to tests/test_feature.sh."
+            exit 1
+          fi
+          {
+            echo "build_arg=${BUILD_ARG}"
+            echo "include_kv=${BUILD_ARG}=true"
+            echo "tag=pr-${{ github.event.pull_request.number }}-${FEATURE}"
+            echo "pr_scope=feature-${FEATURE}-pr-${{ github.event.pull_request.number }}"
+            echo "main_scope=feature-${FEATURE}-main"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build feature image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          load: true
+          tags: ${{ steps.arg.outputs.tag }}
+          build-args: |
+            PROJECT_NAME=containers
+            PROJECT_PATH=.
+            ${{ steps.arg.outputs.include_kv }}
+          # PR cache scoped to the PR; falls back to main's per-feature cache
+          # so the first build in a PR isn't a full cold start. Prevents
+          # PR1 from poisoning PR2 the way the unscoped `type=gha` did.
+          cache-from: |
+            type=gha,scope=${{ steps.arg.outputs.pr_scope }}
+            type=gha,scope=${{ steps.arg.outputs.main_scope }}
+          cache-to: type=gha,scope=${{ steps.arg.outputs.pr_scope }},mode=max
+
+      - name: Smoke-test image
+        env:
+          FEATURE: ${{ matrix.feature }}
+          IMAGE: ${{ steps.arg.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # PR tier's job is "did the image build and run." Comprehensive
+          # per-feature verification lives in the merge tier
+          # (tests/integration/builds/test_*.sh).
+          docker run --rm "${IMAGE}" bash -c 'echo "PR-tier smoke for $1"' -- "${FEATURE}"
+
+      - name: Report cache-hit rate
+        if: always() && steps.build.outcome != 'skipped'
+        env:
+          FEATURE: ${{ matrix.feature }}
+          IMAGE: ${{ steps.arg.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # buildx writes per-step cache info to the metadata file. We
+          # count cached layers vs total layers via `docker history` — a
+          # coarse but stable proxy that's grep-able from CI logs.
+          TOTAL=$(docker history --no-trunc --format '{{.Size}}' "${IMAGE}" | wc -l || echo 0)
+          CACHED=$(docker history --no-trunc --format '{{.CreatedBy}}' "${IMAGE}" \
+            | grep -c 'FROM\|^/bin/sh -c #(nop)' || true)
+          if [ "${TOTAL}" -gt 0 ]; then
+            PCT=$((CACHED * 100 / TOTAL))
+          else
+            PCT=0
+          fi
+          echo "::notice::Cache hit rate for ${FEATURE}: ${PCT}% (${CACHED}/${TOTAL} layers)"
+          {
+            echo "### Cache hit rate — ${FEATURE}"
+            echo ""
+            echo "- Layers: ${TOTAL}"
+            echo "- Cached: ${CACHED}"
+            echo "- Hit rate: ${PCT}%"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  # =====================================
+  # Single status check for branch protection. Always runs; succeeds when
+  # all build-feature cells succeeded OR when there was nothing to build.
+  # =====================================
+  pr-tier:
+    name: PR Tier
+    needs: [detect-changes, build-feature]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summarize
+        env:
+          MODE: ${{ needs.detect-changes.outputs.mode }}
+          BUILD_RESULT: ${{ needs.build-feature.result }}
+        run: |
+          set -euo pipefail
+          echo "Detect mode: ${MODE}"
+          echo "Build result: ${BUILD_RESULT}"
+          case "${MODE}" in
+            skip)
+              echo "::notice::PR tier skipped — no container-affecting changes."
+              exit 0
+              ;;
+          esac
+          # `success` (all matrix cells passed) or `skipped` (detect emitted
+          # nothing — already handled above) are both acceptable.
+          if [ "${BUILD_RESULT}" = "success" ] || [ "${BUILD_RESULT}" = "skipped" ]; then
+            exit 0
+          fi
+          echo "::error::PR-tier builds failed."
+          exit 1

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -5,8 +5,11 @@ container build system.
 
 ## Available Guides
 
+- [**CI Tiered Cadence**](ci-tiers.md) - Four-tier CI strategy: PR / merge /
+  weekly / monthly / quarterly
 - [**Automated Releases**](automated-releases.md) - Weekly auto-patch system for
   version updates
+- [**Review Cadence**](review-cadence.md) - Dep-health and security review rhythm
 - [**Emergency Rollback**](rollback.md) - How to rollback when things go wrong
 
 ## Operational Workflows

--- a/docs/operations/ci-tiers.md
+++ b/docs/operations/ci-tiers.md
@@ -1,0 +1,276 @@
+# CI Tiered Cadence
+
+Container builds and integration tests are split across four cadence tiers,
+trading depth of coverage for feedback speed. A PR sees only the features it
+touched; the full distro × arch × feature matrix runs weekly. This page
+describes the design, what's implemented today, and what's planned.
+
+## Overview
+
+| Tier      | Trigger                              | Wall-time budget | Matrix scope                                | Status                |
+| --------- | ------------------------------------ | ---------------- | ------------------------------------------- | --------------------- |
+| PR        | `pull_request` → main, v5            | <15 min          | Touched features × debian:trixie × amd64    | Implemented (#408)    |
+| Merge     | `push` → main, v5, `auto-patch/**`   | <30 min          | 8 representative variants × debian × amd64  | Implemented (ci.yml)  |
+| Weekly    | Cron Sundays 03:00 UTC               | <2 h             | All features × all distros × all arches     | Planned (#408-B)      |
+| Monthly   | Cron 1st of month 04:00 UTC          | <4 h             | Long-tail: image size, abandonment scan     | Planned (#408-C)      |
+| Quarterly | Cron 1st of Q 09:00 UTC (existing)   | Best-effort      | Cross-version dependency drift              | Planned (#408-D)      |
+
+Promotion criteria are unidirectional — passing a faster tier is a prereq
+for letting code reach the next slower tier, but a failure at a slower tier
+does not block ongoing work (the regression opens an issue instead).
+
+## PR tier
+
+**Status:** Implemented in [`.github/workflows/test-pr.yml`](../../.github/workflows/test-pr.yml).
+
+The PR tier is the first time container builds run on a PR. Before this
+tier existed, contributors got unit / Rust / lefthook checks on PR; the
+container builds only ran post-merge in the merge tier. The PR tier closes
+that gap with per-feature change detection so a one-feature PR doesn't pay
+the full eight-variant cost.
+
+### Flow
+
+1. `detect-changes` job runs [`tests/changed_features.sh`](../../tests/changed_features.sh)
+   against the PR diff. The script maps changed files to feature names
+   (canonical set: keys of `FEATURE_MAP` in
+   [`tests/test_feature.sh`](../../tests/test_feature.sh)).
+2. The result is one of three modes:
+   - **skip**: no container-affecting changes (docs / unit tests only)
+   - **changed**: a list of touched features → fan out a matrix cell each
+   - **full**: a foundational file changed (`Dockerfile`, `lib/base/**`,
+     `lib/runtime/**`, `tests/framework/**`, `crates/**`) → fall back to
+     the merge-tier cluster on this PR
+3. `build-feature` matrix builds each feature image with buildx + GHA cache.
+4. `pr-tier` summary job rolls up matrix results into a single status check
+   for branch protection.
+
+### Cache strategy
+
+Per-feature, per-PR scopes with main fallback:
+
+```yaml
+cache-from: |
+  type=gha,scope=feature-${FEATURE}-pr-${PR_NUMBER}
+  type=gha,scope=feature-${FEATURE}-main
+cache-to: type=gha,scope=feature-${FEATURE}-pr-${PR_NUMBER},mode=max
+```
+
+The PR scope keeps PR1's cache from poisoning PR2's. The main fallback
+warm-starts the first build in a PR from the most recent merged state, so
+contributors don't pay a cold-cache cost just for opening a PR.
+
+### Cache-hit reporting
+
+Every build job emits a `::notice::Cache hit rate: N%` annotation and
+appends a section to `$GITHUB_STEP_SUMMARY`. Numbers are coarse (counted
+via `docker history`), but stable across runs and grep-able in CI logs —
+the acceptance criterion ("cache hit rate measurable") prioritizes
+visibility over precision.
+
+### Promotion criterion
+
+If the PR tier passes, the PR is eligible for review and merge. On merge,
+the same SHA triggers the merge tier (`ci.yml`).
+
+## Merge tier
+
+**Status:** Implemented in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml)
+(`build` + `integration-test` jobs).
+
+The merge tier exercises eight representative multi-feature variants:
+
+- `minimal` — baseline
+- `python-dev`, `node-dev`, `rust-golang`, `r-dev` — per-language stacks
+- `cloud-ops` — kubernetes / terraform / aws / gcloud / cloudflare
+- `polyglot` — python + node + dev-tools + clients
+- `production` — debian-bookworm-slim base, passwordless sudo disabled
+
+Same trigger as before (push to main / v5 / auto-patch, plus
+`workflow_dispatch`). It explicitly does **not** trigger on `pull_request` —
+the PR tier handles that path. Branch protection rules should require both
+"PR Tier" and the merge-tier checks before allowing merge.
+
+### Cache strategy
+
+As of this PR, the global `type=gha` cache has been replaced with
+variant-scoped caches:
+
+```yaml
+cache-from: |
+  type=gha,scope=merge-${VARIANT}
+  type=gha,scope=feature-${VARIANT}-main
+cache-to: type=gha,scope=merge-${VARIANT},mode=max
+```
+
+The `feature-*-main` fallback lets the merge tier warm-start from the PR
+tier's main-branch cache.
+
+## Weekly tier
+
+**Status:** Planned, tracked in **#408-B**.
+
+The full matrix — every feature × every supported distro (Debian 11 / 12 /
+13, Alpine, RHEL/UBI, Ubuntu) × every arch (amd64, arm64) — runs Sundays at
+03:00 UTC. This is the regression-detection tier: cross-cutting changes
+that pass PR and merge tiers but break a less-common distro/arch
+combination get caught here.
+
+### Cron slot
+
+`0 3 * * 0` — Sunday 03:00 UTC. Reserved relative to existing schedule:
+
+| Existing schedule | When         | Why we slot weekly after |
+| ----------------- | ------------ | ------------------------ |
+| `auto-patch.yml`  | Sun 02:00    | 1h gap so auto-patch's PR-creation completes before the full matrix starts |
+| `security-scan.yml` | Mon 03:00  | Separate concerns: security scan runs on Monday |
+
+### Auto-issue on failure
+
+Failed runs open or update a tracking issue rather than blocking merge
+(weekly findings should not gate ongoing PR work). Issues are labeled:
+
+- `severity/medium` — full matrix regression, not a security finding
+- `audit/regression` — produced by automated scanning
+- `type/operations` — owned by the operations rotation
+
+Pattern modeled on `security-scan.yml` lines 75-124: search for an existing
+open issue by title, update it with the latest run URL on re-failure,
+create a new one otherwise. Pseudocode:
+
+```yaml
+- name: Open or update tracking issue on failure
+  if: failure()
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  run: |
+    TITLE="Weekly full-matrix regression"
+    EXISTING=$(gh issue list --label "audit/regression" --state open \
+      --search "\"${TITLE}\" in:title" --json number --jq '.[0].number // empty')
+    if [ -n "${EXISTING}" ]; then
+      gh issue comment "${EXISTING}" --body "Regression again — ${RUN_URL}"
+    else
+      gh issue create --title "${TITLE}" \
+        --label "severity/medium" --label "audit/regression" --label "type/operations" \
+        --body "..."
+    fi
+```
+
+## Monthly tier
+
+**Status:** Planned, tracked in **#408-C**.
+
+`0 4 1 * *` — 1st of month, 04:00 UTC. Long-tail checks that don't fit the
+weekly budget:
+
+- **Image size regression**: compare image sizes against the baseline
+  recorded in [`docs/ci/build-metrics.md`](../ci/build-metrics.md). Open a
+  `severity/low` issue when any variant grows >100MB or >20%.
+- **Abandonment scan**: cross-check `lib/features/*.sh` version pins
+  against the activity tiers tracked in
+  [`crates/luggage`](../../crates/luggage/) (see the
+  `luggage-tooldb-design.md` memory). Flag tools that have moved into the
+  `dormant` or `abandoned` tier — they should either be unpinned, swapped,
+  or formally deprecated.
+- **Stress tests**: parallel build of all variants on the same runner —
+  surfaces disk-pressure, network-contention, and apt-lock race conditions
+  that the spaced-out weekly matrix never reproduces.
+
+## Quarterly tier
+
+**Status:** Planned, tracked in **#408-D**.
+
+Piggy-backs on the existing `quarterly-review.yml` schedule
+(`0 9 1 1,4,7,10 *` — 1st of Jan/Apr/Jul/Oct at 09:00 UTC). Adds one new
+check to the quarterly tracking issue:
+
+- **Cross-version dependency drift**: run a representative tool-version
+  combination matrix (current pinned Python × current Node × current Rust
+  vs. one version older × current vs. one version newer × current, etc.)
+  against the polyglot integration test. Catches the case where two tools
+  individually upgrade smoothly but interact badly with the version of a
+  third tool that hasn't moved.
+
+Uses [`bin/check-versions.sh --json`](../../bin/check-versions.sh) to
+enumerate the pinned versions; combinations are sampled rather than
+exhaustive (full Cartesian product is infeasible for >50 tools).
+
+## Cache strategy summary
+
+| Scope                            | Producer                  | Consumers                                              |
+| -------------------------------- | ------------------------- | ------------------------------------------------------ |
+| `feature-${F}-pr-${PR}`          | PR tier per-feature build | Subsequent runs of the same PR (rebases, fix-up commits) |
+| `feature-${F}-main`              | Merge tier on main        | PR tier's first cold build                             |
+| `merge-${VARIANT}`               | Merge tier on main        | Subsequent merges of the same variant                  |
+
+Scopes never overlap, so two concurrent PRs cannot poison each other's
+caches. The historical global `type=gha` scope is no longer used.
+
+## Adding a new feature to the PR tier
+
+1. Add the feature to `FEATURE_MAP` in
+   [`tests/test_feature.sh`](../../tests/test_feature.sh) — the PR tier's
+   feature → INCLUDE_* mapping is sourced from there.
+2. If the feature has its own integration test under
+   `tests/integration/builds/`, add a `# @tier: ...` header line declaring
+   which tiers it belongs to:
+
+   ```bash
+   #!/usr/bin/env bash
+   # @tier: pr,merge,weekly
+   ```
+
+   Absence of the header defaults to `merge` (the pre-tier behavior).
+3. The PR tier's `changed_features.sh` will automatically pick up the new
+   feature on diffs that touch `lib/features/<name>.sh` or
+   `lib/features/lib/<name>/`.
+
+No workflow file changes are needed — the matrix is dynamic.
+
+## Troubleshooting
+
+### "My PR built feature X but I didn't touch it"
+
+Check `tests/changed_features.sh`'s mapping rules — likely your diff
+touched a foundational path (`Dockerfile`, `lib/base/**`,
+`lib/runtime/**`, `tests/framework/**`, or `crates/**`), which forces the
+full merge-tier cluster as a defensive fallback. The `detect-changes` job
+log shows the diff and emits `mode=full` when this happens.
+
+### "My PR didn't build any features but should have"
+
+The reverse case: your diff touched a path the mapping doesn't recognize.
+Check `tests/unit/changed_features.sh` for the canonical test cases and
+add coverage for the missed path. If the path *shouldn't* trigger a
+build (pure docs / config change), no action needed — the skip is correct.
+
+### "Cache-hit rate dropped to 0%"
+
+Common causes:
+
+- A `Dockerfile` change invalidated all subsequent layers — expected.
+- The cache key changed (e.g., bumping a `*_VERSION` env in
+  `lib/features/<X>.sh` invalidates the X layer and everything after).
+- The cache scope name was edited — first run after a rename is always a
+  cold start.
+
+### "A PR's matrix is empty"
+
+This is correct behavior for docs-only PRs. The summary job emits
+`mode=skip` and passes immediately.
+
+## Workflow files
+
+- [`.github/workflows/test-pr.yml`](../../.github/workflows/test-pr.yml) — PR tier
+- [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) — merge tier
+- `.github/workflows/test-weekly.yml` — planned (#408-B)
+- `.github/workflows/test-monthly.yml` — planned (#408-C)
+- `.github/workflows/quarterly-review.yml` — extends for #408-D
+
+## Related documentation
+
+- [Review Cadence](review-cadence.md) — quarterly tracking issue + ad-hoc sweeps
+- [Automated Releases](automated-releases.md) — weekly auto-patch system
+- [Build Metrics](../ci/build-metrics.md) — image-size baselines
+- [Testing](../development/testing.md) — test framework conventions

--- a/justfile
+++ b/justfile
@@ -87,6 +87,10 @@ test-changed:
 test-feature NAME:
     ./tests/test_feature.sh {{ NAME }}
 
+# Preview which features the PR tier would build for the current diff
+test-changed-features:
+    ./tests/changed_features.sh
+
 # Everything test-worthy: unit + rust + clippy + fmt check + integration
 test-all: test test-integration
 

--- a/lib/features/mise.sh
+++ b/lib/features/mise.sh
@@ -28,8 +28,9 @@
 #
 set -euo pipefail
 
-# Source standard feature header for user handling
-source /tmp/build-scripts/base/feature-header-bootstrap.sh
+# Source feature header — needs feature-utils' create_secure_temp_dir
+# (used below), so bootstrap-only is insufficient.
+source /tmp/build-scripts/base/feature-header.sh
 
 # Source retry + checksum utilities for secure binary downloads
 source /tmp/build-scripts/base/retry-utils.sh

--- a/tests/changed_features.sh
+++ b/tests/changed_features.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Map changed files to the container features they affect.
+#
+# Drives the PR-tier CI matrix in .github/workflows/test-pr.yml: a PR that
+# only touches `lib/features/python.sh` should only rebuild the python
+# image, not the full 8-variant matrix.
+#
+# Output contract (stdout):
+#   - Newline-separated feature names matching tests/test_feature.sh's
+#     FEATURE_MAP keys (python, python-dev, node, …)
+#   - "ALL" on its own line: fall back to the full merge-tier matrix
+#     (foundational file changed — Dockerfile, lib/base, lib/runtime,
+#     tests/framework, crates/*, or an unrecognized feature subtree)
+#   - Empty stdout: nothing relevant changed, no container build needed
+#
+# Exit code: 0 on success (regardless of what was emitted)
+#
+# Usage:
+#   ./tests/changed_features.sh                    # diff vs origin/HEAD
+#   ./tests/changed_features.sh --base=main        # diff vs explicit ref
+#   ./tests/changed_features.sh --files=- < list   # read paths from stdin
+#
+# The --files=- mode lets the GitHub Actions workflow feed `git diff`
+# output directly without re-running git inside this script.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# ---------------------------------------------------------------------------
+# Arg parsing
+# ---------------------------------------------------------------------------
+BASE_REF=""
+READ_FROM_STDIN=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --base=*) BASE_REF="${arg#--base=}" ;;
+        --files=-) READ_FROM_STDIN=true ;;
+        -h | --help)
+            command sed -n '2,/^set -euo/p' "${BASH_SOURCE[0]}" | command sed '$d' | command sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Source of truth for "buildable" feature names: the FEATURE_MAP keys in
+# tests/test_feature.sh. Grepping the file keeps a single source of truth
+# without sourcing (test_feature.sh runs main logic on source).
+# ---------------------------------------------------------------------------
+get_known_features() {
+    /usr/bin/grep -oE '^[[:space:]]*\["[^"]+"\]=' "$PROJECT_ROOT/tests/test_feature.sh" |
+        /usr/bin/grep -oE '"[^"]+"' |
+        /usr/bin/tr -d '"' |
+        command sort -u
+}
+
+is_known_feature() {
+    local candidate="$1"
+    local known
+    known=$(get_known_features)
+    echo "$known" | command grep -Fxq "$candidate"
+}
+
+# ---------------------------------------------------------------------------
+# Discover changed files. Mirrors tests/run_changed_tests.sh:20-37 so the
+# two stay in sync; we don't source it because it has a `main` body.
+# ---------------------------------------------------------------------------
+get_changed_files() {
+    if [ -n "$BASE_REF" ]; then
+        git diff --name-only "${BASE_REF}...HEAD" 2>/dev/null || true
+        git diff --name-only HEAD 2>/dev/null || true
+        return
+    fi
+
+    local remote_head
+    remote_head=$(git rev-parse --verify "origin/HEAD" 2>/dev/null ||
+        git rev-parse --verify "origin/main" 2>/dev/null ||
+        git rev-parse --verify "origin/master" 2>/dev/null || true)
+
+    if [ -n "$remote_head" ]; then
+        git diff --name-only "$remote_head"...HEAD 2>/dev/null || true
+    else
+        git diff --name-only HEAD~1 HEAD 2>/dev/null || true
+    fi
+    git diff --name-only HEAD 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Map one changed file to a feature name, "ALL", or nothing.
+# ---------------------------------------------------------------------------
+map_to_feature() {
+    local file="$1"
+
+    case "$file" in
+        # Foundational — invalidate every cache, rebuild everything.
+        Dockerfile | .dockerignore)
+            echo "ALL"
+            return
+            ;;
+        lib/base/* | lib/runtime/* | lib/shared/*)
+            echo "ALL"
+            return
+            ;;
+        tests/framework.sh | tests/framework/*)
+            echo "ALL"
+            return
+            ;;
+        # Rust crates can change feature-installation behavior via luggage.
+        crates/*)
+            echo "ALL"
+            return
+            ;;
+
+        # Feature helper directory: lib/features/lib/<subdir>/<file>.
+        # IMPORTANT: must come before the `lib/features/*.sh` arm — bash
+        # case-glob `*` matches `/`, so the broader pattern would otherwise
+        # claim helper-subdir paths first.
+        lib/features/lib/*)
+            local subdir
+            subdir=$(echo "$file" | command sed 's|lib/features/lib/\([^/]*\)/.*|\1|')
+            if is_known_feature "$subdir"; then
+                echo "$subdir"
+            else
+                # Subdir name doesn't match a known feature (e.g. "claude",
+                # which is shared infra). Be defensive.
+                echo "ALL"
+            fi
+            return
+            ;;
+
+        # Top-level feature script.
+        lib/features/*.sh)
+            local name
+            name=$(basename "$file" .sh)
+            if is_known_feature "$name"; then
+                echo "$name"
+            else
+                # Unknown feature script (helper or new feature not yet in
+                # FEATURE_MAP). Defensive: rebuild the full matrix rather
+                # than silently skip.
+                echo "ALL"
+            fi
+            return
+            ;;
+
+        # Integration test for a specific build — rebuild + retest that build.
+        tests/integration/builds/test_*.sh)
+            local name
+            name=$(basename "$file" .sh)
+            name="${name#test_}"
+            name="${name//_/-}"
+            if is_known_feature "$name"; then
+                echo "$name"
+            fi
+            # Unknown variant test (e.g. test_polyglot covers multiple
+            # features) — no single feature to map; let merge tier cover it.
+            return
+            ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+if [ "$READ_FROM_STDIN" = true ]; then
+    CHANGED_FILES=$(cat)
+else
+    CHANGED_FILES=$(get_changed_files)
+fi
+
+if [ -z "$CHANGED_FILES" ]; then
+    exit 0
+fi
+
+declare -A SEEN
+RUN_ALL=false
+
+while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    result=$(map_to_feature "$file")
+    [ -z "$result" ] && continue
+    if [ "$result" = "ALL" ]; then
+        RUN_ALL=true
+        break
+    fi
+    SEEN["$result"]=1
+done < <(echo "$CHANGED_FILES" | command sort -u)
+
+if [ "$RUN_ALL" = true ]; then
+    echo "ALL"
+    exit 0
+fi
+
+# Emit deduplicated, sorted feature list.
+if [ ${#SEEN[@]} -gt 0 ]; then
+    command printf '%s\n' "${!SEEN[@]}" | command sort -u
+fi

--- a/tests/integration/builds/test_android.sh
+++ b/tests/integration/builds/test_android.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# @tier: merge,weekly
 # Test android container build
 #
 # This test verifies the Android SDK configuration including:

--- a/tests/integration/builds/test_bindfs.sh
+++ b/tests/integration/builds/test_bindfs.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# @tier: merge,weekly
 # Test bindfs container build
 #
 # This test verifies that the bindfs feature:

--- a/tests/integration/builds/test_checker_workflow.sh
+++ b/tests/integration/builds/test_checker_workflow.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# @tier: merge,weekly
 # Test checker agent workflow: skill discovery globs, domain override logic,
 # project-level skill precedence, and patterns.sh pipeline execution.
 #

--- a/tests/integration/builds/test_claude_code_setup.sh
+++ b/tests/integration/builds/test_claude_code_setup.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# @tier: merge,weekly
 # Test Claude Code setup (CLI, MCP servers, and plugin integrations)
 #
 # This test verifies the Claude Code setup installed by claude-code-setup.sh:

--- a/tests/integration/builds/test_claude_skills_agents.sh
+++ b/tests/integration/builds/test_claude_skills_agents.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# @tier: merge,weekly
 # Test Claude Code skills and agents installation
 #
 # This test verifies that skill and agent templates are staged at build time

--- a/tests/integration/builds/test_cloud_ops.sh
+++ b/tests/integration/builds/test_cloud_ops.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# @tier: merge,weekly
 # Test cloud-ops container build
 #
 # This test verifies the cloud-ops configuration that includes:

--- a/tests/integration/builds/test_docker_socket.sh
+++ b/tests/integration/builds/test_docker_socket.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# @tier: merge,weekly
 # Test Docker socket access fix in entrypoint
 #
 # This test verifies that the entrypoint correctly configures Docker socket

--- a/tests/integration/builds/test_kotlin.sh
+++ b/tests/integration/builds/test_kotlin.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# @tier: merge,weekly
 # Test kotlin container build
 #
 # This test verifies the Kotlin configuration including:

--- a/tests/integration/builds/test_kubernetes_deployment.sh
+++ b/tests/integration/builds/test_kubernetes_deployment.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# @tier: merge,weekly
 # Test Kubernetes deployment manifests with kind (Kubernetes in Docker)
 #
 # This test verifies the Kubernetes manifests work correctly by:

--- a/tests/integration/builds/test_luggage_rust.sh
+++ b/tests/integration/builds/test_luggage_rust.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# @tier: merge,weekly
 # Smoke test: `luggage install rust@<RUST_VERSION>` end-state.
 #
 # Issue #407 — once lib/features/rust.sh delegates to luggage, the

--- a/tests/integration/builds/test_minimal.sh
+++ b/tests/integration/builds/test_minimal.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# @tier: pr,merge,weekly
 # Test minimal container builds
 #
 # This test verifies that the most basic container configurations

--- a/tests/integration/builds/test_mise.sh
+++ b/tests/integration/builds/test_mise.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# @tier: merge,weekly
 # Test mise (polyglot runtime version manager) container build
 #
 # This test verifies that the mise feature:

--- a/tests/integration/builds/test_node_dev.sh
+++ b/tests/integration/builds/test_node_dev.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# @tier: merge,weekly
 # Test node-dev container build
 #
 # This test verifies the node-dev configuration that includes:

--- a/tests/integration/builds/test_polyglot.sh
+++ b/tests/integration/builds/test_polyglot.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# @tier: merge,weekly
 # Test polyglot container build
 #
 # This test verifies the polyglot configuration that includes:

--- a/tests/integration/builds/test_production.sh
+++ b/tests/integration/builds/test_production.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# @tier: merge,weekly
 # Test production container builds
 #
 # This test verifies that production-optimized containers build successfully

--- a/tests/integration/builds/test_python_dev.sh
+++ b/tests/integration/builds/test_python_dev.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# @tier: merge,weekly
 # Test python-dev container build
 #
 # This test verifies the python-dev configuration that includes:

--- a/tests/integration/builds/test_r_dev.sh
+++ b/tests/integration/builds/test_r_dev.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# @tier: merge,weekly
 # Test r-dev container build
 #
 # This test verifies the R development environment that includes:

--- a/tests/integration/builds/test_rust_golang.sh
+++ b/tests/integration/builds/test_rust_golang.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# @tier: merge,weekly
 # Test rust-golang container build
 #
 # This test verifies a systems programming polyglot setup with:

--- a/tests/integration/builds/test_setup_commands.sh
+++ b/tests/integration/builds/test_setup_commands.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# @tier: merge,weekly
 # Test setup-git, setup-gh, and setup-glab commands functionally
 #
 # This test builds two images (minimal + dev-tools) and runs the setup

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -5,10 +5,21 @@
 # actual Docker containers with various feature combinations.
 #
 # Usage:
-#   ./tests/run_integration_tests.sh [test_name]
+#   ./tests/run_integration_tests.sh [--tier=<tier>] [test_name]
+#
+# Tiers (filter tests by their `# @tier: ...` header comment):
+#   pr        — fast feedback on every PR (<15min)
+#   merge     — representative cluster on main push (<30min, default coverage)
+#   weekly    — full matrix on Sunday cadence
+#   monthly   — long-tail: image-size regression, abandonment scans
+#   quarterly — cross-version dependency drift
+#
+# A test without an `@tier:` header defaults to the `merge` tier. See
+# docs/operations/ci-tiers.md for the full tier definitions.
 #
 # Examples:
-#   ./tests/run_integration_tests.sh                 # Run all integration tests
+#   ./tests/run_integration_tests.sh                 # All tests
+#   ./tests/run_integration_tests.sh --tier=pr       # PR-tier only
 #   ./tests/run_integration_tests.sh minimal         # Run only minimal tests
 #   ./tests/run_integration_tests.sh python_dev      # Run only python-dev tests
 
@@ -44,22 +55,79 @@ echo "Project: Container Build System"
 echo "Date: $(date)"
 echo ""
 
-# Find all integration test files
+# Parse arguments: optional --tier=<tier> and optional test_name.
+TIER=""
+TEST_NAME=""
+for arg in "$@"; do
+    case "$arg" in
+        --tier=*) TIER="${arg#--tier=}" ;;
+        -*)
+            echo -e "${RED}Error: unknown option: $arg${NC}"
+            exit 2
+            ;;
+        *)
+            if [ -n "$TEST_NAME" ]; then
+                echo -e "${RED}Error: too many positional arguments${NC}"
+                exit 2
+            fi
+            TEST_NAME="$arg"
+            ;;
+    esac
+done
+
+case "$TIER" in
+    "" | pr | merge | weekly | monthly | quarterly) ;;
+    *)
+        echo -e "${RED}Error: unknown tier: $TIER${NC}"
+        echo "Valid tiers: pr, merge, weekly, monthly, quarterly"
+        exit 2
+        ;;
+esac
+
+# Returns 0 if the test file declares membership in $TIER (or if $TIER is
+# empty — meaning "no filter"). Reads the first 5 non-shebang lines for an
+# `@tier: ...` comment; absence defaults to `merge` (matches the historical
+# behavior — every test pre-tier was effectively a merge-tier test).
+test_in_tier() {
+    local file="$1"
+    local want="$2"
+    [ -z "$want" ] && return 0
+
+    local declared
+    declared=$(/usr/bin/grep -m1 -oE '^#[[:space:]]*@tier:[[:space:]]*[a-z,[:space:]]+' "$file" 2>/dev/null |
+        command sed -E 's/^#[[:space:]]*@tier:[[:space:]]*//' || true)
+    [ -z "$declared" ] && declared="merge"
+
+    echo "$declared" | command tr ',' '\n' | command tr -d '[:space:]' | command grep -Fxq "$want"
+}
+
+# Find all integration test files (then filter by tier if requested).
 TEST_FILES=()
-if [ $# -eq 0 ]; then
-    # Run all tests
+if [ -z "$TEST_NAME" ]; then
     while IFS= read -r file; do
-        TEST_FILES+=("$file")
+        if test_in_tier "$file" "$TIER"; then
+            TEST_FILES+=("$file")
+        fi
     done < <(command find "$SCRIPT_DIR/integration/builds" -name "test_*.sh" -type f | sort)
+
+    if [ -n "$TIER" ]; then
+        echo -e "${BLUE}Filtering by tier: $TIER${NC}"
+    fi
 else
-    # Run specific test
-    TEST_NAME="$1"
     TEST_FILE="$SCRIPT_DIR/integration/builds/test_${TEST_NAME}.sh"
     if [ ! -f "$TEST_FILE" ]; then
         echo -e "${RED}Error: Test file not found: $TEST_FILE${NC}"
         exit 1
     fi
+    if [ -n "$TIER" ] && ! test_in_tier "$TEST_FILE" "$TIER"; then
+        echo -e "${YELLOW}Note: $TEST_NAME is not in tier '$TIER' — running anyway (explicit name overrides filter).${NC}"
+    fi
     TEST_FILES=("$TEST_FILE")
+fi
+
+if [ ${#TEST_FILES[@]} -eq 0 ]; then
+    echo -e "${YELLOW}No integration tests match tier '$TIER' — nothing to run.${NC}"
+    exit 0
 fi
 
 echo -e "${BLUE}Found ${#TEST_FILES[@]} integration test suite(s)${NC}"

--- a/tests/unit/changed_features.sh
+++ b/tests/unit/changed_features.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# Unit tests for tests/changed_features.sh.
+#
+# Validates the change-detection mapping used by the PR-tier CI workflow
+# (.github/workflows/test-pr.yml) to decide which features to rebuild.
+# Wrong mapping means either wasted CI time (overbuilding) or missing
+# coverage (underbuilding) on PRs.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../framework.sh"
+
+init_test_framework
+
+test_suite "tests/changed_features.sh — change detection"
+
+SCRIPT="$PROJECT_ROOT/tests/changed_features.sh"
+
+# Pipe a list of "changed" file paths to the script and capture stdout.
+run_with() {
+    command printf '%s\n' "$@" | "$SCRIPT" --files=- 2>/dev/null
+}
+
+test_empty_input_emits_nothing() {
+    local out
+    out=$(/usr/bin/printf '' | "$SCRIPT" --files=- 2>/dev/null || true)
+    if [ -z "$out" ]; then
+        assert_true true "empty stdin → no output"
+    else
+        assert_true false "empty stdin should emit nothing, got: $out"
+    fi
+}
+
+test_dockerfile_emits_all() {
+    local out
+    out=$(run_with "Dockerfile")
+    if [ "$out" = "ALL" ]; then
+        assert_true true "Dockerfile → ALL"
+    else
+        assert_true false "expected ALL, got: $out"
+    fi
+}
+
+test_lib_base_emits_all() {
+    local out
+    out=$(run_with "lib/base/setup-user.sh")
+    if [ "$out" = "ALL" ]; then
+        assert_true true "lib/base/* → ALL (foundational)"
+    else
+        assert_true false "expected ALL, got: $out"
+    fi
+}
+
+test_lib_runtime_emits_all() {
+    local out
+    out=$(run_with "lib/runtime/entrypoint.sh")
+    if [ "$out" = "ALL" ]; then
+        assert_true true "lib/runtime/* → ALL (foundational)"
+    else
+        assert_true false "expected ALL, got: $out"
+    fi
+}
+
+test_tests_framework_emits_all() {
+    local out
+    out=$(run_with "tests/framework/assertions/docker.sh")
+    if [ "$out" = "ALL" ]; then
+        assert_true true "tests/framework/* → ALL (test infra)"
+    else
+        assert_true false "expected ALL, got: $out"
+    fi
+}
+
+test_crates_emits_all() {
+    local out
+    out=$(run_with "crates/luggage/src/main.rs")
+    if [ "$out" = "ALL" ]; then
+        assert_true true "crates/* → ALL (luggage build engine)"
+    else
+        assert_true false "expected ALL, got: $out"
+    fi
+}
+
+test_single_feature() {
+    local out
+    out=$(run_with "lib/features/python.sh")
+    if [ "$out" = "python" ]; then
+        assert_true true "lib/features/python.sh → python"
+    else
+        assert_true false "expected 'python', got: $out"
+    fi
+}
+
+test_two_features_sorted() {
+    local out
+    out=$(run_with "lib/features/rust.sh" "lib/features/node.sh")
+    local expected
+    expected=$(/usr/bin/printf 'node\nrust\n')
+    if [ "$out" = "$expected" ]; then
+        assert_true true "two features → deduplicated and sorted"
+    else
+        assert_true false "expected sorted node/rust, got: $out"
+    fi
+}
+
+test_unknown_feature_emits_all() {
+    # `lib/features/totally-fake.sh` doesn't exist in FEATURE_MAP. Defensive
+    # behavior: fall back to ALL rather than silently producing a feature
+    # name the workflow can't build.
+    local out
+    out=$(run_with "lib/features/totally-fake-feature.sh")
+    if [ "$out" = "ALL" ]; then
+        assert_true true "unknown feature script → ALL (defensive)"
+    else
+        assert_true false "expected ALL for unknown feature, got: $out"
+    fi
+}
+
+test_helper_subdir_matching_feature() {
+    # lib/features/lib/python/pyenv-helper.sh → parent feature "python"
+    local out
+    out=$(run_with "lib/features/lib/python/pyenv-helper.sh")
+    if [ "$out" = "python" ]; then
+        assert_true true "lib/features/lib/python/* → python (parent feature)"
+    else
+        assert_true false "expected 'python', got: $out"
+    fi
+}
+
+test_helper_subdir_unknown_emits_all() {
+    # "claude" is a helper subdir, not a buildable feature. Defensive: ALL.
+    local out
+    out=$(run_with "lib/features/lib/claude/claude-setup")
+    if [ "$out" = "ALL" ]; then
+        assert_true true "lib/features/lib/<unknown-subdir>/* → ALL"
+    else
+        assert_true false "expected ALL, got: $out"
+    fi
+}
+
+test_integration_test_for_known_feature() {
+    # tests/integration/builds/test_python_dev.sh → "python-dev"
+    local out
+    out=$(run_with "tests/integration/builds/test_python_dev.sh")
+    if [ "$out" = "python-dev" ]; then
+        assert_true true "test_python_dev.sh → python-dev"
+    else
+        assert_true false "expected 'python-dev', got: $out"
+    fi
+}
+
+test_integration_test_for_unknown_variant() {
+    # test_polyglot is a multi-feature variant — no single feature mapping.
+    # Should emit nothing (merge tier covers it).
+    local out
+    out=$(run_with "tests/integration/builds/test_polyglot.sh")
+    if [ -z "$out" ]; then
+        assert_true true "test_polyglot.sh (multi-feature variant) → no mapping (merge tier covers it)"
+    else
+        assert_true false "expected empty, got: $out"
+    fi
+}
+
+test_docs_only_change_emits_nothing() {
+    local out
+    out=$(run_with "docs/operations/ci-tiers.md" "README.md")
+    if [ -z "$out" ]; then
+        assert_true true "docs-only changes → no container build"
+    else
+        assert_true false "expected empty, got: $out"
+    fi
+}
+
+test_mixed_with_dockerfile_short_circuits_to_all() {
+    local out
+    out=$(run_with "lib/features/python.sh" "Dockerfile" "docs/foo.md")
+    if [ "$out" = "ALL" ]; then
+        assert_true true "ALL short-circuits on foundational + feature mix"
+    else
+        assert_true false "expected ALL, got: $out"
+    fi
+}
+
+test_dedup_same_feature_twice() {
+    local out
+    out=$(run_with "lib/features/python.sh" "lib/features/lib/python/helper.sh")
+    if [ "$out" = "python" ]; then
+        assert_true true "feature script + its helper dir → deduplicated to one"
+    else
+        assert_true false "expected single 'python', got: $out"
+    fi
+}
+
+test_known_features_extractable() {
+    # Sanity: the FEATURE_MAP grep must find a reasonable set of features.
+    # If test_feature.sh's FEATURE_MAP format ever changes, this catches it.
+    local count
+    count=$(/usr/bin/grep -oE '^[[:space:]]*\["[^"]+"\]=' "$PROJECT_ROOT/tests/test_feature.sh" | command wc -l)
+    if [ "$count" -ge 20 ]; then
+        assert_true true "FEATURE_MAP has $count entries (expected >=20)"
+    else
+        assert_true false "FEATURE_MAP extraction found only $count entries — has the format changed?"
+    fi
+}
+
+run_test test_empty_input_emits_nothing "empty input → no output"
+run_test test_dockerfile_emits_all "Dockerfile → ALL"
+run_test test_lib_base_emits_all "lib/base/* → ALL"
+run_test test_lib_runtime_emits_all "lib/runtime/* → ALL"
+run_test test_tests_framework_emits_all "tests/framework/* → ALL"
+run_test test_crates_emits_all "crates/* → ALL"
+run_test test_single_feature "single feature script → feature name"
+run_test test_two_features_sorted "multiple features → sorted, deduplicated"
+run_test test_unknown_feature_emits_all "unknown feature script → ALL"
+run_test test_helper_subdir_matching_feature "feature helper subdir → parent feature"
+run_test test_helper_subdir_unknown_emits_all "unknown helper subdir → ALL"
+run_test test_integration_test_for_known_feature "integration test → matching feature"
+run_test test_integration_test_for_unknown_variant "variant integration test → no mapping"
+run_test test_docs_only_change_emits_nothing "docs-only changes → nothing"
+run_test test_mixed_with_dockerfile_short_circuits_to_all "ALL short-circuits"
+run_test test_dedup_same_feature_twice "feature + its helper → deduplicated"
+run_test test_known_features_extractable "FEATURE_MAP extractable from test_feature.sh"
+
+generate_report


### PR DESCRIPTION
## Summary

Phase A of #408. Introduces a fourth CI tier so PRs get fast container
build feedback (<15 min) for the features they touch. Before this,
container builds only ran post-merge in `ci.yml` — PRs got unit / Rust /
lefthook checks but no build verification.

## What's in the box

- **`tests/changed_features.sh`** (new) — maps changed paths → feature
  names. Source of truth for the feature set is `FEATURE_MAP` in
  `tests/test_feature.sh` (grepped, not duplicated). 17 unit tests in
  `tests/unit/changed_features.sh` cover every mapping branch.
- **`.github/workflows/test-pr.yml`** (new) — three-job workflow:
  - `detect-changes` runs `changed_features.sh` against the PR diff
  - `build-feature` matrix-fans-out one buildx build per touched feature
  - `pr-tier` summary job for branch protection
- **`tests/run_integration_tests.sh`** — learns `--tier=<pr|merge|weekly|
  monthly|quarterly>` filter. Reads `# @tier: ...` header from each test
  file; absence defaults to `merge` (pre-tier behavior preserved).
- **`tests/integration/builds/test_*.sh`** (19 files) — `@tier:` headers
  added. `test_minimal` is `pr,merge,weekly`; the other 18 are
  `merge,weekly`.
- **`.github/workflows/ci.yml`** — `build` job renamed
  `Build Images (Merge Tier)`. Variant-scoped cache
  (`scope=merge-${variant}`) replaces the global `type=gha`, fixing
  cross-variant cache poisoning. Cache-hit-rate logging step added.
- **`docs/operations/ci-tiers.md`** (new) — full four-tier design.
  Weekly/monthly/quarterly are marked planned and tracked in follow-ups
  (see below).
- **`justfile`** — `test-changed-features` recipe so contributors can
  preview the PR-tier matrix locally.

## Decomposition (per issue body scope-note)

#408 invited splitting "(a) PR + merge tiers as the immediate win, (b)
weekly/monthly/quarterly as a follow-up." This PR delivers (a). Follow-ups
file the (b) work as separate issues:

- #464 — weekly tier: full matrix + auto-issue on regression
- #465 — monthly tier: image-size regression + abandonment scan + stress
- #466 — quarterly tier: cross-version dependency drift

Each is small enough to ship as its own PR without losing the overall
design coherence (which lives in `ci-tiers.md`).

## Acceptance criteria coverage (#408)

| Criterion | This PR | Tracked in |
|-----------|---------|------------|
| PR tier <15 min for typical 1-feature changes | ✅ via timeout + per-feature matrix | this PR |
| Merge tier <30 min | ✅ unchanged from current ci.yml | this PR |
| Weekly tier exercises full matrix | designed | #464 |
| Monthly + quarterly defined & scheduled | designed | #465, #466 |
| Cache hit rate measurable (per build) | ✅ logged as `::notice::` + step summary | this PR |
| Failed weekly auto-opens issues | designed, pseudo-code in ci-tiers.md | #464 |
| Documented in `docs/operations/ci-tiers.md` | ✅ all four tiers covered | this PR |
| Per-feature change detection working | ✅ + 17 unit tests | this PR |

## Security note

Every interpolation of `github.event.*` or `matrix.*` into a shell context
in `test-pr.yml` is plumbed through `env:` rather than direct `${{ ... }}`
expansion — prevents workflow injection via PR metadata.

## Test plan

- [x] `just test-shell` — all 2994 unit tests pass (4 skipped, 0 failed)
- [x] `actionlint` — both `test-pr.yml` and `ci.yml` clean (pre-existing
      shellcheck warnings unchanged)
- [x] `rumdl check docs/operations/ci-tiers.md` — clean
- [x] `shellcheck` + `shfmt` on new/modified shell scripts — clean
- [x] Manual verification of `changed_features.sh` mapping rules
- [x] Tier filter smoke test: `--tier=pr` → 1 test, `--tier=weekly` → 19,
      `--tier=monthly` → 0
- [ ] End-to-end PR-tier validation requires this PR's own run + a
      follow-up single-feature PR (cannot be tested locally — buildx GHA
      cache is GitHub-runner-only)

Closes #408