### PR TITLE
fix(features): prevent SIGABRT in mise --version build verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,6 +336,7 @@ jobs:
               INCLUDE_POSTGRES_CLIENT=true
               INCLUDE_REDIS_CLIENT=true
               INCLUDE_SQLITE_CLIENT=true
+              INCLUDE_MISE=true
           - name: rust-golang
             build_args: |
               PROJECT_NAME=containers

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -93,10 +93,9 @@ jobs:
           #       cache, making PR-tier feedback unreliable
           # Skipped features are still exercised by the merge tier.
           # Entries:
-          #   mise  — #468: `mise --version` exits 134 in isolation
           #   r-dev — exceeds 25min PR-tier ceiling (CRAN package set);
           #           covered by merge-tier `r-dev` variant in ci.yml
-          SKIP_LIST='^(mise|r-dev)$'
+          SKIP_LIST='^(r-dev)$'
           FILTERED=$(printf '%s\n' "${OUT}" | grep -vE "${SKIP_LIST}" || true)
 
           if [ -z "${FILTERED}" ]; then

--- a/lib/features/mise.sh
+++ b/lib/features/mise.sh
@@ -153,11 +153,14 @@ chmod +x /etc/bashrc.d/70-mise.sh
 # ============================================================================
 log_message "Verifying mise installation..."
 
-if mise --version >/dev/null 2>&1; then
-    MISE_VER=$(mise --version 2>&1 | command head -1)
+# Don't pipe `--version` through head: mise's async self-update check writes
+# to stderr after the version line, and piping with `2>&1 | head` closes the
+# stream early, triggering SIGPIPE → Rust panic=abort → SIGABRT (exit 134).
+# Capture stdout directly; discard stderr.
+if MISE_VER=$(mise --version 2>/dev/null); then
     log_message "  ${MISE_VER}"
 else
-    log_error "mise installation verification failed"
+    log_error "mise installation verification failed (exit $?)"
     log_feature_end
     exit 1
 fi

--- a/tests/integration/builds/test_mise.sh
+++ b/tests/integration/builds/test_mise.sh
@@ -83,8 +83,10 @@ test_mise_install_runtime() {
 
     # Interactive shell ensures the 70-mise.sh fragment is sourced and mise
     # activate has set up shims. Use printf for a multi-line .mise.toml.
+    # `mise trust` is required because /tmp isn't under the default
+    # MISE_TRUSTED_CONFIG_PATHS (/workspace).
     assert_command_in_container "$image" \
-        "bash -ic 'cd /tmp && mkdir -p mise-test && cd mise-test && printf \"[tools]\\ndeno = \\\"1\\\"\\n\" > .mise.toml && mise install >/dev/null 2>&1 && mise which deno >/dev/null 2>&1 && echo install-ok'" \
+        "bash -ic 'cd /tmp && mkdir -p mise-test && cd mise-test && printf \"[tools]\\ndeno = \\\"1\\\"\\n\" > .mise.toml && mise trust >/dev/null 2>&1 && mise install >/dev/null 2>&1 && mise which deno >/dev/null 2>&1 && echo install-ok'" \
         "install-ok"
 }
 


### PR DESCRIPTION
## Summary
- Root cause: the verification block's second call `mise --version 2>&1 | head -1` triggered SIGPIPE → Rust `panic=abort` → SIGABRT (exit 134). mise has an async self-update check that writes a WARN to stderr after `--version` returns; once `head -1` closed the pipe, that write hit a broken stdout. Latent until #467's PR-tier surfaced isolation builds.
- Fix: collapse to a single `MISE_VER=$(mise --version 2>/dev/null)` — captures stdout, discards stderr, no pipe.
- Adjacent fixes (reachable only now that the build no longer dies):
  - `test_mise_install_runtime`: add `mise trust` so the test's `.mise.toml` under `/tmp` is honored (default `MISE_TRUSTED_CONFIG_PATHS` is `/workspace`).
  - Drop `mise` from PR-tier `SKIP_LIST` — isolation builds now exercise `tests/integration/builds/test_mise.sh` on every `mise.sh` change.
  - Add `INCLUDE_MISE=true` to the merge-tier `polyglot` variant for bundled coverage.

## Test plan
- [x] Reproduced the original SIGABRT on `origin/main` via `./tests/test_feature.sh mise`.
- [x] Verified the fix builds the isolated image successfully (`./tests/test_feature.sh mise` → PASS).
- [x] Ran the full integration suite against the built image (`IMAGE_TO_TEST=test-feature-mise ./tests/integration/builds/test_mise.sh`) → **7/7 PASS**.
- [x] `actionlint` + `shellcheck` clean on edited files (pre-existing findings in `ci.yml` are outside the diff).
- [x] Conform commit-message linter passed.

Closes #468