### PR TITLE
feat(containers-common): add TaggedVersion for round-trip prefix preservation

### DIFF
--- a/crates/containers-common/src/tooldb/tool.rs
+++ b/crates/containers-common/src/tooldb/tool.rs
@@ -5,7 +5,7 @@
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
-use crate::version::VersionStyle;
+use crate::version::{TagPrefix, VersionStyle};
 
 /// Top-level catalog entry for a tool.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -37,6 +37,17 @@ pub struct Tool {
     /// How version strings on this tool should be parsed. Defaults to semver.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version_style: Option<VersionStyle>,
+    /// Convention upstream uses to prefix this tool's release tags.
+    ///
+    /// Drives writers (auto-patch, workflow updater, install-script
+    /// renderers) that must emit references in the exact form their
+    /// consumer expects — e.g. `aquasecurity/trivy-action@v0.36.0` vs
+    /// `@0.36.0`. See [`crate::version::TaggedVersion`] for the round-trip
+    /// primitive. Optional for forward compatibility with catalog entries
+    /// predating this field; absent means "convention unknown" and writers
+    /// should fall back to whatever form they read.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tag_prefix: Option<TagPrefix>,
     /// Default version selected when no version is requested.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_version: Option<String>,
@@ -296,10 +307,29 @@ mod tests {
         assert_eq!(tool.kind, Kind::Language);
         assert_eq!(tool.activity.score, ActivityScore::VeryActive);
         assert_eq!(tool.default_version.as_deref(), Some("1.95.0"));
+        // tag_prefix is omitted from this fixture — verifies the field
+        // is forward-compatible with catalog entries predating it.
+        assert!(tool.tag_prefix.is_none());
         let avail = tool.available.as_ref().expect("available[]");
         assert_eq!(avail.len(), 5);
         let channels = tool.channels.as_ref().expect("channels");
         assert_eq!(channels.get("stable").unwrap().default, Some(true));
+    }
+
+    #[test]
+    fn parses_tag_prefix_field() {
+        let json = r#"{
+            "schemaVersion": 1,
+            "id": "trivy-action",
+            "display_name": "Trivy Action",
+            "kind": "cli",
+            "activity": { "score": "active", "scanned_at": "2026-01-01T00:00:00Z" },
+            "tag_prefix": "v",
+            "default_version": "0.36.0"
+        }"#;
+        let tool: Tool = serde_json::from_str(json).unwrap();
+        assert_eq!(tool.tag_prefix, Some(TagPrefix::V));
+        assert_eq!(tool.default_version.as_deref(), Some("0.36.0"));
     }
 
     #[test]

--- a/crates/containers-common/src/version/mod.rs
+++ b/crates/containers-common/src/version/mod.rs
@@ -32,6 +32,22 @@
 //! at parse time so the catalog can store `1.95.0` while upstream tags
 //! ship as `v1.95.0`.
 //!
+//! # Reference form vs canonical form
+//!
+//! [`Version`] is lossy on the prefix: parsing `v0.36.0` produces the
+//! same value as parsing `0.36.0`. That is correct for comparison and
+//! storage, but wrong at I/O boundaries — `aquasecurity/trivy-action@v0.36.0`
+//! resolves to a tag and `@0.36.0` does not. Use [`TaggedVersion`] when
+//! the upstream prefix must survive the round-trip:
+//!
+//! ```
+//! use containers_common::version::{TagPrefix, TaggedVersion, VersionStyle};
+//!
+//! let upstream = TaggedVersion::parse("v0.36.0", VersionStyle::Semver).unwrap();
+//! assert_eq!(upstream.prefix, TagPrefix::V);
+//! assert_eq!(format!("{upstream}"), "v0.36.0");
+//! ```
+//!
 //! # Style modes
 //!
 //! See [`VersionStyle`]: `Semver` (default), `Prefix`, `Calver`, `Opaque`.
@@ -43,8 +59,10 @@ mod constraint;
 mod error;
 mod parse;
 mod style;
+mod tagged;
 
 pub use constraint::Constraint;
 pub use error::{IntersectError, VersionError};
 pub use parse::Version;
 pub use style::VersionStyle;
+pub use tagged::{TagPrefix, TaggedVersion};

--- a/crates/containers-common/src/version/parse.rs
+++ b/crates/containers-common/src/version/parse.rs
@@ -7,27 +7,46 @@ use std::fmt;
 
 use super::error::VersionError;
 use super::style::VersionStyle;
+use super::tagged::TagPrefix;
 
-/// Strips a single tag-style prefix from a version literal.
+/// Splits a version literal into its tag-style prefix and the trailing
+/// version core.
 ///
 /// Recognised prefixes (longest first): `release-`, `v`, `V`, and `r`
 /// when followed by a digit. The function only strips at the start; it
 /// does not recurse. This is used at parse time so the catalog can store
 /// `1.95.0` while upstream tags ship as `v1.95.0` or `release-1.95.0`.
+///
+/// Returns [`TagPrefix::Bare`] and the original slice when no prefix
+/// matches. Callers who only need the suffix can use [`strip_prefix`].
 #[must_use]
-pub(super) fn strip_prefix(s: &str) -> &str {
+pub(super) fn split_prefix(s: &str) -> (TagPrefix, &str) {
     if let Some(rest) = s.strip_prefix("release-") {
-        return rest;
+        return (TagPrefix::Release, rest);
     }
-    if let Some(rest) = s.strip_prefix('v').or_else(|| s.strip_prefix('V')) {
-        return rest;
+    if let Some(rest) = s.strip_prefix('v') {
+        return (TagPrefix::V, rest);
+    }
+    if let Some(rest) = s.strip_prefix('V') {
+        return (TagPrefix::VCapital, rest);
     }
     if let Some(rest) = s.strip_prefix('r')
         && rest.chars().next().is_some_and(|c| c.is_ascii_digit())
     {
-        return rest;
+        return (TagPrefix::R, rest);
     }
-    s
+    (TagPrefix::Bare, s)
+}
+
+/// Strips a single tag-style prefix from a version literal, discarding
+/// which prefix matched.
+///
+/// Thin wrapper over [`split_prefix`] for call sites that don't need to
+/// remember the original form. See [`split_prefix`] for the recognised
+/// prefix list.
+#[must_use]
+pub(super) fn strip_prefix(s: &str) -> &str {
+    split_prefix(s).1
 }
 
 /// A parsed version literal.

--- a/crates/containers-common/src/version/tagged.rs
+++ b/crates/containers-common/src/version/tagged.rs
@@ -1,0 +1,226 @@
+//! Prefix-preserving version literals for round-tripping upstream tags.
+//!
+//! [`Version`] is lossy by design: `v1.95.0` and `1.95.0` parse to the
+//! same canonical value, so comparators and constraint matchers see one
+//! release no matter how upstream chooses to spell its tag. That is the
+//! right behaviour for storage and comparison.
+//!
+//! It is the wrong behaviour at I/O boundaries. When auto-patch tooling
+//! reads `v0.36.0` from a GitHub release and writes it back into a
+//! workflow file, the `v` is not cosmetic — `aquasecurity/trivy-action@0.36.0`
+//! does not resolve to a tag, while `aquasecurity/trivy-action@v0.36.0`
+//! does. [`TaggedVersion`] is the boundary type that remembers which
+//! prefix style the upstream tag used so writers can re-emit it.
+
+use std::fmt;
+use std::hash::{Hash, Hasher};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use super::error::VersionError;
+use super::parse::{Version, split_prefix};
+use super::style::VersionStyle;
+
+/// Closed set of recognised upstream tag prefixes.
+///
+/// One variant per literal form. Modelled as an enum rather than
+/// `String` so writers cannot accidentally emit a prefix a downstream
+/// reader doesn't recognise — adding a new convention is an explicit
+/// schema change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TagPrefix {
+    /// No prefix — e.g. `1.95.0`.
+    #[default]
+    Bare,
+    /// Lowercase `v` — e.g. `v1.95.0`. Most common convention.
+    V,
+    /// Uppercase `V` — e.g. `V1.0.0`. Rare but seen on some legacy tools.
+    #[serde(rename = "v-capital")]
+    VCapital,
+    /// Literal `release-` — e.g. `release-1.95.0`.
+    Release,
+    /// Lowercase `r` followed by a digit — e.g. `r1.2.3` (Ghidra-style).
+    R,
+}
+
+impl TagPrefix {
+    /// Detects the prefix on `s` and returns the matched variant along
+    /// with the trailing version core.
+    ///
+    /// Returns `(TagPrefix::Bare, s)` when no recognised prefix matches.
+    #[must_use]
+    pub fn detect(s: &str) -> (Self, &str) {
+        split_prefix(s)
+    }
+
+    /// Returns the literal characters this prefix renders as.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Bare => "",
+            Self::V => "v",
+            Self::VCapital => "V",
+            Self::Release => "release-",
+            Self::R => "r",
+        }
+    }
+}
+
+impl fmt::Display for TagPrefix {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A parsed version literal that remembers its upstream tag prefix.
+///
+/// Use this at I/O boundaries (release-fetchers, workflow updaters,
+/// catalog writers) so the form an upstream publishes survives the
+/// round-trip through internal storage and back out.
+///
+/// Equality and ordering delegate to the canonical [`Version`]:
+/// `TaggedVersion::parse("v1.0.0")` and `TaggedVersion::parse("1.0.0")`
+/// compare equal because they describe the same release. Use
+/// [`Self::is_textually_identical`] when the textual form matters.
+#[derive(Debug, Clone)]
+pub struct TaggedVersion {
+    /// Canonical comparable version. Use this for ordering and constraint matching.
+    pub core: Version,
+    /// Reference form the upstream tag was published in.
+    pub prefix: TagPrefix,
+}
+
+impl TaggedVersion {
+    /// Parses a version literal, preserving the matched tag prefix.
+    ///
+    /// # Errors
+    ///
+    /// Forwards every error from [`Version::parse`] — the prefix
+    /// detection step is infallible.
+    pub fn parse(s: &str, style: VersionStyle) -> Result<Self, VersionError> {
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            return Err(VersionError::Empty);
+        }
+        let (prefix, _rest) = split_prefix(trimmed);
+        // Delegate to Version::parse so relaxed-semver padding (`1.7` →
+        // `1.7.0`) and style routing stay in one place. It will strip
+        // the prefix again internally — that's fine; the recognised set
+        // is the same.
+        let core = Version::parse(trimmed, style)?;
+        Ok(Self { core, prefix })
+    }
+
+    /// Constructs a [`TaggedVersion`] from an already-parsed canonical
+    /// version plus an explicit prefix.
+    ///
+    /// Use this when a writer needs to emit a known core under a
+    /// specific convention — e.g. "always render with `v` regardless
+    /// of how the user typed it on the CLI".
+    #[must_use]
+    pub const fn new(core: Version, prefix: TagPrefix) -> Self {
+        Self { core, prefix }
+    }
+
+    /// Borrows the canonical [`Version`] for comparison or constraint matching.
+    #[must_use]
+    pub const fn as_canonical(&self) -> &Version {
+        &self.core
+    }
+
+    /// Returns a copy with the prefix replaced.
+    #[must_use]
+    pub const fn with_prefix(mut self, prefix: TagPrefix) -> Self {
+        self.prefix = prefix;
+        self
+    }
+
+    /// True when both the prefix and the canonical core match.
+    ///
+    /// Stricter than `==`, which compares only the canonical core. Use
+    /// in assertions where the rendered form is the contract — e.g. a
+    /// writer test verifying it emits the form a consumer requires.
+    #[must_use]
+    pub fn is_textually_identical(&self, other: &Self) -> bool {
+        self.prefix == other.prefix && self.core == other.core
+    }
+}
+
+impl fmt::Display for TaggedVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}{}", self.prefix, self.core)
+    }
+}
+
+impl PartialEq for TaggedVersion {
+    fn eq(&self, other: &Self) -> bool {
+        self.core == other.core
+    }
+}
+
+impl Eq for TaggedVersion {}
+
+impl PartialOrd for TaggedVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for TaggedVersion {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.core.cmp(&other.core)
+    }
+}
+
+impl Hash for TaggedVersion {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.core.hash(state);
+    }
+}
+
+impl Serialize for TaggedVersion {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for TaggedVersion {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(d)?;
+        // Default to Semver for serde — mirrors the convention used by
+        // `Version`'s Deserialize. Callers needing a different style
+        // should deserialize as String and route through `Self::parse`.
+        Self::parse(&s, VersionStyle::Semver).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_returns_bare_when_no_match() {
+        let (prefix, rest) = TagPrefix::detect("1.95.0");
+        assert_eq!(prefix, TagPrefix::Bare);
+        assert_eq!(rest, "1.95.0");
+    }
+
+    #[test]
+    fn as_str_round_trips_via_display() {
+        for prefix in
+            [TagPrefix::Bare, TagPrefix::V, TagPrefix::VCapital, TagPrefix::Release, TagPrefix::R]
+        {
+            assert_eq!(format!("{prefix}"), prefix.as_str());
+        }
+    }
+
+    #[test]
+    fn with_prefix_replaces_only_the_prefix() {
+        let original = TaggedVersion::parse("0.36.0", VersionStyle::Semver).unwrap();
+        let v_prefixed = original.clone().with_prefix(TagPrefix::V);
+        assert_eq!(v_prefixed.core, original.core);
+        assert_eq!(v_prefixed.prefix, TagPrefix::V);
+        assert_eq!(format!("{v_prefixed}"), "v0.36.0");
+    }
+}

--- a/crates/containers-common/tests/version_tagged.rs
+++ b/crates/containers-common/tests/version_tagged.rs
@@ -1,0 +1,202 @@
+//! Tests for [`TaggedVersion`] — prefix detection, round-trip identity,
+//! equality semantics, and the trivy-action regression class.
+
+use std::collections::HashSet;
+
+use containers_common::version::{TagPrefix, TaggedVersion, Version, VersionStyle};
+
+fn tagged(s: &str) -> TaggedVersion {
+    TaggedVersion::parse(s, VersionStyle::Semver).unwrap()
+}
+
+// ---------- 1. Tag-prefix detection ----------
+
+#[test]
+fn detects_bare_prefix() {
+    let v = tagged("1.95.0");
+    assert_eq!(v.prefix, TagPrefix::Bare);
+    assert_eq!(format!("{}", v.as_canonical()), "1.95.0");
+}
+
+#[test]
+fn detects_v_prefix() {
+    let v = tagged("v1.95.0");
+    assert_eq!(v.prefix, TagPrefix::V);
+    assert_eq!(format!("{}", v.as_canonical()), "1.95.0");
+}
+
+#[test]
+fn detects_capital_v_prefix() {
+    let v = tagged("V1.0.0");
+    assert_eq!(v.prefix, TagPrefix::VCapital);
+    assert_eq!(format!("{}", v.as_canonical()), "1.0.0");
+}
+
+#[test]
+fn detects_release_prefix() {
+    let v = tagged("release-1.95.0");
+    assert_eq!(v.prefix, TagPrefix::Release);
+    assert_eq!(format!("{}", v.as_canonical()), "1.95.0");
+}
+
+#[test]
+fn detects_r_prefix() {
+    let v = tagged("r1.2.3");
+    assert_eq!(v.prefix, TagPrefix::R);
+    assert_eq!(format!("{}", v.as_canonical()), "1.2.3");
+}
+
+#[test]
+fn r_prefix_only_strips_when_followed_by_digit() {
+    // Same guard as `Version::parse` — `rhel` is rejected by semver, not
+    // silently parsed as a prefix.
+    assert!(TaggedVersion::parse("rhel", VersionStyle::Semver).is_err());
+}
+
+// ---------- 2. Round-trip identity ----------
+
+#[test]
+fn round_trips_three_part_versions_under_every_prefix() {
+    let cases = [
+        ("1.95.0", TagPrefix::Bare),
+        ("v1.95.0", TagPrefix::V),
+        ("V1.0.0", TagPrefix::VCapital),
+        ("release-1.95.0", TagPrefix::Release),
+        ("r1.2.3", TagPrefix::R),
+    ];
+    for (input, expected_prefix) in cases {
+        let parsed = tagged(input);
+        assert_eq!(parsed.prefix, expected_prefix, "wrong prefix for {input}");
+        assert_eq!(format!("{parsed}"), input, "lost form for {input}");
+    }
+}
+
+#[test]
+fn round_trip_pads_relaxed_semver_consistently() {
+    // `Version::parse` pads `1.7` → `1.7.0`; that padding survives the
+    // round-trip — the prefix is preserved but the core normalizes.
+    let parsed = tagged("v1.7");
+    assert_eq!(parsed.prefix, TagPrefix::V);
+    assert_eq!(format!("{parsed}"), "v1.7.0");
+}
+
+// ---------- 3. Equality semantics ----------
+
+#[test]
+fn equality_ignores_prefix() {
+    let v = tagged("v1.0.0");
+    let bare = tagged("1.0.0");
+    let release = tagged("release-1.0.0");
+    assert_eq!(v, bare);
+    assert_eq!(v, release);
+    // Hash agrees with Eq (a hash-set deduplicates across prefixes).
+    let set: HashSet<_> = [v, bare, release].into_iter().collect();
+    assert_eq!(set.len(), 1);
+}
+
+#[test]
+fn is_textually_identical_distinguishes_prefix() {
+    let v = tagged("v1.0.0");
+    let bare = tagged("1.0.0");
+    assert!(!v.is_textually_identical(&bare));
+    assert!(v.is_textually_identical(&v.clone()));
+}
+
+#[test]
+fn ordering_follows_canonical_core() {
+    let mut versions =
+        [tagged("v1.10.0"), tagged("release-1.2.0"), tagged("1.9.0"), tagged("v1.2.5")];
+    versions.sort();
+    let cores: Vec<_> = versions.iter().map(|v| format!("{}", v.as_canonical())).collect();
+    assert_eq!(cores, vec!["1.2.0", "1.2.5", "1.9.0", "1.10.0"]);
+}
+
+// ---------- 4. trivy-action regression ----------
+
+/// The bug this primitive exists to prevent.
+///
+/// trivy-action published `0.35.0` for years, then switched to v-prefixed-only
+/// tags at v0.36.0. Our shell pipeline normalized everything to bare, wrote
+/// `aquasecurity/trivy-action@0.36.0` into CI, and every Security Scan job
+/// failed because that tag does not exist.
+///
+/// With [`TaggedVersion`], a writer that knows the tool's convention can
+/// emit the correct form regardless of how the upstream payload arrived.
+#[test]
+fn trivy_action_writes_v_prefix_even_when_read_bare() {
+    // 1. Upstream GitHub API returns `v0.36.0`, parsed into a TaggedVersion.
+    let upstream = tagged("v0.36.0");
+    assert_eq!(upstream.prefix, TagPrefix::V);
+
+    // 2. Catalog stores the canonical core (`0.36.0`) — same as today.
+    let core = upstream.as_canonical().clone();
+    assert_eq!(format!("{core}"), "0.36.0");
+
+    // 3. The writer emits using the recorded prefix, NOT bare.
+    let to_write = TaggedVersion::new(core, TagPrefix::V);
+    assert_eq!(format!("{to_write}"), "v0.36.0");
+}
+
+#[test]
+fn writer_can_force_prefix_even_for_bare_input() {
+    // The reverse scenario: an old catalog entry stored `0.36.0` bare
+    // before this primitive existed, but the consumer now requires
+    // `v0.36.0`. `with_prefix` upgrades it deterministically.
+    let bare = tagged("0.36.0");
+    let v_prefixed = bare.with_prefix(TagPrefix::V);
+    assert_eq!(format!("{v_prefixed}"), "v0.36.0");
+}
+
+// ---------- 5. Serde round-trip ----------
+
+#[test]
+fn serde_preserves_prefix_through_json() {
+    let original = tagged("v0.36.0");
+    let json = serde_json::to_string(&original).unwrap();
+    assert_eq!(json, "\"v0.36.0\"");
+    let reparsed: TaggedVersion = serde_json::from_str(&json).unwrap();
+    assert!(original.is_textually_identical(&reparsed));
+}
+
+#[test]
+fn serde_round_trip_every_prefix() {
+    for input in ["1.95.0", "v1.95.0", "V1.0.0", "release-1.95.0", "r1.2.3"] {
+        let v = tagged(input);
+        let json = serde_json::to_string(&v).unwrap();
+        let back: TaggedVersion = serde_json::from_str(&json).unwrap();
+        assert!(v.is_textually_identical(&back), "lost form across serde: {input}");
+    }
+}
+
+// ---------- 6. Bridge with Version ----------
+
+#[test]
+fn as_canonical_returns_same_value_as_version_parse() {
+    let direct = Version::parse("v1.95.0", VersionStyle::Semver).unwrap();
+    let via_tagged = tagged("v1.95.0");
+    assert_eq!(via_tagged.as_canonical(), &direct);
+}
+
+#[test]
+fn empty_input_is_rejected() {
+    assert!(TaggedVersion::parse("", VersionStyle::Semver).is_err());
+    assert!(TaggedVersion::parse("   ", VersionStyle::Semver).is_err());
+}
+
+#[test]
+fn tag_prefix_detect_matches_internal_split() {
+    // Public TagPrefix::detect should produce identical results to what
+    // TaggedVersion::parse records internally.
+    for (raw, expected) in [
+        ("1.0.0", TagPrefix::Bare),
+        ("v1.0.0", TagPrefix::V),
+        ("V1.0.0", TagPrefix::VCapital),
+        ("release-1.0.0", TagPrefix::Release),
+        ("r1.0.0", TagPrefix::R),
+    ] {
+        let (prefix, _) = TagPrefix::detect(raw);
+        assert_eq!(prefix, expected, "detect disagreed for {raw}");
+        let parsed = tagged(raw);
+        assert_eq!(parsed.prefix, prefix);
+    }
+}

--- a/crates/luggage/src/resolver.rs
+++ b/crates/luggage/src/resolver.rs
@@ -389,6 +389,7 @@ mod tests {
             },
             validation_tiers: None,
             version_style: Some(VersionStyle::Semver),
+            tag_prefix: None,
             default_version: Some("1.95.0".into()),
             minimum_recommended: None,
             channels: Some(


### PR DESCRIPTION
## Summary

- New `TagPrefix` enum (`Bare`/`V`/`VCapital`/`Release`/`R`) + `TaggedVersion` wrapper in `containers-common::version` — the boundary type that preserves the upstream tag's reference form (`v0.36.0` vs `0.36.0`) so writers can emit the form the consumer expects regardless of how the value arrived.
- Equality and ordering on `TaggedVersion` delegate to the canonical `Version`, so `v1.0.0 == 1.0.0`. Storage and constraint matching are unchanged.
- Added optional `tag_prefix: Option<TagPrefix>` to `tooldb::Tool` (serde-default; forward-compatible with the pinned containers-db schema v0.1.0).
- 18-test round-trip suite at `crates/containers-common/tests/version_tagged.rs` including an explicit **trivy-action regression test** that asserts a writer with `TagPrefix::V` emits `"v0.36.0"`, not `"0.36.0"`.

## Scope

This PR delivers the **foundation** for #410. Follow-ups are tracked separately:

1. containers-db schema bump adding `tag_prefix` to `tool.schema.json` (against the sibling repo).
2. Stibbons `check-versions` Rust tool consuming `TaggedVersion` end-to-end.
3. Shared URL-templating helper for `lib/features/*.sh`.
4. Retiring `bin/check-versions.sh` + `bin/lib/update-versions/updaters.sh` once the Rust tool reaches parity.

The trivy-action hotfix (`c45724b`) and the bash version pipeline are intentionally untouched — they stay live until (2)–(4) land.

## Test plan

- [x] `cargo test --workspace` — 257+ tests pass, including the 18 new tests and the new module-level doctest.
- [x] `just lint containers-common` — clippy + rustfmt + taplo clean.
- [x] `cargo doc -p containers-common --no-deps` — no new doc warnings (one pre-existing `Verification.extra` link warning unrelated to this PR).
- [x] Manual verification of the trivy-action scenario: `TaggedVersion::new(Version::parse("0.36.0", Semver)?, TagPrefix::V).to_string() == "v0.36.0"` — codified in `tests/version_tagged.rs::trivy_action_writes_v_prefix_even_when_read_bare`.

## Pre-review findings

- 1x missing-test-file scanner heuristic flagged `crates/containers-common/src/version/parse.rs` — false positive; `parse.rs` is covered by the existing `tests/version_parse.rs` integration tests (the scanner doesn't recognize that naming convention).

Closes #410