### PR TITLE
fix(luggage): chown new cache subdirs to install user

### DIFF
--- a/crates/luggage/src/installer/methods/script_installer.rs
+++ b/crates/luggage/src/installer/methods/script_installer.rs
@@ -2,7 +2,8 @@
 //!
 //! Reproduces the side-effects of `lib/features/rust.sh` in Rust:
 //!
-//! 1. Ensure `cache_root/cargo` and `cache_root/rustup` exist.
+//! 1. Ensure `cache_root/cargo` and `cache_root/rustup` exist, and chown
+//!    them to the install user so `su -c` writes don't hit EACCES.
 //! 2. Mark the downloaded artifact executable.
 //! 3. `su - <user> -c "export CARGO_HOME=...; export RUSTUP_HOME=...;
 //!    <artifact> <args...>"`.
@@ -22,7 +23,7 @@ use shell_words::quote;
 
 use super::{CommandRunner, MethodContext};
 use crate::error::{LuggageError, Result};
-use crate::installer::user::su_command;
+use crate::installer::user::{chown_command, su_command};
 
 /// Binaries the rust install must surface in `bin_root` for parity with
 /// `lib/features/rust.sh`.
@@ -42,11 +43,29 @@ pub const RUST_BINARIES: &[&str] =
 ///   rather than post-install — but the error variant fits "user-running
 ///   command failed" semantics best.)
 pub fn run(ctx: &MethodContext<'_>) -> Result<()> {
-    // 1. Ensure cache directories exist.
+    // 1. Ensure cache directories exist and are owned by the install
+    //    user. `create_dir_all` runs in the parent (root) process, so any
+    //    subdirs it creates would otherwise be root-owned; the subsequent
+    //    `su -c rustup-init` child would then hit EACCES on the first
+    //    write into `$RUSTUP_HOME` (see issue #462).
     let cargo_home = ctx.cache_root.join("cargo");
     let rustup_home = ctx.cache_root.join("rustup");
     for dir in [&cargo_home, &rustup_home] {
         fs::create_dir_all(dir).map_err(|e| LuggageError::Io { path: dir.clone(), source: e })?;
+        let argv = chown_command(ctx.user, dir);
+        let outcome = ctx.runner.run(&argv[0], &argv[1..])?;
+        if !outcome.success() {
+            return Err(LuggageError::InstallStageFailed {
+                stage: "chown",
+                message: format!(
+                    "chown {} -> {} exited with status {:?}: {}",
+                    dir.display(),
+                    ctx.user,
+                    outcome.status,
+                    String::from_utf8_lossy(&outcome.stderr).trim_end(),
+                ),
+            });
+        }
     }
 
     // 2. chmod +x the downloaded installer.
@@ -193,6 +212,62 @@ mod tests {
         assert!(payload.contains("--default-toolchain"));
         assert!(payload.contains("1.95.0"));
         assert!(payload.contains(&artifact.display().to_string()));
+
+        // chown must precede su, so the su child can write into the
+        // cache subdirs without hitting EACCES.
+        let su_idx = calls.iter().position(|(p, _)| p == "su").unwrap();
+        let chown_idx = calls
+            .iter()
+            .position(|(p, _)| p == "chown")
+            .expect("expected at least one chown call before su");
+        assert!(
+            chown_idx < su_idx,
+            "expected chown to run before su (chown_idx={chown_idx}, su_idx={su_idx})",
+        );
+    }
+
+    #[test]
+    fn run_chowns_cache_directories() {
+        let cache = tempdir().unwrap();
+        let bin = tempdir().unwrap();
+        let tmp = tempdir().unwrap();
+        let artifact = make_artifact(tmp.path());
+        let runner = RecordingRunner::new();
+        let env = BTreeMap::new();
+        let args: Vec<String> = vec![];
+
+        let ctx = MethodContext {
+            artifact: &artifact,
+            args: &args,
+            env: &env,
+            user: "vscode",
+            cache_root: cache.path(),
+            bin_root: bin.path(),
+            runner: &runner,
+        };
+        run(&ctx).unwrap();
+
+        let calls = runner.calls();
+        let chown_calls: Vec<&(String, Vec<String>)> =
+            calls.iter().filter(|(p, _)| p == "chown").collect();
+        assert_eq!(chown_calls.len(), 2, "expected one chown per cache subdir");
+
+        let cargo_path = cache.path().join("cargo").display().to_string();
+        let rustup_path = cache.path().join("rustup").display().to_string();
+        let chown_paths: Vec<&String> =
+            chown_calls.iter().map(|(_, args)| args.last().unwrap()).collect();
+        assert!(
+            chown_paths.iter().any(|p| **p == cargo_path),
+            "expected a chown for {cargo_path} in {chown_paths:?}",
+        );
+        assert!(
+            chown_paths.iter().any(|p| **p == rustup_path),
+            "expected a chown for {rustup_path} in {chown_paths:?}",
+        );
+        for (_, chown_args) in chown_calls {
+            assert_eq!(chown_args[0], "-R");
+            assert_eq!(chown_args[1], "vscode:vscode");
+        }
     }
 
     #[test]
@@ -248,6 +323,47 @@ mod tests {
                 "expected {name} to be symlinked under {}",
                 bin.path().display(),
             );
+        }
+    }
+
+    #[test]
+    fn run_propagates_chown_failure_as_install_stage_failed() {
+        let cache = tempdir().unwrap();
+        let bin = tempdir().unwrap();
+        let tmp = tempdir().unwrap();
+        let artifact = make_artifact(tmp.path());
+        let runner = RecordingRunner::new();
+        runner.set_outcome(
+            "chown",
+            CommandOutcome {
+                status: Some(1),
+                stdout: vec![],
+                stderr: b"chown: invalid user: 'vscode'".to_vec(),
+            },
+        );
+        let env = BTreeMap::new();
+        let args: Vec<String> = vec![];
+
+        let ctx = MethodContext {
+            artifact: &artifact,
+            args: &args,
+            env: &env,
+            user: "vscode",
+            cache_root: cache.path(),
+            bin_root: bin.path(),
+            runner: &runner,
+        };
+        let err = run(&ctx).unwrap_err();
+        match err {
+            LuggageError::InstallStageFailed { stage, message } => {
+                assert_eq!(stage, "chown");
+                assert!(message.contains("vscode"), "message missing user: {message}");
+                assert!(
+                    message.contains("invalid user"),
+                    "message missing stderr passthrough: {message}",
+                );
+            }
+            other => panic!("expected InstallStageFailed, got {other:?}"),
         }
     }
 

--- a/crates/luggage/src/installer/user.rs
+++ b/crates/luggage/src/installer/user.rs
@@ -11,6 +11,7 @@
 use std::collections::BTreeMap;
 use std::env;
 use std::fmt::Write as _;
+use std::path::Path;
 
 use shell_words::quote;
 
@@ -52,6 +53,19 @@ pub fn su_command(user: &str, env: &BTreeMap<String, String>, body: &str) -> Vec
     }
     payload.push_str(body);
     vec!["su".into(), "-".into(), user.into(), "-c".into(), payload]
+}
+
+/// Build a `chown -R <user>:<user> <path>` argv.
+///
+/// Used after `create_dir_all` in the root process to transfer ownership
+/// of freshly-created directory trees to the install user, so the
+/// subsequent `su - <user> -c "..."` child can write into them without
+/// hitting permission-denied on the first write. The colon form sets
+/// group ownership too; the production user-creation step gives the
+/// install user a matching login group.
+#[must_use]
+pub fn chown_command(user: &str, path: &Path) -> Vec<String> {
+    vec!["chown".into(), "-R".into(), format!("{user}:{user}"), path.display().to_string()]
 }
 
 #[cfg(test)]
@@ -107,5 +121,11 @@ mod tests {
         env.insert("WEIRD".to_owned(), "value with spaces".to_owned());
         let argv = su_command("vscode", &env, "true");
         assert!(argv[4].contains("'value with spaces'"));
+    }
+
+    #[test]
+    fn chown_command_builds_recursive_user_group_argv() {
+        let argv = chown_command("vscode", Path::new("/cache/cargo"));
+        assert_eq!(argv, vec!["chown", "-R", "vscode:vscode", "/cache/cargo"]);
     }
 }

--- a/tests/integration/builds/luggage_rust/Dockerfile.luggage-rust
+++ b/tests/integration/builds/luggage_rust/Dockerfile.luggage-rust
@@ -35,13 +35,14 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends adduser ca-certificates curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Match the production user setup. lib/features/rust.sh pre-creates the
-# cargo/rustup cache subdirs and chowns them to the install user before
-# invoking luggage; the fixture mirrors that so `su -c rustup-init` can
-# write `/cache/rustup/settings.toml` without a permission error.
+# Create the install user plus the `/cache` and `/var/log/luggage` roots
+# that luggage will write into. luggage itself creates the `cargo` and
+# `rustup` cache subdirs and chowns them to the install user (issue #462),
+# so this fixture deliberately does NOT pre-create those subdirs — that
+# proves the in-binary chown path works end-to-end on a clean image.
 RUN adduser --disabled-password --gecos '' --shell /bin/bash vscode \
-    && mkdir -p /cache/cargo /cache/rustup /var/log/luggage \
-    && chown -R vscode:vscode /cache /var/log/luggage
+    && mkdir -p /cache /var/log/luggage \
+    && chown vscode:vscode /cache /var/log/luggage
 ENV USERNAME=vscode
 
 # Bring the luggage binary and the testdata catalog into the image.


### PR DESCRIPTION
## Summary

`script_installer::run` created `<cache>/cargo` and `<cache>/rustup` via
`fs::create_dir_all` in the root process, then `su`ed to the install user
for rustup-init. The fresh subdirs were root-owned, so the `su` child hit
EACCES on the first write into `$RUSTUP_HOME`. amd64 builds masked the bug
because qemu emulation aborted rustup-init earlier; the smoke fixture on
arm64 surfaced it.

- Add `chown_command(user, path)` argv builder in `installer/user.rs` —
  mirrors the existing `su_command` pattern (pure argv, caller dispatches
  via the runner).
- `script_installer::run` invokes `chown -R <user>:<user> <path>` after
  each `create_dir_all`; non-zero exits surface as
  `LuggageError::InstallStageFailed { stage: "chown", .. }`.
- Drop `/cache/cargo /cache/rustup` from the smoke fixture's pre-create
  so it exercises the new in-binary chown path. `/cache` and
  `/var/log/luggage` parent dirs are still pre-created.

The `lib/features/rust.sh` workaround removal is **out of scope** per the
issue acceptance criteria — file a follow-up if desired.

## Test plan

- [x] `cargo test -p luggage --lib` — 147 pass, including:
  - `installer::user::tests::chown_command_builds_recursive_user_group_argv`
  - `installer::methods::script_installer::tests::run_invokes_su_with_expected_payload` (extended to assert chown precedes su)
  - `installer::methods::script_installer::tests::run_chowns_cache_directories`
  - `installer::methods::script_installer::tests::run_propagates_chown_failure_as_install_stage_failed`
- [x] `cargo clippy -p luggage --lib --tests -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [ ] `just test-integration-one luggage_rust` on arm64 — exercises the
      simplified Dockerfile end-to-end (skipped locally — CI is authoritative)

## Pre-review findings

- 1x `missing-test-file` (`crates/luggage/src/installer/methods/script_installer.rs`)
  — false positive; the file has inline `#[cfg(all(test, unix))] mod tests`
  per Rust convention, with four tests covering this method including the
  three new/updated ones above.

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)