### PR TITLE
fix(luggage): propagate env map to validate subprocess

### DIFF
--- a/crates/luggage/src/installer/mod.rs
+++ b/crates/luggage/src/installer/mod.rs
@@ -317,12 +317,23 @@ impl Installer {
         fs::write(&artifact, &bytes)
             .map_err(|e| LuggageError::Io { path: artifact.clone(), source: e })?;
 
-        let env_map = invoke_env_map(resolved);
+        // Build the env map once so every stage that shells out (install
+        // method, post-install steps, post-install validate) sees the same
+        // CARGO_HOME / RUSTUP_HOME. validate previously relied on the parent
+        // process's exports and failed when the rustup proxy fell back to
+        // `$HOME/.rustup` (issue #463).
+        let mut env_map = invoke_env_map(resolved);
+        env_map
+            .entry("CARGO_HOME".to_owned())
+            .or_insert_with(|| self.options.cache_root.join("cargo").display().to_string());
+        env_map
+            .entry("RUSTUP_HOME".to_owned())
+            .or_insert_with(|| self.options.cache_root.join("rustup").display().to_string());
         let invoke_args = plan.invoke_args.clone().unwrap_or_default();
         let user = plan.user;
         self.stage_method(resolved, &artifact, &invoke_args, &env_map, &user, logger)?;
-        self.stage_post_install(resolved, &user, env_map, logger)?;
-        self.stage_validate(resolved, logger)
+        self.stage_post_install(resolved, &user, &env_map, logger)?;
+        self.stage_validate(resolved, &env_map, logger)
     }
 
     fn stage_system_packages(
@@ -412,19 +423,12 @@ impl Installer {
         &self,
         resolved: &ResolvedInstall,
         user: &str,
-        mut env_map: BTreeMap<String, String>,
+        env_map: &BTreeMap<String, String>,
         logger: Option<&logging::FeatureLogger>,
     ) -> Result<()> {
         // Post-install runs in a fresh `su -` so it needs the same env the
-        // install method exported. If the catalog didn't pin them, add the
-        // pilot defaults under `cache_root`.
-        env_map
-            .entry("CARGO_HOME".to_owned())
-            .or_insert_with(|| self.options.cache_root.join("cargo").display().to_string());
-        env_map
-            .entry("RUSTUP_HOME".to_owned())
-            .or_insert_with(|| self.options.cache_root.join("rustup").display().to_string());
-
+        // install method exported. `run_stages` prefills the cache-root
+        // CARGO_HOME / RUSTUP_HOME defaults so every stage shares one map.
         let Some(steps) = resolved.post_install.as_deref() else { return Ok(()) };
         if steps.is_empty() {
             return Ok(());
@@ -432,18 +436,19 @@ impl Installer {
         if let Some(l) = logger {
             l.step(&format!("post-install ({} steps)", steps.len()));
         }
-        post_install::run_steps(steps, user, &env_map, self.runner.as_ref())
+        post_install::run_steps(steps, user, env_map, self.runner.as_ref())
     }
 
     fn stage_validate(
         &self,
         resolved: &ResolvedInstall,
+        env_map: &BTreeMap<String, String>,
         logger: Option<&logging::FeatureLogger>,
     ) -> Result<()> {
         if let Some(l) = logger {
             l.step("validate");
         }
-        validate::check(&resolved.tool, &resolved.version, &self.options.bin_root)
+        validate::check(&resolved.tool, &resolved.version, &self.options.bin_root, env_map)
     }
 }
 

--- a/crates/luggage/src/installer/validate.rs
+++ b/crates/luggage/src/installer/validate.rs
@@ -8,6 +8,7 @@
 //! Same scope/limitation as the idempotency check (issue #404 will
 //! generalise this via catalog `validation_tiers`).
 
+use std::collections::BTreeMap;
 use std::path::Path;
 use std::process::Command;
 
@@ -17,12 +18,23 @@ use crate::installer::idempotency::primary_binary;
 /// Confirm that `tool` reports `version` from `<bin_root>/<binary> --version`,
 /// where `binary` is [`primary_binary`] of `tool`.
 ///
+/// `env` is layered on top of the inherited process environment with
+/// [`Command::envs`]. For rustup-proxy binaries this must include
+/// `CARGO_HOME` / `RUSTUP_HOME`; otherwise the proxy falls back to
+/// `$HOME/.rustup` and reports "no default toolchain configured" even when
+/// the toolchain was just installed under `cache_root`.
+///
 /// # Errors
 ///
 /// - [`LuggageError::ValidationFailed`] when the binary is missing, the
 ///   command fails to launch, the exit status is non-zero, or the output
 ///   doesn't mention the target version.
-pub fn check(tool: &str, version: &str, bin_root: &Path) -> Result<()> {
+pub fn check(
+    tool: &str,
+    version: &str,
+    bin_root: &Path,
+    env: &BTreeMap<String, String>,
+) -> Result<()> {
     let binary = bin_root.join(primary_binary(tool));
     if !binary.exists() {
         return Err(LuggageError::ValidationFailed {
@@ -31,7 +43,7 @@ pub fn check(tool: &str, version: &str, bin_root: &Path) -> Result<()> {
             message: format!("binary not found at {}", binary.display()),
         });
     }
-    let output = Command::new(&binary).arg("--version").output().map_err(|e| {
+    let output = Command::new(&binary).arg("--version").envs(env).output().map_err(|e| {
         LuggageError::ValidationFailed {
             tool: tool.to_owned(),
             version: version.to_owned(),
@@ -84,7 +96,7 @@ mod tests {
     #[test]
     fn missing_binary_returns_validation_failed() {
         let dir = tempdir().unwrap();
-        let err = check("rustc", "1.95.0", dir.path()).unwrap_err();
+        let err = check("rustc", "1.95.0", dir.path(), &BTreeMap::new()).unwrap_err();
         assert!(matches!(err, LuggageError::ValidationFailed { .. }));
     }
 
@@ -93,7 +105,7 @@ mod tests {
     fn matching_output_passes() {
         let dir = tempdir().unwrap();
         write_shim(dir.path(), "rustc", "rustc 1.95.0 (abcdef0)");
-        check("rustc", "1.95.0", dir.path()).unwrap();
+        check("rustc", "1.95.0", dir.path(), &BTreeMap::new()).unwrap();
     }
 
     #[cfg(unix)]
@@ -101,12 +113,42 @@ mod tests {
     fn mismatched_output_returns_validation_failed() {
         let dir = tempdir().unwrap();
         write_shim(dir.path(), "rustc", "rustc 1.84.0");
-        let err = check("rustc", "1.95.0", dir.path()).unwrap_err();
+        let err = check("rustc", "1.95.0", dir.path(), &BTreeMap::new()).unwrap_err();
         match err {
             LuggageError::ValidationFailed { message, .. } => {
                 assert!(message.contains("1.95.0"));
             }
             other => panic!("expected ValidationFailed, got {other:?}"),
         }
+    }
+
+    /// Regression test for issue #463: validate must propagate the env map
+    /// to the child process so the rustup proxy can find the toolchain
+    /// under `CARGO_HOME` / `RUSTUP_HOME` regardless of what the caller
+    /// exported.
+    ///
+    /// The shim echoes `rustc $LUGGAGE_TEST_VERSION` — when the env map is
+    /// propagated, the substituted value matches the version the check is
+    /// looking for; without propagation the variable expands to empty and
+    /// the version-contains assertion fails.
+    #[cfg(unix)]
+    #[test]
+    fn propagates_env_to_subprocess() {
+        let dir = tempdir().unwrap();
+        let shim = dir.path().join("rustc");
+        fs::write(&shim, "#!/bin/sh\necho \"rustc $LUGGAGE_TEST_VERSION\"\n").unwrap();
+        let mut perms = fs::metadata(&shim).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&shim, perms).unwrap();
+
+        let mut env = BTreeMap::new();
+        env.insert("LUGGAGE_TEST_VERSION".to_owned(), "1.95.0".to_owned());
+
+        check("rustc", "1.95.0", dir.path(), &env).unwrap();
+
+        // Negative case: without the env entry, the shim emits `rustc ` and
+        // the contains-version assertion must fail.
+        let err = check("rustc", "1.95.0", dir.path(), &BTreeMap::new()).unwrap_err();
+        assert!(matches!(err, LuggageError::ValidationFailed { .. }));
     }
 }

--- a/docs/architecture/luggage-migration.md
+++ b/docs/architecture/luggage-migration.md
@@ -90,4 +90,4 @@ For each feature script (e.g. `node.sh`, `python.sh`):
 
 | Feature | Issue | Notes |
 | --- | --- | --- |
-| `rust.sh` | #407 | Pilot. Channels (`stable`/`beta`/`nightly`) route through `--channel`. cargo dev tools (cargo-watch, mdbook suite) remain in bash. |
+| `rust.sh` | #407 | Pilot. Channels (`stable`/`beta`/`nightly`) route through `--channel`. cargo dev tools (cargo-watch, mdbook suite) remain in bash. Callers no longer need to `export CARGO_HOME` / `RUSTUP_HOME` before invoking luggage — the validate subprocess now inherits them from the install (#463). |

--- a/lib/features/rust.sh
+++ b/lib/features/rust.sh
@@ -112,12 +112,6 @@ log_command "Setting cache directory ownership" \
 # route through `--channel`; semver-shaped values use `tool@<version>`.
 log_message "Installing Rust toolchain via luggage..."
 
-# Export CARGO_HOME/RUSTUP_HOME so luggage's post-install validation step —
-# which runs `rustc --version` via the rustup proxy — can locate the
-# toolchain it just installed. Without these, the proxy looks at
-# `$HOME/.rustup` and reports "no default toolchain configured".
-export CARGO_HOME RUSTUP_HOME
-
 if [[ "$RUST_VERSION" =~ ^(stable|beta|nightly)$ ]]; then
     log_command "luggage install rust --channel ${RUST_VERSION}" \
         /usr/local/bin/luggage install rust \

--- a/tests/integration/builds/luggage_rust/Dockerfile.luggage-rust
+++ b/tests/integration/builds/luggage_rust/Dockerfile.luggage-rust
@@ -54,19 +54,16 @@ COPY crates/luggage/testdata/catalog /opt/containers-db
 # from a single Cargo.lock without depending on the live containers-db
 # repo. Platform is auto-detected from /etc/os-release + ARCH so the
 # fixture works on amd64 and arm64 build hosts alike.
-#
-# CARGO_HOME / RUSTUP_HOME are exported so luggage's post-install
-# validation (`rustc --version` via the rustup proxy) can locate the
-# toolchain — without them the proxy reports "no default toolchain".
-ENV CARGO_HOME=/cache/cargo \
-    RUSTUP_HOME=/cache/rustup
 RUN /usr/local/bin/luggage install "rust@${RUST_VERSION}" \
     --catalog /opt/containers-db \
     --user vscode
 
-# Sanity touchstone for the smoke test driver. CARGO_HOME / RUSTUP_HOME
-# are already set above for the install RUN; here we just add the PATH.
-ENV PATH="/cache/cargo/bin:/usr/local/bin:${PATH}"
+# Toolchain env for the USER vscode session below (smoke driver runs
+# cargo). The install RUN above intentionally runs without these set —
+# luggage propagates them internally.
+ENV CARGO_HOME=/cache/cargo \
+    RUSTUP_HOME=/cache/rustup \
+    PATH="/cache/cargo/bin:/usr/local/bin:${PATH}"
 
 USER vscode
 WORKDIR /home/vscode


### PR DESCRIPTION
## Summary

`validate::check` was inheriting the parent process env for its
`<bin_root>/<tool> --version` subprocess. For rustup-proxy binaries that
meant a missing `RUSTUP_HOME` sent the proxy to `$HOME/.rustup`, where it
couldn't find the toolchain just installed under `cache_root` — and the
install bailed with `"no default toolchain configured"`.

- Hoist the cache-root-derived `CARGO_HOME` / `RUSTUP_HOME` defaulting
  from `stage_post_install` up into `run_stages`, build the env map once,
  and thread `&env_map` through `stage_method`, `stage_post_install`, and
  the new `stage_validate(env_map)`.
- `validate::check` now calls `Command::envs(env)` so the child inherits
  a known-good env regardless of caller exports. `.envs()` (additive) is
  preferred over `env_clear()+envs()` so the rustup proxy still sees
  `PATH` / `HOME` / `USER`.
- Drop the `export CARGO_HOME RUSTUP_HOME` workaround in
  `lib/features/rust.sh`.
- In `Dockerfile.luggage-rust`, the `ENV CARGO_HOME` / `RUSTUP_HOME`
  block moves from before the install RUN to after it (the runtime
  `USER vscode` session still needs them; the install no longer does).
- Note the export removal in the `luggage-migration.md` Ported features
  table so future port authors don't reintroduce the workaround.

## Test plan

- [x] `cargo test -p luggage --lib installer::validate` — 4/4 pass,
      including new `propagates_env_to_subprocess` regression test.
- [x] `cargo test -p luggage` — full suite passes (8 unit + 6 install_rust
      integration + 11 policy + doctest).
- [x] `cargo clippy -p luggage --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `shellcheck lib/features/rust.sh` clean.
- [ ] CI exercises the smoke fixture (`tests/integration/builds/luggage_rust`)
      end-to-end on amd64 + arm64 with `ENV CARGO_HOME` / `RUSTUP_HOME`
      removed from before the install RUN — proves the fix on a clean image
      without the caller pre-exporting.

Closes #463