### PR TITLE
fix(tooldb): switch db-validate to validate-catalog Rust binary

### DIFF
--- a/justfile
+++ b/justfile
@@ -301,6 +301,9 @@ db-validate: db-compile
     #!/usr/bin/env bash
     set -euo pipefail
     cd "{{ CONTAINERS_DB }}"
+    # Build the Rust semantic validator once; the negative-fixture loop below
+    # invokes it per fixture and we don't want cargo re-checking freshness each time.
+    cargo build --release -p db-validator --bin validate-catalog
     ajv() {
         npx --yes -p ajv-cli@{{ AJV_CLI_VERSION }} -p ajv-formats@{{ AJV_FORMATS_VERSION }} -- ajv "$@"
     }
@@ -308,24 +311,24 @@ db-validate: db-compile
     ajv validate {{ AJV_FLAGS }} -s schema/tool.schema.json    -d fixtures/sample-tool/index.json
     ajv validate {{ AJV_FLAGS }} -s schema/version.schema.json -d "fixtures/sample-tool/versions/*.json"
     ajv validate {{ AJV_FLAGS }} -s schema/version.schema.json -d "fixtures/tier*-example.json"
-    # Cross-reference + comparator-placeholder check
-    node scripts/validate-cross-refs.mjs
-    # Negative fixtures: each must be rejected by ajv OR by validate-cross-refs
-    # (matches the workflow's combined ajv_rc/xref_rc check).
+    # Semantic validation (full catalog walk via the Rust validator)
+    ./target/release/validate-catalog
+    # Negative fixtures: each must be rejected by ajv OR by validate-catalog
+    # (matches the workflow's combined ajv_rc/sem_rc check).
     for fixture in fixtures/_negative/*.json; do
         ajv_rc=0
-        xref_rc=0
+        sem_rc=0
         set +e
         ajv validate {{ AJV_FLAGS }} -s schema/version.schema.json -d "$fixture"
         ajv_rc=$?
-        node scripts/validate-cross-refs.mjs --only "$fixture"
-        xref_rc=$?
+        ./target/release/validate-catalog --only "$fixture"
+        sem_rc=$?
         set -e
-        if [ "$ajv_rc" -eq 0 ] && [ "$xref_rc" -eq 0 ]; then
-            echo "ERROR: negative fixture $fixture passed both ajv AND cross-ref" >&2
+        if [ "$ajv_rc" -eq 0 ] && [ "$sem_rc" -eq 0 ]; then
+            echo "ERROR: negative fixture $fixture passed both ajv AND validate-catalog" >&2
             exit 1
         fi
-        echo "Negative fixture $fixture correctly rejected (ajv=$ajv_rc, xref=$xref_rc)"
+        echo "Negative fixture $fixture correctly rejected (ajv=$ajv_rc, validate-catalog=$sem_rc)"
     done
 
 # Validate one tool's index (and versions/, if present).


### PR DESCRIPTION
## Summary

`just db-validate` was wired to `node scripts/validate-cross-refs.mjs` in the
sibling `containers-db` repo. That script was deleted upstream
([joshjhall/containers-db@5e8b5c1](https://github.com/joshjhall/containers-db/commit/5e8b5c1))
when the cross-reference / semantic check was rewritten as the Rust binary
`validate-catalog` (in `containers-db/validator/`). The recipe was crashing
mid-run with `Cannot find module …/validate-cross-refs.mjs`, after the
positive ajv pass succeeded — masking a real local validation gap. CI is
unaffected (it already uses the Rust binary).

This PR swaps both `node` invocations for the Rust validator, building it
once at the top of the recipe so the per-negative-fixture loop stays fast.
Variable name and failure message updated from `xref_rc` to `sem_rc` /
`validate-catalog` to match the terminology in
[`containers-db/.github/workflows/validate.yml`](https://github.com/joshjhall/containers-db/blob/main/.github/workflows/validate.yml).

`db-validate-tool` and `db-validate-all` don't touch the missing script —
no changes there.

## Test plan

- [x] `just db-validate` runs clean (exit 0) against the local containers-db checkout
- [x] Both positive (`fixtures/sample-tool/*`, `fixtures/tier*-example.json`) and
      negative (`fixtures/_negative/*.json`) fixture validation still exercised
- [x] `grep "validate-cross-refs\|xref_rc" justfile` → no matches
- [x] Lefthook + conform pre-commit and pre-push hooks pass

Closes #474