### PR TITLE
feat(luggage): add --json-report and TestEntry recorder for evidence runs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,6 +696,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1790,6 +1799,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1997,6 +2012,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2215,6 +2236,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "record-evidence"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "containers-common",
+ "luggage",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]
@@ -2841,6 +2876,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,11 @@
 [workspace]
 resolver = "3"
-members = ["crates/stibbons", "crates/containers-common", "crates/luggage"]
+members = [
+  "crates/stibbons",
+  "crates/containers-common",
+  "crates/luggage",
+  "crates/record-evidence",
+]
 
 [workspace.package]
 edition = "2024"
@@ -31,6 +36,7 @@ tempfile = "3"
 sha2 = "0.10"
 semver = { version = "1", features = ["serde"] }
 thiserror = "2"
+time = { version = "0.3", features = ["formatting", "macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/crates/containers-common/src/tooldb/mod.rs
+++ b/crates/containers-common/src/tooldb/mod.rs
@@ -8,8 +8,12 @@
 //!
 //! # Compatibility
 //!
-//! Pinned to **containers-db v0.1.0** (commit `03c1fd5`, tagged 2026-04-26).
-//! Bump when the upstream `schemaVersion` const changes.
+//! Pinned to **containers-db** commit `aa14378` (tagged 2026-05-14).
+//! `schemaVersion` remains `1` — the 2026-05-14 update added optional
+//! evidence fields to [`TestEntry`] (`image_ref`, `image_digest`,
+//! `duration_seconds`, `version_output`, `error_class`) but kept the
+//! shape backward-compatible. Bump the pin when `schemaVersion` itself
+//! changes upstream.
 //!
 //! # Forward compatibility
 //!
@@ -33,5 +37,6 @@ pub use tool::{
     ValidationTiers,
 };
 pub use version::{
-    SupportEntry, SupportStatus, TestEntry, TestResult, ToolVersion, Uninstall, VersionMetadata,
+    ErrorClass, SupportEntry, SupportStatus, TestEntry, TestResult, ToolVersion, Uninstall,
+    VersionMetadata,
 };

--- a/crates/containers-common/src/tooldb/version.rs
+++ b/crates/containers-common/src/tooldb/version.rs
@@ -98,6 +98,29 @@ pub struct TestEntry {
     pub ci_run: Option<String>,
     /// Outcome of the run.
     pub result: TestResult,
+    /// Human-readable image reference exercised by this run, e.g.
+    /// `ghcr.io/joshjhall/containers/base-debian-12-amd64:v1.0.0`.
+    /// Pair with [`Self::image_digest`] — the tag may move but the
+    /// digest pins the artifact.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_ref: Option<String>,
+    /// Content-addressed digest of the image exercised, formatted
+    /// `sha256:<64 hex chars>`. Required for a run to be reproducible
+    /// after the tag has moved.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_digest: Option<String>,
+    /// Wallclock duration of the install step in seconds. Sourced from
+    /// `luggage install --json-report`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_seconds: Option<f64>,
+    /// Captured stdout of the validate stage's `<tool> --version`
+    /// invocation, trimmed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version_output: Option<String>,
+    /// Stage-aligned failure category, populated when [`Self::result`]
+    /// is [`TestResult::Fail`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_class: Option<ErrorClass>,
     /// Free-form notes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub notes: Option<String>,
@@ -113,6 +136,30 @@ pub enum TestResult {
     Fail,
     /// CI run was skipped.
     Skip,
+}
+
+/// Structured failure category for [`TestEntry::error_class`].
+///
+/// Mirrors the enum in containers-db's
+/// `schema/version.schema.json`. Values map to luggage installer stages
+/// so categorization is mechanical rather than editorial.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorClass {
+    /// Artifact fetch failed.
+    Download,
+    /// Checksum or signature mismatch.
+    Verify,
+    /// Install-method dispatch failed.
+    InstallMethod,
+    /// A `post_install[]` step failed.
+    PostInstall,
+    /// The `<tool> --version` validation did not match the requested version.
+    Validate,
+    /// CI runner / network / registry failure unrelated to the tool.
+    Infra,
+    /// Older runs predating this enum or truly unclassifiable.
+    Unknown,
 }
 
 /// Optional uninstall steps.
@@ -182,5 +229,87 @@ mod tests {
         assert_eq!(v.tool, reparsed.tool);
         assert_eq!(v.version, reparsed.version);
         assert_eq!(v.install_methods.len(), reparsed.install_methods.len());
+    }
+
+    #[test]
+    fn test_entry_round_trips_evidence_fields() {
+        let json = r#"{
+            "os": "debian",
+            "os_version": "12",
+            "arch": "amd64",
+            "tested_at": "2026-05-16T12:00:00Z",
+            "ci_run": "https://github.com/joshjhall/containers/actions/runs/1",
+            "result": "pass",
+            "image_ref": "ghcr.io/joshjhall/containers/base-debian-12-amd64:v1.0.0",
+            "image_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+            "duration_seconds": 42.5,
+            "version_output": "rustc 1.95.0 (abcdef0 2026-05-01)"
+        }"#;
+        let entry: TestEntry = serde_json::from_str(json).expect("parse evidence row");
+        assert_eq!(
+            entry.image_digest.as_deref(),
+            Some("sha256:0000000000000000000000000000000000000000000000000000000000000000",)
+        );
+        assert_eq!(entry.duration_seconds, Some(42.5));
+        assert_eq!(entry.version_output.as_deref(), Some("rustc 1.95.0 (abcdef0 2026-05-01)"));
+        assert!(entry.error_class.is_none(), "pass row has no error_class");
+
+        let serialized = serde_json::to_string(&entry).unwrap();
+        let reparsed: TestEntry = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(reparsed.image_ref, entry.image_ref);
+        assert_eq!(reparsed.duration_seconds, entry.duration_seconds);
+    }
+
+    #[test]
+    fn test_entry_round_trips_failure_row_with_error_class() {
+        let json = r#"{
+            "os": "alpine",
+            "os_version": "3.21",
+            "arch": "arm64",
+            "tested_at": "2026-05-16T12:30:00Z",
+            "result": "fail",
+            "image_digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+            "duration_seconds": 7.25,
+            "error_class": "verify",
+            "notes": "tier-3 checksum mismatch"
+        }"#;
+        let entry: TestEntry = serde_json::from_str(json).expect("parse failure row");
+        assert_eq!(entry.result, TestResult::Fail);
+        assert_eq!(entry.error_class, Some(ErrorClass::Verify));
+        assert_eq!(entry.notes.as_deref(), Some("tier-3 checksum mismatch"));
+    }
+
+    #[test]
+    fn test_entry_legacy_row_without_evidence_fields_still_parses() {
+        // Belt-and-braces: rows written by the old (pre-2026-05-14) shape
+        // must continue to deserialize so we don't break catalog reads.
+        let json = r#"{
+            "os": "debian",
+            "arch": "amd64",
+            "tested_at": "2026-04-01T00:00:00Z",
+            "result": "pass"
+        }"#;
+        let entry: TestEntry = serde_json::from_str(json).unwrap();
+        assert!(entry.image_digest.is_none());
+        assert!(entry.duration_seconds.is_none());
+        assert!(entry.error_class.is_none());
+    }
+
+    #[test]
+    fn error_class_wire_format_matches_schema_enum() {
+        let pairs = [
+            (ErrorClass::Download, "\"download\""),
+            (ErrorClass::Verify, "\"verify\""),
+            (ErrorClass::InstallMethod, "\"install_method\""),
+            (ErrorClass::PostInstall, "\"post_install\""),
+            (ErrorClass::Validate, "\"validate\""),
+            (ErrorClass::Infra, "\"infra\""),
+            (ErrorClass::Unknown, "\"unknown\""),
+        ];
+        for (c, expected) in pairs {
+            assert_eq!(serde_json::to_string(&c).unwrap(), expected);
+            let back: ErrorClass = serde_json::from_str(expected).unwrap();
+            assert_eq!(back, c);
+        }
     }
 }

--- a/crates/luggage/src/bin/luggage.rs
+++ b/crates/luggage/src/bin/luggage.rs
@@ -13,8 +13,10 @@
 //! exit code `2` ("we will not install on this host") versus `1`
 //! ("something else went wrong") without parsing stderr.
 
+use std::fs::File;
 use std::io;
-use std::path::PathBuf;
+use std::io::{BufWriter, Write as _};
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use clap::{Args, Parser, Subcommand, ValueEnum};
@@ -141,6 +143,12 @@ struct InstallArgs {
     /// manager is unavailable or already pre-populated.
     #[arg(long)]
     skip_system_packages: bool,
+
+    /// Write a JSON [`InstallReport`] to this path. Emitted on every
+    /// exit path — success, skip, dry-run, or failure — so evidence-run
+    /// CI can record a row even when the install itself failed.
+    #[arg(long, value_name = "PATH")]
+    json_report: Option<PathBuf>,
 }
 
 /// CLI mirror of [`luggage::PolicyPreset`].
@@ -239,23 +247,52 @@ fn cmd_install(args: &InstallArgs) -> Result<(), LuggageError> {
     };
     let installer = Installer::with_options(opts);
 
+    // Dry-run emits the plan to stdout for human inspection. Done before
+    // run_with_report so we can short-circuit without spinning up the
+    // log directory; run_with_report still produces a report for the
+    // --json-report file via the dry-run branch.
     if args.dry_run {
         let plan = installer.plan(&resolved)?;
         let out = serde_json::to_string_pretty(&plan)
             .map_err(|source| LuggageError::Parse { path: PathBuf::from("<stdout>"), source })?;
         println!("{out}");
-        return Ok(());
     }
 
-    let report: InstallReport = installer.run(&resolved)?;
-    if report.already_installed {
-        println!("{}@{} already installed", report.tool, report.version);
-    } else {
-        println!("installed {}@{}", report.tool, report.version);
+    let (report, result) = installer.run_with_report(&resolved);
+
+    if let Some(path) = &args.json_report {
+        write_json_report(path, &report)?;
     }
-    if let Some(p) = &report.log_path {
-        println!("  log: {}", p.display());
+
+    // On success, surface the same human-readable lines the previous
+    // implementation printed. On failure, the caller (main) prints the
+    // error after we return Err — leave stdout to the report.
+    if result.is_ok() && !args.dry_run {
+        if report.already_installed {
+            println!("{}@{} already installed", report.tool, report.version);
+        } else {
+            println!("installed {}@{}", report.tool, report.version);
+        }
+        if let Some(p) = &report.log_path {
+            println!("  log: {}", p.display());
+        }
     }
+    result
+}
+
+/// Write `report` to `path` as pretty JSON, returning a typed error on
+/// I/O or serialization failure so the CLI's error reporter handles it.
+fn write_json_report(path: &Path, report: &InstallReport) -> Result<(), LuggageError> {
+    let file = File::create(path)
+        .map_err(|source| LuggageError::Io { path: path.to_path_buf(), source })?;
+    let mut writer = BufWriter::new(file);
+    serde_json::to_writer_pretty(&mut writer, report)
+        .map_err(|source| LuggageError::Parse { path: path.to_path_buf(), source })?;
+    // Trailing newline so the file plays nicely with line-oriented tools.
+    writer
+        .write_all(b"\n")
+        .map_err(|source| LuggageError::Io { path: path.to_path_buf(), source })?;
+    writer.flush().map_err(|source| LuggageError::Io { path: path.to_path_buf(), source })?;
     Ok(())
 }
 

--- a/crates/luggage/src/error.rs
+++ b/crates/luggage/src/error.rs
@@ -12,10 +12,71 @@ use std::path::PathBuf;
 
 use containers_common::tooldb::ActivityScore;
 use containers_common::version::VersionError;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// Result alias used throughout the luggage crate.
 pub type Result<T> = core::result::Result<T, LuggageError>;
+
+/// Stage-aligned classification of an install failure, suitable for
+/// inclusion in an evidence row.
+///
+/// Values match the `error_class` enum in containers-db's
+/// `schema/version.schema.json` exactly, so a serialized `ErrorClass`
+/// validates as-is against the schema. The mapping from `LuggageError`
+/// keeps categorization mechanical: every install-time failure variant
+/// maps to a stage; everything else (pre-install resolver, catalog
+/// parse, IO) maps to `Unknown`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorClass {
+    /// Artifact download failed after retries.
+    Download,
+    /// 4-tier verification rejected the downloaded artifact.
+    Verify,
+    /// Install method (rustup-init, script, etc.) failed mid-run.
+    InstallMethod,
+    /// A `post_install[]` step failed.
+    PostInstall,
+    /// Post-install `<bin>/<tool> --version` validation failed.
+    Validate,
+    /// CI runner / network / registry / host-package-manager failure —
+    /// anything that wasn't the tool's own fault.
+    Infra,
+    /// Pre-install resolver, catalog, parse, IO, or otherwise
+    /// unclassified error. Older runs predating this enum also surface
+    /// here.
+    Unknown,
+}
+
+impl From<&LuggageError> for ErrorClass {
+    fn from(err: &LuggageError) -> Self {
+        match err {
+            LuggageError::PackageManagerFailed { .. } => Self::Infra,
+            LuggageError::DownloadFailed { .. } => Self::Download,
+            LuggageError::VerificationFailed { .. } => Self::Verify,
+            LuggageError::PostInstallFailed { .. } => Self::PostInstall,
+            LuggageError::ValidationFailed { .. } => Self::Validate,
+            // `chown` and `spawn` are emitted inside install-method
+            // execution; any other stage value from a future method
+            // also belongs here.
+            LuggageError::InstallStageFailed { .. } => Self::InstallMethod,
+            LuggageError::Io { .. }
+            | LuggageError::Parse { .. }
+            | LuggageError::ToolNotFound(_)
+            | LuggageError::VersionNotFound { .. }
+            | LuggageError::UnsupportedPlatform(_)
+            | LuggageError::NoMatchingInstallMethod { .. }
+            | LuggageError::VersionParse(_)
+            | LuggageError::ActivityBelowThreshold { .. }
+            | LuggageError::BelowMinimumRecommended { .. }
+            | LuggageError::PlatformDetectionFailed(_)
+            | LuggageError::NotImplemented(_)
+            | LuggageError::Catalog(_)
+            | LuggageError::TemplateMissingKey(_) => Self::Unknown,
+        }
+    }
+}
 
 /// Detail payload for [`LuggageError::UnsupportedPlatform`].
 ///
@@ -423,5 +484,102 @@ mod tests {
         let err = LuggageError::TemplateMissingKey("rustup_target".into());
         assert_eq!(err.exit_code(), 1);
         assert!(format!("{err}").contains("rustup_target"));
+    }
+
+    #[test]
+    fn error_class_maps_runtime_variants_to_their_stage() {
+        let cases: &[(LuggageError, ErrorClass)] = &[
+            (LuggageError::PackageManagerFailed { message: "apt".into() }, ErrorClass::Infra),
+            (
+                LuggageError::DownloadFailed {
+                    url: "https://x".into(),
+                    attempts: 1,
+                    message: "x".into(),
+                },
+                ErrorClass::Download,
+            ),
+            (
+                LuggageError::VerificationFailed {
+                    tool: "rust".into(),
+                    version: "1.0".into(),
+                    tier: 3,
+                    reason: "x".into(),
+                },
+                ErrorClass::Verify,
+            ),
+            (
+                LuggageError::InstallStageFailed { stage: "spawn", message: "x".into() },
+                ErrorClass::InstallMethod,
+            ),
+            (
+                LuggageError::PostInstallFailed { step: "x".into(), message: "x".into() },
+                ErrorClass::PostInstall,
+            ),
+            (
+                LuggageError::ValidationFailed {
+                    tool: "rust".into(),
+                    version: "1.0".into(),
+                    message: "x".into(),
+                },
+                ErrorClass::Validate,
+            ),
+        ];
+        for (err, expected) in cases {
+            assert_eq!(ErrorClass::from(err), *expected, "{err}");
+        }
+    }
+
+    #[test]
+    fn error_class_maps_pre_install_variants_to_unknown() {
+        let cases: Vec<LuggageError> = vec![
+            LuggageError::Io { path: PathBuf::from("/x"), source: std::io::Error::other("x") },
+            LuggageError::ToolNotFound("ghost".into()),
+            LuggageError::VersionNotFound { tool: "rust".into(), spec: "9.9.9".into() },
+            LuggageError::NoMatchingInstallMethod {
+                tool: "rust".into(),
+                version: "1.0".into(),
+                os: "darwin".into(),
+                os_version: None,
+                arch: "amd64".into(),
+            },
+            LuggageError::ActivityBelowThreshold {
+                tool: "ghost".into(),
+                score: ActivityScore::Abandoned,
+                threshold: ActivityScore::Maintained,
+            },
+            LuggageError::BelowMinimumRecommended {
+                tool: "rust".into(),
+                version: "1.0".into(),
+                minimum: "1.84.0".into(),
+            },
+            LuggageError::PlatformDetectionFailed("missing /etc/os-release".into()),
+            LuggageError::NotImplemented("x"),
+            LuggageError::Catalog("x".into()),
+            LuggageError::TemplateMissingKey("x".into()),
+        ];
+        for err in &cases {
+            assert_eq!(ErrorClass::from(err), ErrorClass::Unknown, "{err}");
+        }
+    }
+
+    #[test]
+    fn error_class_wire_format_matches_containers_db_schema() {
+        // Pin the wire format to the containers-db enum exactly. If the
+        // schema changes, this test forces a coordinated update.
+        let pairs = [
+            (ErrorClass::Download, "\"download\""),
+            (ErrorClass::Verify, "\"verify\""),
+            (ErrorClass::InstallMethod, "\"install_method\""),
+            (ErrorClass::PostInstall, "\"post_install\""),
+            (ErrorClass::Validate, "\"validate\""),
+            (ErrorClass::Infra, "\"infra\""),
+            (ErrorClass::Unknown, "\"unknown\""),
+        ];
+        for (c, expected) in pairs {
+            let got = serde_json::to_string(&c).unwrap();
+            assert_eq!(got, expected);
+            let back: ErrorClass = serde_json::from_str(expected).unwrap();
+            assert_eq!(back, c);
+        }
     }
 }

--- a/crates/luggage/src/installer/mod.rs
+++ b/crates/luggage/src/installer/mod.rs
@@ -27,11 +27,12 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Instant;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tempfile::tempdir_in;
 
-use crate::error::{LuggageError, Result};
+use crate::error::{ErrorClass, LuggageError, Result};
 use crate::resolver::ResolvedInstall;
 
 use download::{HttpClient, UreqClient};
@@ -110,8 +111,16 @@ pub struct InstallPlan {
     pub user: String,
 }
 
-/// Outcome of a successful install run.
-#[derive(Debug, Clone, Serialize)]
+/// Outcome of an install run — emitted on success, skip, dry-run, and
+/// failure paths alike when callers use [`Installer::run_with_report`].
+///
+/// Evidence-run CI ([containers#473]) feeds this struct (via the CLI's
+/// `--json-report` flag) to the `record-evidence` wrapper, which combines
+/// it with runner-supplied metadata (image digest, `ci_run`, tuple coords)
+/// into a `tested[]` row for containers-db.
+///
+/// [containers#473]: https://github.com/joshjhall/containers/issues/473
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InstallReport {
     /// Tool id.
     pub tool: String,
@@ -120,8 +129,19 @@ pub struct InstallReport {
     /// `true` if the idempotency check skipped the install.
     pub already_installed: bool,
     /// Path to the per-feature log file.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub log_path: Option<PathBuf>,
+    /// Wallclock duration of [`Installer::run_with_report`] from entry
+    /// to return — covers idempotency check + all stages.
+    pub duration_seconds: f64,
+    /// Trimmed output captured from the validate stage's
+    /// `<bin>/<tool> --version` invocation. Populated on success;
+    /// `None` on skip, dry-run, and failure paths.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version_output: Option<String>,
+    /// Stage-aligned failure category. `Some` iff the run failed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_class: Option<ErrorClass>,
 }
 
 /// The install execution engine.
@@ -214,7 +234,8 @@ impl Installer {
         })
     }
 
-    /// Execute the install end-to-end.
+    /// Execute the install end-to-end, returning a populated
+    /// [`InstallReport`] on success.
     ///
     /// Stage order, mirroring `lib/features/rust.sh`:
     ///
@@ -232,6 +253,20 @@ impl Installer {
     /// Propagates whatever any stage returns. See module-level docs for
     /// the full list of variants.
     pub fn run(&self, resolved: &ResolvedInstall) -> Result<InstallReport> {
+        let (report, result) = self.run_with_report(resolved);
+        result.map(|()| report)
+    }
+
+    /// Execute the install end-to-end, always returning a populated
+    /// [`InstallReport`] paired with the run's [`Result`].
+    ///
+    /// On success, skip, and dry-run paths the `Result<()>` is `Ok`. On
+    /// failure it carries the underlying [`LuggageError`] and the report's
+    /// `error_class` is set from it; partial fields (`duration_seconds`)
+    /// are filled in regardless. Evidence-run CI uses this entry point
+    /// so it can record a row even when the install itself failed.
+    pub fn run_with_report(&self, resolved: &ResolvedInstall) -> (InstallReport, Result<()>) {
+        let started = Instant::now();
         let logger =
             logging::FeatureLogger::open(&self.options.log_dir, &resolved.tool, &resolved.version)
                 .ok();
@@ -246,30 +281,52 @@ impl Installer {
                 &self.options.bin_root,
             )
         {
-            return Ok(Self::report_skipped(resolved, logger));
+            return (
+                Self::report_skipped(resolved, logger, started.elapsed().as_secs_f64()),
+                Ok(()),
+            );
         }
 
-        let plan = self.plan(resolved)?;
+        let plan = match self.plan(resolved) {
+            Ok(p) => p,
+            Err(e) => {
+                let report =
+                    Self::report_failure(resolved, &e, logger, started.elapsed().as_secs_f64());
+                return (report, Err(e));
+            }
+        };
         if self.options.dry_run {
-            return Ok(Self::report_dry_run(plan, logger));
+            return (Self::report_dry_run(plan, logger, started.elapsed().as_secs_f64()), Ok(()));
         }
 
-        self.run_stages(resolved, plan, logger.as_ref())?;
-
-        if let Some(l) = &logger {
-            l.feature_end();
+        match self.run_stages(resolved, plan, logger.as_ref()) {
+            Ok(version_output) => {
+                if let Some(l) = &logger {
+                    l.feature_end();
+                }
+                let report = InstallReport {
+                    tool: resolved.tool.clone(),
+                    version: resolved.version.clone(),
+                    already_installed: false,
+                    log_path: logger.map(|l| l.path().to_owned()),
+                    duration_seconds: started.elapsed().as_secs_f64(),
+                    version_output: Some(version_output),
+                    error_class: None,
+                };
+                (report, Ok(()))
+            }
+            Err(e) => {
+                let report =
+                    Self::report_failure(resolved, &e, logger, started.elapsed().as_secs_f64());
+                (report, Err(e))
+            }
         }
-        Ok(InstallReport {
-            tool: resolved.tool.clone(),
-            version: resolved.version.clone(),
-            already_installed: false,
-            log_path: logger.map(|l| l.path().to_owned()),
-        })
     }
 
     fn report_skipped(
         resolved: &ResolvedInstall,
         logger: Option<logging::FeatureLogger>,
+        duration_seconds: f64,
     ) -> InstallReport {
         if let Some(l) = &logger {
             l.message(&format!(
@@ -283,10 +340,17 @@ impl Installer {
             version: resolved.version.clone(),
             already_installed: true,
             log_path: logger.map(|l| l.path().to_owned()),
+            duration_seconds,
+            version_output: None,
+            error_class: None,
         }
     }
 
-    fn report_dry_run(plan: InstallPlan, logger: Option<logging::FeatureLogger>) -> InstallReport {
+    fn report_dry_run(
+        plan: InstallPlan,
+        logger: Option<logging::FeatureLogger>,
+        duration_seconds: f64,
+    ) -> InstallReport {
         if let Some(l) = &logger {
             l.message("dry-run: stopping after plan");
             l.feature_end();
@@ -296,6 +360,30 @@ impl Installer {
             version: plan.version,
             already_installed: false,
             log_path: logger.map(|l| l.path().to_owned()),
+            duration_seconds,
+            version_output: None,
+            error_class: None,
+        }
+    }
+
+    fn report_failure(
+        resolved: &ResolvedInstall,
+        err: &LuggageError,
+        logger: Option<logging::FeatureLogger>,
+        duration_seconds: f64,
+    ) -> InstallReport {
+        if let Some(l) = &logger {
+            l.message(&format!("install failed: {err}"));
+            l.feature_end();
+        }
+        InstallReport {
+            tool: resolved.tool.clone(),
+            version: resolved.version.clone(),
+            already_installed: false,
+            log_path: logger.map(|l| l.path().to_owned()),
+            duration_seconds,
+            version_output: None,
+            error_class: Some(ErrorClass::from(err)),
         }
     }
 
@@ -304,7 +392,7 @@ impl Installer {
         resolved: &ResolvedInstall,
         plan: InstallPlan,
         logger: Option<&logging::FeatureLogger>,
-    ) -> Result<()> {
+    ) -> Result<String> {
         self.stage_system_packages(resolved, logger)?;
         let bytes = self.stage_download(&plan, logger)?;
         self.stage_verify(resolved, &bytes, logger)?;
@@ -444,7 +532,7 @@ impl Installer {
         resolved: &ResolvedInstall,
         env_map: &BTreeMap<String, String>,
         logger: Option<&logging::FeatureLogger>,
-    ) -> Result<()> {
+    ) -> Result<String> {
         if let Some(l) = logger {
             l.step("validate");
         }

--- a/crates/luggage/src/installer/validate.rs
+++ b/crates/luggage/src/installer/validate.rs
@@ -24,6 +24,10 @@ use crate::installer::idempotency::primary_binary;
 /// `$HOME/.rustup` and reports "no default toolchain configured" even when
 /// the toolchain was just installed under `cache_root`.
 ///
+/// Returns the trimmed captured output from the version invocation
+/// (stdout preferred, stderr if stdout is empty), so callers can surface
+/// it through evidence reports.
+///
 /// # Errors
 ///
 /// - [`LuggageError::ValidationFailed`] when the binary is missing, the
@@ -34,7 +38,7 @@ pub fn check(
     version: &str,
     bin_root: &Path,
     env: &BTreeMap<String, String>,
-) -> Result<()> {
+) -> Result<String> {
     let binary = bin_root.join(primary_binary(tool));
     if !binary.exists() {
         return Err(LuggageError::ValidationFailed {
@@ -65,7 +69,10 @@ pub fn check(
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     if stdout.contains(version) || stderr.contains(version) {
-        Ok(())
+        let trimmed = stdout.trim();
+        let captured =
+            if trimmed.is_empty() { stderr.trim().to_owned() } else { trimmed.to_owned() };
+        Ok(captured)
     } else {
         Err(LuggageError::ValidationFailed {
             tool: tool.to_owned(),
@@ -105,7 +112,8 @@ mod tests {
     fn matching_output_passes() {
         let dir = tempdir().unwrap();
         write_shim(dir.path(), "rustc", "rustc 1.95.0 (abcdef0)");
-        check("rustc", "1.95.0", dir.path(), &BTreeMap::new()).unwrap();
+        let captured = check("rustc", "1.95.0", dir.path(), &BTreeMap::new()).unwrap();
+        assert_eq!(captured, "rustc 1.95.0 (abcdef0)");
     }
 
     #[cfg(unix)]

--- a/crates/luggage/src/lib.rs
+++ b/crates/luggage/src/lib.rs
@@ -33,7 +33,7 @@ pub mod policy;
 pub mod resolver;
 
 pub use catalog::{Catalog, CatalogSource};
-pub use error::{LuggageError, Result};
+pub use error::{ErrorClass, LuggageError, Result};
 pub use installer::{InstallPlan, InstallReport, Installer, InstallerOptions};
 pub use platform::Platform;
 pub use policy::{PolicyPreset, ResolutionPolicy};

--- a/crates/luggage/tests/cli.rs
+++ b/crates/luggage/tests/cli.rs
@@ -7,6 +7,8 @@
 use std::path::PathBuf;
 use std::process::{Command, Output};
 
+use tempfile::tempdir;
+
 const fn binary() -> &'static str {
     env!("CARGO_BIN_EXE_luggage")
 }
@@ -176,4 +178,86 @@ fn resolve_missing_catalog_exits_one() {
         stderr.contains("not a directory"),
         "stderr should explain the missing catalog: {stderr}",
     );
+}
+
+/// Dry-run with `--json-report` writes the report file alongside the
+/// existing plan-on-stdout behavior. The report has every field the
+/// evidence-run wrapper depends on, even though the install was never
+/// executed.
+#[test]
+fn install_dry_run_writes_json_report() {
+    let workdir = tempdir().expect("tempdir");
+    let report_path = workdir.path().join("report.json");
+    let out = run(&[
+        "install",
+        "rust@1.95.0",
+        "--os",
+        "debian",
+        "--os-version",
+        "13",
+        "--arch",
+        "amd64",
+        "--dry-run",
+        "--log-dir",
+        workdir.path().to_str().unwrap(),
+        "--bin-root",
+        workdir.path().to_str().unwrap(),
+        "--cache-root",
+        workdir.path().to_str().unwrap(),
+        "--tmp-root",
+        workdir.path().to_str().unwrap(),
+        "--json-report",
+        report_path.to_str().unwrap(),
+    ]);
+    assert_exit(&out, 0);
+
+    let body = std::fs::read_to_string(&report_path).expect("read report file");
+    let report: serde_json::Value = serde_json::from_str(&body).expect("parse report JSON");
+
+    assert_eq!(report["tool"], "rust");
+    assert_eq!(report["version"], "1.95.0");
+    assert_eq!(report["already_installed"], false);
+    assert!(report["duration_seconds"].is_number(), "duration_seconds must be present");
+    assert!(report["version_output"].is_null(), "dry-run has no validate output");
+    assert!(report["error_class"].is_null(), "dry-run is not a failure");
+
+    // Stdout still carries the plan JSON for human inspection.
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let plan: serde_json::Value = serde_json::from_str(&stdout).expect("parse plan from stdout");
+    assert_eq!(plan["tool"], "rust");
+    assert_eq!(plan["method_name"], "rustup-init");
+}
+
+/// Resolve-time errors (`ToolNotFound`, `UnsupportedPlatform`) return
+/// before `run_with_report` is reached, so no report file is written.
+/// Evidence rows only make sense for tuples that resolve cleanly;
+/// misconfigured inputs are stderr-only.
+#[test]
+fn install_resolve_time_errors_do_not_write_json_report() {
+    let workdir = tempdir().expect("tempdir");
+    let report_path = workdir.path().join("report.json");
+    let out = run(&[
+        "install",
+        "ghosttool",
+        "--os",
+        "debian",
+        "--os-version",
+        "13",
+        "--arch",
+        "amd64",
+        "--log-dir",
+        workdir.path().to_str().unwrap(),
+        "--bin-root",
+        workdir.path().to_str().unwrap(),
+        "--cache-root",
+        workdir.path().to_str().unwrap(),
+        "--tmp-root",
+        workdir.path().to_str().unwrap(),
+        "--json-report",
+        report_path.to_str().unwrap(),
+    ]);
+    assert_exit(&out, 1);
+    assert!(!report_path.exists(), "resolve-time errors run before run_with_report");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("not found"), "stderr should mention 'not found': {stderr}");
 }

--- a/crates/luggage/tests/install_rust.rs
+++ b/crates/luggage/tests/install_rust.rs
@@ -192,6 +192,66 @@ fn corrupt_artifact_returns_tier_3_verification_failed() {
 }
 
 #[test]
+fn run_with_report_on_verification_failure_populates_error_class() {
+    let roots = TempDir::new().unwrap();
+    let resolved = resolve_rust();
+    let mock = Arc::new(mock_with(Some(b"this is not rustup-init")));
+    let runner = Arc::new(RecordingRunner::new());
+
+    let installer = Installer::with_runners(
+        options_in(&roots),
+        mock as Arc<dyn HttpClient>,
+        runner as Arc<dyn luggage::installer::methods::CommandRunner>,
+    );
+
+    let (report, result) = installer.run_with_report(&resolved);
+    assert!(result.is_err(), "verification should fail");
+    assert_eq!(report.tool, "rust");
+    assert_eq!(report.version, "1.95.0");
+    assert!(!report.already_installed);
+    assert!(report.version_output.is_none(), "validate never ran");
+    assert_eq!(
+        report.error_class,
+        Some(luggage::ErrorClass::Verify),
+        "tier-3 checksum mismatch is a Verify-stage failure",
+    );
+    assert!(report.duration_seconds >= 0.0);
+}
+
+#[test]
+fn run_with_report_on_success_captures_validate_output() {
+    let roots = TempDir::new().unwrap();
+    let resolved = resolve_rust();
+    let mock = Arc::new(mock_with(None));
+    let runner = Arc::new(RecordingRunner::new());
+
+    // Pre-populate the cargo bin shims so the install method's symlink
+    // step has real targets and validate sees a `rustc --version` line
+    // that contains the resolved version.
+    let cargo_bin = roots.path().join("cache").join("cargo").join("bin");
+    std::fs::create_dir_all(&cargo_bin).unwrap();
+    write_version_shim(&cargo_bin.join("rustc"), "rustc 1.95.0 (linked)");
+    for name in RUST_BINARIES {
+        if *name != "rustc" {
+            std::fs::write(cargo_bin.join(name), b"#!/bin/sh\necho stub\n").unwrap();
+        }
+    }
+
+    let installer = Installer::with_runners(
+        options_in(&roots),
+        mock as Arc<dyn HttpClient>,
+        runner as Arc<dyn luggage::installer::methods::CommandRunner>,
+    );
+
+    let (report, result) = installer.run_with_report(&resolved);
+    result.expect("install should succeed");
+    assert!(!report.already_installed);
+    assert!(report.error_class.is_none(), "success has no error_class");
+    let captured = report.version_output.as_deref().unwrap_or("");
+    assert!(captured.contains("1.95.0"), "version_output should include the version: {captured}");
+}
+
+#[test]
 fn idempotent_skip_when_rustc_already_at_target_version() {
     let roots = TempDir::new().unwrap();
     let resolved = resolve_rust();

--- a/crates/record-evidence/Cargo.toml
+++ b/crates/record-evidence/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "record-evidence"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Wrapper that combines a `luggage install --json-report` with CI metadata into a containers-db TestEntry row"
+publish = false
+
+[[bin]]
+name = "record-evidence"
+path = "src/main.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+containers-common = { workspace = true }
+luggage = { workspace = true }
+clap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+time = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/record-evidence/src/lib.rs
+++ b/crates/record-evidence/src/lib.rs
@@ -1,0 +1,271 @@
+//! Evidence-row builder: combines a [`luggage::InstallReport`] with
+//! CI-runner-supplied metadata (image digest, image ref, `ci_run`, tuple
+//! coords) into a [`containers_common::tooldb::TestEntry`] matching
+//! containers-db's `tested[]` schema.
+//!
+//! See containers#473 (evidence-runs design tracker) and containers-db#14
+//! (schema extension that added `image_digest`, `duration_seconds`, and
+//! `error_class`).
+
+use containers_common::tooldb::{ErrorClass as DbErrorClass, TestEntry, TestResult};
+use luggage::{ErrorClass as LuggageErrorClass, InstallReport};
+use thiserror::Error;
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
+
+/// Inputs to [`build_test_entry`].
+///
+/// `luggage_report` is the [`InstallReport`] luggage wrote via
+/// `--json-report`. Everything else is metadata only the surrounding CI
+/// runner knows.
+#[derive(Debug, Clone)]
+pub struct RecorderInputs {
+    /// The parsed `--json-report` file luggage produced.
+    pub luggage_report: InstallReport,
+    /// Pull-spec for the base image exercised
+    /// (`ghcr.io/.../base-debian-12-amd64:v1.0.0`).
+    pub image_ref: String,
+    /// Content-addressed digest of `image_ref`.
+    pub image_digest: String,
+    /// CI run URL.
+    pub ci_run: Option<String>,
+    /// Distro id.
+    pub os: String,
+    /// Distro version.
+    pub os_version: Option<String>,
+    /// CPU architecture.
+    pub arch: String,
+}
+
+/// Errors raised by [`build_test_entry`] and the binary entry point.
+#[derive(Debug, Error)]
+pub enum RecorderError {
+    /// `image_digest` does not match the schema's
+    /// `^sha256:[0-9a-f]{64}$` pattern.
+    #[error(
+        "invalid image_digest `{0}`: expected `sha256:<64 hex chars>` per containers-db schema"
+    )]
+    InvalidImageDigest(String),
+
+    /// `image_ref` was empty or whitespace-only.
+    #[error("empty image_ref")]
+    EmptyImageRef,
+
+    /// Wallclock retrieval failed. Practically unreachable on a sane
+    /// system, but we surface it rather than panic so CI gets a clean
+    /// error.
+    #[error("could not format current time as RFC3339: {0}")]
+    Time(#[from] time::error::Format),
+
+    /// JSON serialization failed.
+    #[error("could not serialize TestEntry as JSON: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// Failed to read or parse the luggage `--json-report` file.
+    #[error("could not read luggage report at {path}: {message}")]
+    LuggageReport {
+        /// Path that was being read.
+        path: String,
+        /// Underlying message.
+        message: String,
+    },
+}
+
+/// Build a [`TestEntry`] from runner inputs and a luggage install report.
+///
+/// `tested_at` is the current UTC time at call time (RFC3339).
+/// `result` is derived from the report: `error_class == None` and
+/// `already_installed == true` → [`TestResult::Skip`]; `error_class ==
+/// None` and ran → [`TestResult::Pass`]; otherwise [`TestResult::Fail`].
+///
+/// # Errors
+///
+/// - [`RecorderError::InvalidImageDigest`] if the digest fails the
+///   `sha256:<64 hex>` shape check.
+/// - [`RecorderError::EmptyImageRef`] if `image_ref` is empty.
+/// - [`RecorderError::Time`] if the system clock cannot be formatted.
+pub fn build_test_entry(inputs: RecorderInputs) -> Result<TestEntry, RecorderError> {
+    validate_image_digest(&inputs.image_digest)?;
+    if inputs.image_ref.trim().is_empty() {
+        return Err(RecorderError::EmptyImageRef);
+    }
+
+    let report = &inputs.luggage_report;
+    let result = derive_result(report);
+    let error_class = report.error_class.map(translate_error_class);
+    let tested_at = OffsetDateTime::now_utc().format(&Rfc3339)?;
+
+    Ok(TestEntry {
+        os: inputs.os,
+        os_version: inputs.os_version,
+        arch: inputs.arch,
+        tested_at,
+        ci_run: inputs.ci_run,
+        result,
+        image_ref: Some(inputs.image_ref),
+        image_digest: Some(inputs.image_digest),
+        duration_seconds: Some(report.duration_seconds),
+        version_output: report.version_output.clone(),
+        error_class,
+        notes: None,
+    })
+}
+
+const fn derive_result(report: &InstallReport) -> TestResult {
+    match (report.error_class, report.already_installed) {
+        (Some(_), _) => TestResult::Fail,
+        (None, true) => TestResult::Skip,
+        (None, false) => TestResult::Pass,
+    }
+}
+
+const fn translate_error_class(c: LuggageErrorClass) -> DbErrorClass {
+    match c {
+        LuggageErrorClass::Download => DbErrorClass::Download,
+        LuggageErrorClass::Verify => DbErrorClass::Verify,
+        LuggageErrorClass::InstallMethod => DbErrorClass::InstallMethod,
+        LuggageErrorClass::PostInstall => DbErrorClass::PostInstall,
+        LuggageErrorClass::Validate => DbErrorClass::Validate,
+        LuggageErrorClass::Infra => DbErrorClass::Infra,
+        LuggageErrorClass::Unknown => DbErrorClass::Unknown,
+    }
+}
+
+fn validate_image_digest(digest: &str) -> Result<(), RecorderError> {
+    let Some(hex) = digest.strip_prefix("sha256:") else {
+        return Err(RecorderError::InvalidImageDigest(digest.to_owned()));
+    };
+    if hex.len() != 64 || !hex.bytes().all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase()) {
+        return Err(RecorderError::InvalidImageDigest(digest.to_owned()));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_report() -> InstallReport {
+        InstallReport {
+            tool: "rust".into(),
+            version: "1.95.0".into(),
+            already_installed: false,
+            log_path: None,
+            duration_seconds: 12.5,
+            version_output: Some("rustc 1.95.0 (abcdef0)".into()),
+            error_class: None,
+        }
+    }
+
+    fn base_inputs() -> RecorderInputs {
+        RecorderInputs {
+            luggage_report: base_report(),
+            image_ref: "ghcr.io/x/base-debian-12-amd64:v1.0.0".into(),
+            image_digest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+                .into(),
+            ci_run: Some("https://github.com/x/runs/1".into()),
+            os: "debian".into(),
+            os_version: Some("12".into()),
+            arch: "amd64".into(),
+        }
+    }
+
+    #[test]
+    fn success_row_maps_to_pass() {
+        let entry = build_test_entry(base_inputs()).unwrap();
+        assert_eq!(entry.result, TestResult::Pass);
+        assert_eq!(entry.duration_seconds, Some(12.5));
+        assert_eq!(entry.version_output.as_deref(), Some("rustc 1.95.0 (abcdef0)"));
+        assert!(entry.error_class.is_none());
+        assert!(entry.tested_at.contains('T'), "RFC3339 has a `T` separator");
+    }
+
+    #[test]
+    fn skip_row_emitted_when_already_installed() {
+        let mut inputs = base_inputs();
+        inputs.luggage_report.already_installed = true;
+        let entry = build_test_entry(inputs).unwrap();
+        assert_eq!(entry.result, TestResult::Skip);
+    }
+
+    #[test]
+    fn failure_row_maps_error_class() {
+        let mut inputs = base_inputs();
+        inputs.luggage_report.error_class = Some(LuggageErrorClass::Verify);
+        inputs.luggage_report.version_output = None;
+        let entry = build_test_entry(inputs).unwrap();
+        assert_eq!(entry.result, TestResult::Fail);
+        assert_eq!(entry.error_class, Some(DbErrorClass::Verify));
+    }
+
+    #[test]
+    fn rejects_bad_digest_shape() {
+        let mut inputs = base_inputs();
+        inputs.image_digest = "sha256:not-hex".into();
+        assert!(matches!(
+            build_test_entry(inputs).unwrap_err(),
+            RecorderError::InvalidImageDigest(_),
+        ));
+    }
+
+    #[test]
+    fn rejects_missing_sha_prefix() {
+        let mut inputs = base_inputs();
+        inputs.image_digest =
+            "0000000000000000000000000000000000000000000000000000000000000000".into();
+        assert!(matches!(
+            build_test_entry(inputs).unwrap_err(),
+            RecorderError::InvalidImageDigest(_),
+        ));
+    }
+
+    #[test]
+    fn rejects_empty_image_ref() {
+        let mut inputs = base_inputs();
+        inputs.image_ref = "  ".into();
+        assert!(matches!(build_test_entry(inputs).unwrap_err(), RecorderError::EmptyImageRef));
+    }
+
+    #[test]
+    fn validate_image_digest_accepts_lowercase_64_hex() {
+        validate_image_digest(
+            "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn validate_image_digest_rejects_uppercase() {
+        // Schema requires lowercase hex.
+        let err = validate_image_digest(
+            "sha256:ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789",
+        )
+        .unwrap_err();
+        assert!(matches!(err, RecorderError::InvalidImageDigest(_)));
+    }
+
+    #[test]
+    fn every_luggage_error_class_has_db_mapping() {
+        // Exhaustiveness check: forces the translator to update when a
+        // new variant lands on either side.
+        for c in [
+            LuggageErrorClass::Download,
+            LuggageErrorClass::Verify,
+            LuggageErrorClass::InstallMethod,
+            LuggageErrorClass::PostInstall,
+            LuggageErrorClass::Validate,
+            LuggageErrorClass::Infra,
+            LuggageErrorClass::Unknown,
+        ] {
+            let translated = translate_error_class(c);
+            // Round-trip through JSON to make sure both enums share the
+            // same wire format on each variant.
+            let s_luggage = serde_json::to_string(&c).unwrap();
+            let s_db = serde_json::to_string(&translated).unwrap();
+            assert_eq!(
+                s_luggage, s_db,
+                "wire-format drift between luggage and containers-common for {c:?}"
+            );
+        }
+    }
+}

--- a/crates/record-evidence/src/main.rs
+++ b/crates/record-evidence/src/main.rs
@@ -1,0 +1,104 @@
+//! `record-evidence` CLI binary.
+//!
+//! Reads a `luggage install --json-report` file, combines it with
+//! CI-runner-supplied metadata, and writes a containers-db `TestEntry`
+//! row as pretty JSON to stdout.
+
+use std::fs;
+use std::io;
+use std::io::Write as _;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::Parser;
+use luggage::InstallReport;
+use record_evidence::{RecorderError, RecorderInputs, build_test_entry};
+
+/// Combine a luggage install report with CI metadata into a
+/// containers-db `TestEntry` row.
+#[derive(Parser, Debug)]
+#[command(name = "record-evidence", version, about, long_about = None)]
+struct Cli {
+    /// Path to the JSON file luggage wrote via `--json-report`.
+    #[arg(long, value_name = "PATH")]
+    luggage_report: PathBuf,
+
+    /// Pull-spec for the base image exercised.
+    #[arg(long, value_name = "REF")]
+    image_ref: String,
+
+    /// Content-addressed digest of `--image-ref` (must match
+    /// `sha256:<64 hex chars>`).
+    #[arg(long, value_name = "SHA256")]
+    image_digest: String,
+
+    /// CI run URL.
+    #[arg(long, value_name = "URL")]
+    ci_run: Option<String>,
+
+    /// Distro id.
+    #[arg(long)]
+    os: String,
+
+    /// Distro version (e.g. `12`, `3.21`).
+    #[arg(long)]
+    os_version: Option<String>,
+
+    /// CPU architecture.
+    #[arg(long)]
+    arch: String,
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("record-evidence: {e}");
+            // 2 reserved for input-validation problems (bad digest,
+            // empty image_ref) so CI can branch on it. Everything else
+            // exits 1.
+            match e {
+                RecorderError::InvalidImageDigest(_) | RecorderError::EmptyImageRef => {
+                    ExitCode::from(2)
+                }
+                _ => ExitCode::from(1),
+            }
+        }
+    }
+}
+
+fn run() -> Result<(), RecorderError> {
+    let cli = Cli::parse();
+    let report = read_report(&cli.luggage_report)?;
+
+    let inputs = RecorderInputs {
+        luggage_report: report,
+        image_ref: cli.image_ref,
+        image_digest: cli.image_digest,
+        ci_run: cli.ci_run,
+        os: cli.os,
+        os_version: cli.os_version,
+        arch: cli.arch,
+    };
+    let entry = build_test_entry(inputs)?;
+
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+    serde_json::to_writer_pretty(&mut handle, &entry)?;
+    handle.write_all(b"\n").map_err(|e| RecorderError::LuggageReport {
+        path: "<stdout>".into(),
+        message: e.to_string(),
+    })?;
+    Ok(())
+}
+
+fn read_report(path: &PathBuf) -> Result<InstallReport, RecorderError> {
+    let body = fs::read_to_string(path).map_err(|e| RecorderError::LuggageReport {
+        path: path.display().to_string(),
+        message: e.to_string(),
+    })?;
+    serde_json::from_str(&body).map_err(|e| RecorderError::LuggageReport {
+        path: path.display().to_string(),
+        message: e.to_string(),
+    })
+}

--- a/crates/record-evidence/tests/cli.rs
+++ b/crates/record-evidence/tests/cli.rs
@@ -1,0 +1,179 @@
+//! End-to-end CLI tests for `record-evidence`.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+use tempfile::tempdir;
+
+const fn binary() -> &'static str {
+    env!("CARGO_BIN_EXE_record-evidence")
+}
+
+fn write_report(dir: &std::path::Path, report: &str) -> PathBuf {
+    let path = dir.join("report.json");
+    fs::write(&path, report).unwrap();
+    path
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(binary()).args(args).output().expect("spawn record-evidence")
+}
+
+fn assert_exit(out: &Output, expected: i32) {
+    let actual = out.status.code().unwrap_or(-1);
+    assert_eq!(
+        actual,
+        expected,
+        "expected exit {expected}, got {actual}\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+const SUCCESS_REPORT: &str = r#"{
+    "tool": "rust",
+    "version": "1.95.0",
+    "already_installed": false,
+    "duration_seconds": 12.5,
+    "version_output": "rustc 1.95.0 (abcdef0)"
+}"#;
+
+const FAILURE_REPORT: &str = r#"{
+    "tool": "rust",
+    "version": "1.95.0",
+    "already_installed": false,
+    "duration_seconds": 4.2,
+    "error_class": "verify"
+}"#;
+
+const SKIP_REPORT: &str = r#"{
+    "tool": "rust",
+    "version": "1.95.0",
+    "already_installed": true,
+    "duration_seconds": 0.1
+}"#;
+
+#[test]
+fn success_report_emits_pass_row_with_evidence_fields() {
+    let dir = tempdir().unwrap();
+    let report = write_report(dir.path(), SUCCESS_REPORT);
+    let out = run(&[
+        "--luggage-report",
+        report.to_str().unwrap(),
+        "--image-ref",
+        "ghcr.io/x/base-debian-12-amd64:v1.0.0",
+        "--image-digest",
+        "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        "--ci-run",
+        "https://github.com/x/runs/1",
+        "--os",
+        "debian",
+        "--os-version",
+        "12",
+        "--arch",
+        "amd64",
+    ]);
+    assert_exit(&out, 0);
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let row: serde_json::Value = serde_json::from_str(&stdout).expect("parse stdout JSON");
+    assert_eq!(row["result"], "pass");
+    assert_eq!(row["os"], "debian");
+    assert_eq!(row["arch"], "amd64");
+    assert_eq!(
+        row["image_digest"],
+        "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    );
+    assert_eq!(row["duration_seconds"], 12.5);
+    assert_eq!(row["version_output"], "rustc 1.95.0 (abcdef0)");
+    assert!(row["error_class"].is_null());
+    assert!(row["tested_at"].as_str().unwrap().contains('T'));
+}
+
+#[test]
+fn failure_report_emits_fail_row_with_error_class() {
+    let dir = tempdir().unwrap();
+    let report = write_report(dir.path(), FAILURE_REPORT);
+    let out = run(&[
+        "--luggage-report",
+        report.to_str().unwrap(),
+        "--image-ref",
+        "ghcr.io/x/base-debian-12-amd64:v1.0.0",
+        "--image-digest",
+        "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        "--os",
+        "debian",
+        "--os-version",
+        "12",
+        "--arch",
+        "amd64",
+    ]);
+    assert_exit(&out, 0);
+
+    let row: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(row["result"], "fail");
+    assert_eq!(row["error_class"], "verify");
+    assert!(row["ci_run"].is_null(), "ci_run is optional");
+}
+
+#[test]
+fn skip_report_emits_skip_row() {
+    let dir = tempdir().unwrap();
+    let report = write_report(dir.path(), SKIP_REPORT);
+    let out = run(&[
+        "--luggage-report",
+        report.to_str().unwrap(),
+        "--image-ref",
+        "ghcr.io/x/base-debian-12-amd64:v1.0.0",
+        "--image-digest",
+        "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+        "--os",
+        "debian",
+        "--arch",
+        "amd64",
+    ]);
+    assert_exit(&out, 0);
+
+    let row: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(row["result"], "skip");
+    assert!(row["os_version"].is_null(), "os_version is optional");
+}
+
+#[test]
+fn rejects_bad_image_digest_with_exit_two() {
+    let dir = tempdir().unwrap();
+    let report = write_report(dir.path(), SUCCESS_REPORT);
+    let out = run(&[
+        "--luggage-report",
+        report.to_str().unwrap(),
+        "--image-ref",
+        "ghcr.io/x/base-debian-12-amd64:v1.0.0",
+        "--image-digest",
+        "not-a-real-digest",
+        "--os",
+        "debian",
+        "--arch",
+        "amd64",
+    ]);
+    assert_exit(&out, 2);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("invalid image_digest"), "stderr: {stderr}");
+}
+
+#[test]
+fn missing_luggage_report_exits_one() {
+    let out = run(&[
+        "--luggage-report",
+        "/does/not/exist.json",
+        "--image-ref",
+        "ghcr.io/x/base-debian-12-amd64:v1.0.0",
+        "--image-digest",
+        "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        "--os",
+        "debian",
+        "--arch",
+        "amd64",
+    ]);
+    assert_exit(&out, 1);
+}

--- a/justfile
+++ b/justfile
@@ -36,7 +36,7 @@ AJV_FLAGS := "--spec=draft2020 -c ajv-formats"
 # Tests
 # ============================================================================
 
-# Test suite. Default: rust tests + clippy + fmt --check + shell unit. Scopes: v5, v4, stibbons, containers-common, luggage (integration stays in `just test-integration`).
+# Test suite. Default: rust tests + clippy + fmt --check + shell unit. Scopes: v5, v4, stibbons, containers-common, luggage, record-evidence (integration stays in `just test-integration`).
 test SCOPE="":
     #!/usr/bin/env bash
     set -euo pipefail
@@ -53,17 +53,17 @@ test SCOPE="":
       v4)
           ./tests/run_unit_tests.sh
           ;;
-      stibbons|containers-common|luggage)
+      stibbons|containers-common|luggage|record-evidence)
           cargo test -p "{{ SCOPE }}"
           ;;
       *)
           echo "Unknown scope: {{ SCOPE }}" >&2
-          echo "Valid scopes: v5, v4, stibbons, containers-common, luggage" >&2
+          echo "Valid scopes: v5, v4, stibbons, containers-common, luggage, record-evidence" >&2
           exit 2
           ;;
     esac
 
-# Rust workspace tests (stibbons + containers-common + luggage)
+# Rust workspace tests (stibbons + containers-common + luggage + record-evidence)
 test-rust:
     cargo test --workspace
 
@@ -98,7 +98,7 @@ test-all: test test-integration
 # Lint & format
 # ============================================================================
 
-# Lint. Default: full lefthook pre-commit sweep. Scopes: v5 (rust workspace), v4 (shellcheck+shfmt), stibbons, containers-common, luggage.
+# Lint. Default: full lefthook pre-commit sweep. Scopes: v5 (rust workspace), v4 (shellcheck+shfmt), stibbons, containers-common, luggage, record-evidence.
 lint SCOPE="":
     #!/usr/bin/env bash
     set -euo pipefail
@@ -118,14 +118,14 @@ lint SCOPE="":
               echo "$files" | xargs -r shfmt -d -i 4 -ci
           fi
           ;;
-      stibbons|containers-common|luggage)
+      stibbons|containers-common|luggage|record-evidence)
           cargo clippy -p "{{ SCOPE }}" --all-targets -- -D warnings
           cargo fmt -p "{{ SCOPE }}" -- --check
           taplo fmt --check "crates/{{ SCOPE }}/**/*.toml"
           ;;
       *)
           echo "Unknown scope: {{ SCOPE }}" >&2
-          echo "Valid scopes: v5, v4, stibbons, containers-common, luggage" >&2
+          echo "Valid scopes: v5, v4, stibbons, containers-common, luggage, record-evidence" >&2
           exit 2
           ;;
     esac


### PR DESCRIPTION
## Summary

Sub-issue B of #473 (evidence-runs design tracker). Three coordinated
changes that together let evidence-run CI capture a row even when the
install itself fails:

- **Enrich `InstallReport`** with `duration_seconds`, `version_output`,
  and a typed `ErrorClass` (variants match the containers-db schema
  exactly: `download`/`verify`/`install_method`/`post_install`/
  `validate`/`infra`/`unknown`).
- **`Installer::run_with_report` -> `(InstallReport, Result<()>)`** —
  always returns a populated report, even on failure. `Installer::run`
  stays as a thin compat shim.
- **`luggage install --json-report PATH`** writes the report on every
  exit path (success, skip, dry-run, failure) so failed evidence runs
  still emit a record.
- **`containers-common::TestEntry`** extended with the v0.2 evidence
  fields (`image_ref`, `image_digest`, `duration_seconds`,
  `version_output`, `error_class`); containers-db pin bumped to the
  current `main` SHA.
- **New `record-evidence` crate** (lib + bin) combines luggage's report
  with CI-supplied metadata (image digest, image ref, ci_run, tuple
  coords) into a schema-valid `TestEntry` row on stdout.

Closes #476

## Test plan

- [x] `cargo test --workspace` — 392 tests pass, including:
  - `error_class_maps_runtime_variants_to_their_stage` + pre-install →
    `unknown` coverage
  - `error_class_wire_format_matches_containers_db_schema` pins the
    JSON serialization to the schema enum
  - `install_dry_run_writes_json_report` + resolve-time error
    semantics in the luggage CLI suite
  - `run_with_report_on_verification_failure_populates_error_class`
    and `run_with_report_on_success_captures_validate_output` exercise
    both the in-installer failure path and the validate-output capture
  - `test_entry_round_trips_evidence_fields`,
    `test_entry_round_trips_failure_row_with_error_class`,
    `test_entry_legacy_row_without_evidence_fields_still_parses`
    confirm forward + backward compat on the schema mirror
  - `record-evidence` integration tests cover success / fail / skip
    rows plus bad-digest and missing-report rejection
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] End-to-end smoke: `luggage install rust@1.95.0 --dry-run
  --json-report report.json` piped through `record-evidence` produces
  a row that validates against the live containers-db `TestEntry`
  schema (verified with `jsonschema` against the fetched schema)

## Notes for reviewers

- `ErrorClass` is defined once in `luggage` and a parallel mirror in
  `containers-common`. The wrapper translates between them; both sides
  serialize to identical wire formats and there's an exhaustiveness
  test that pins this invariant.
- Luggage release pipeline is deferred until v5 stabilizes — sub-issue
  D will build luggage in-CI and mount the binary into the evidence-run
  container, same convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)