### PR TITLE
fix(luggage): serialize shim-writing validate tests to close fork/exec race

### DIFF
--- a/crates/luggage/src/installer/validate.rs
+++ b/crates/luggage/src/installer/validate.rs
@@ -109,6 +109,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    #[serial_test::serial]
     fn matching_output_passes() {
         let dir = tempdir().unwrap();
         write_shim(dir.path(), "rustc", "rustc 1.95.0 (abcdef0)");
@@ -118,6 +119,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    #[serial_test::serial]
     fn mismatched_output_returns_validation_failed() {
         let dir = tempdir().unwrap();
         write_shim(dir.path(), "rustc", "rustc 1.84.0");
@@ -141,6 +143,7 @@ mod tests {
     /// the version-contains assertion fails.
     #[cfg(unix)]
     #[test]
+    #[serial_test::serial]
     fn propagates_env_to_subprocess() {
         let dir = tempdir().unwrap();
         let shim = dir.path().join("rustc");


### PR DESCRIPTION
## Summary

- Mark the three shim-writing tests in `crates/luggage/src/installer/validate.rs` with `#[serial_test::serial]` to close the same fork+ETXTBSY race that #459 fixed for `installer::idempotency`.
- The three tests (`matching_output_passes`, `mismatched_output_returns_validation_failed`, `propagates_env_to_subprocess`) use the identical `write_shim` + `Command::output()` pattern but were never serialized.

## Root cause

CI run [25982111224](https://github.com/joshjhall/containers/actions/runs/25982111224) — the merge-to-main of #479 — failed on Ubuntu only with:

```
test installer::validate::tests::mismatched_output_returns_validation_failed ... FAILED
thread '...' panicked at crates/luggage/src/installer/validate.rs:127:17:
assertion failed: message.contains(\"1.95.0\")
```

The assertion fires inside the \`ValidationFailed { message, .. }\` arm. The only \`message\` formats that *don't* contain the requested version are the launch-failure branches (\`binary not found\`, \`failed to launch\`, \`exited N: ...\`). Under parallel \`cargo test\`, one thread's in-flight write-FD on the shim raises \`i_writecount\` while another thread forks for \`execve\`, and the child returns \`ETXTBSY\` (rust-lang/rust#100904). Ubuntu's faster fork/exec exposes it; macOS / Windows runners did not reproduce.

This is the same diagnosis and fix recipe that #459 applied to \`idempotency.rs\` — the \`serial_test\` dev-dep is already wired in.

## Test plan

- [x] \`cargo test -p luggage --lib installer::validate\` — 4/4 pass
- [x] \`cargo test -p luggage --lib\` — 151/151 pass
- [x] \`cargo clippy -p luggage --tests -- -D warnings\` — clean
- [x] Stress: ran \`cargo test -p luggage --lib installer::validate\` 25× consecutively — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)