### PR TITLE
fix(base): apt-get upgrade to pick up Debian security advisories

### DIFF
--- a/base-images/debian/12/amd64/Dockerfile
+++ b/base-images/debian/12/amd64/Dockerfile
@@ -34,8 +34,17 @@ ENV DEBIAN_FRONTEND=noninteractive
 # passwd for nologin lookups, and that's it. Anything else is a tool the
 # evidence run is supposed to install — keeping it out of this layer
 # preserves the "tool under test is the only major variable" invariant.
-# hadolint ignore=DL3008
+#
+# `apt-get upgrade` runs against `debian:12-slim`'s preinstalled set
+# (libc-bin, libcap2, libsystemd0, …) so a fresh build picks up Debian
+# security advisories without waiting for an upstream image refresh.
+# Without it, Trivy fails the publish step on HIGH CVEs the security
+# repo has already shipped fixes for (see incident 2026-05-17). DL3005
+# normally discourages this for derived images, but a base image is
+# itself a security boundary.
+# hadolint ignore=DL3005,DL3008
 RUN apt-get update \
+ && apt-get upgrade -y \
  && apt-get install -y --no-install-recommends \
         ca-certificates \
         sudo \


### PR DESCRIPTION
## Summary

- Add \`apt-get upgrade -y\` between \`update\` and \`install\` in \`base-images/debian/12/amd64/Dockerfile\` so every fresh build refreshes the \`debian:12-slim\` preinstalled set against the Debian security repo.
- Add hadolint \`DL3005\` ignore: that rule targets derived application images where upgrade introduces non-determinism, but a base image is itself the security boundary and *should* track upstream patches.

## Root cause

Trivy failed the Build Base Images publish step on the v4.19.1 release tag ([run 25981902366](https://github.com/joshjhall/containers/actions/runs/25981902366)) with 5 HIGH CVEs:

| Package | CVE | Fixed in |
|---|---|---|
| libc-bin / libc6 | CVE-2026-0861 (glibc heap corruption) | 2.36-9+deb12u14 |
| libcap2 | CVE-2026-4878 (TOCTOU privilege escalation) | 1:2.66-4+deb12u3 |
| libsystemd0 / libudev1 | CVE-2026-29111 (arbitrary code execution via IPC) | 252.39-1~deb12u2 |

All five are preinstalled in the \`debian:12-slim\` FROM layer. The existing Dockerfile only \`apt-get install\`s ca-certificates/sudo/passwd, so those preinstalled packages stay frozen at whatever versions the cached FROM layer carried — \`apt-get install\` doesn't upgrade anything it isn't asked to install. Trivy is configured with \`--exit-code 1 --severity CRITICAL,HIGH --ignore-unfixed\` so the publish step (correctly) failed.

## Test plan

- [x] \`just lint-docker\` — clean on the base-images Dockerfile (existing DL3059 info-level messages on the unrelated main Dockerfile remain)
- [ ] CI Build Base Images job builds and Trivy scan returns 0 HIGH/CRITICAL

🤖 Generated with [Claude Code](https://claude.com/claude-code)