### PR TITLE
fix(ci): move auto-patch matrix update from pre-merge to post-merge

### DIFF
--- a/.github/workflows/auto-patch.yml
+++ b/.github/workflows/auto-patch.yml
@@ -356,100 +356,12 @@ jobs:
             echo "gpg_keys_changed=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Update compatibility matrix with test results
-        run: |
-          echo "Updating compatibility matrix with passing test results..."
-          if [ -f "version-compatibility-matrix.json" ]; then
-            # Extract current versions from Dockerfile
-            PYTHON_VER=$(grep "^ARG PYTHON_VERSION=" Dockerfile | cut -d= -f2 | tr -d '"')
-            NODE_VER=$(grep "^ARG NODE_VERSION=" Dockerfile | cut -d= -f2 | tr -d '"')
-            RUST_VER=$(grep "^ARG RUST_VERSION=" Dockerfile | cut -d= -f2 | tr -d '"')
-            GO_VER=$(grep "^ARG GO_VERSION=" Dockerfile | cut -d= -f2 | tr -d '"')
-            RUBY_VER=$(grep "^ARG RUBY_VERSION=" Dockerfile | cut -d= -f2 | tr -d '"')
-            JAVA_VER=$(grep "^ARG JAVA_VERSION=" Dockerfile | cut -d= -f2 | tr -d '"')
-            R_VER=$(grep "^ARG R_VERSION=" Dockerfile | cut -d= -f2 | tr -d '"')
-
-            # Update tested_combinations status to passing and update tested arrays
-            jq \
-              --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-              --arg python "${PYTHON_VER:-}" \
-              --arg node "${NODE_VER:-}" \
-              --arg rust "${RUST_VER:-}" \
-              --arg go "${GO_VER:-}" \
-              --arg ruby "${RUBY_VER:-}" \
-              --arg java "${JAVA_VER:-}" \
-              --arg r "${R_VER:-}" \
-              '
-              .last_updated = $timestamp |
-              # Update all tested_combinations to passing with current timestamp
-              .tested_combinations = [
-                .tested_combinations[] |
-                .status = "passing" |
-                .tested_at = $timestamp |
-                # Update versions in tested combinations
-                if .variant == "python-dev" and $python != "" then .versions.python = $python
-                elif .variant == "node-dev" and $node != "" then .versions.node = $node
-                elif .variant == "rust-golang" and $rust != "" and $go != "" then .versions.rust = $rust | .versions.go = $go
-                elif .variant == "polyglot" then
-                  (if $python != "" then .versions.python = $python else . end) |
-                  (if $node != "" then .versions.node = $node else . end) |
-                  (if $rust != "" then .versions.rust = $rust else . end) |
-                  (if $go != "" then .versions.go = $go else . end)
-                else .
-                end
-              ] |
-              # Update tested arrays in language_versions
-              (if $python != "" and (.language_versions.python.tested | index($python) | not) then
-                .language_versions.python.tested += [$python]
-              else . end) |
-              (if $node != "" and (.language_versions.node.tested | index($node) | not) then
-                .language_versions.node.tested += [$node]
-              else . end) |
-              (if $rust != "" and (.language_versions.rust.tested | index($rust) | not) then
-                .language_versions.rust.tested += [$rust]
-              else . end) |
-              (if $go != "" and (.language_versions.go.tested | index($go) | not) then
-                .language_versions.go.tested += [$go]
-              else . end) |
-              (if $ruby != "" and (.language_versions.ruby.tested | index($ruby) | not) then
-                .language_versions.ruby.tested += [$ruby]
-              else . end) |
-              (if $java != "" and (.language_versions.java.tested | index($java) | not) then
-                .language_versions.java.tested += [$java]
-              else . end) |
-              (if $r != "" and (.language_versions.r.tested | index($r) | not) then
-                .language_versions.r.tested += [$r]
-              else . end)
-              ' version-compatibility-matrix.json > version-compatibility-matrix.json.tmp \
-              && mv version-compatibility-matrix.json.tmp version-compatibility-matrix.json
-
-            # Format JSON with dprint (jq expands compact arrays; dprint normalizes)
-            dprint fmt version-compatibility-matrix.json || true
-
-            # Skip commit/push when the only diff is the last_updated/tested_at
-            # timestamps. Without this guard, every workflow_run retry pushes a
-            # new commit, which re-triggers CI, which re-triggers this job —
-            # producing a chain of empty "Update compatibility matrix" commits.
-            NON_TIMESTAMP_DIFF=$(git diff --no-color version-compatibility-matrix.json \
-              | /usr/bin/grep -E '^[+-][^+-]' \
-              | /usr/bin/grep -vE '^[+-][[:space:]]*"(last_updated|tested_at)":' \
-              || true)
-
-            if [ -z "$NON_TIMESTAMP_DIFF" ]; then
-              echo "Only timestamp updates detected — skipping commit to avoid retry loop"
-              git checkout -- version-compatibility-matrix.json
-            else
-              # Commit the matrix update
-              git config user.name "github-actions[bot]"
-              git config user.email "github-actions[bot]@users.noreply.github.com"
-              git add version-compatibility-matrix.json
-              git commit -m "chore: Update compatibility matrix with passing test results"
-              git push origin "${{ steps.branch_info.outputs.branch }}"
-              echo "Compatibility matrix updated with test results"
-            fi
-          else
-            echo "Warning: version-compatibility-matrix.json not found"
-          fi
+      # The compatibility-matrix update is intentionally NOT done here.
+      # Pushing a second commit to the auto-patch branch invalidates the
+      # CI conclusion that triggered this workflow_run (which validated
+      # commit N, not N+1) and ships a different SHA to `main` than the
+      # one that was tested. The matrix update moved to the `post-merge`
+      # job below, which writes against `main` after the merge succeeds.
 
       - name: Create pull request
         id: create_pr
@@ -588,6 +500,99 @@ jobs:
             echo "$COMMIT_MSG"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Update compatibility matrix with test results
+        run: |
+          echo "Updating compatibility matrix with passing test results..."
+          if [ -f "version-compatibility-matrix.json" ]; then
+            # Extract current versions from Dockerfile
+            PYTHON_VER=$(grep "^ARG PYTHON_VERSION=" Dockerfile | cut -d= -f2 | tr -d '"')
+            NODE_VER=$(grep "^ARG NODE_VERSION=" Dockerfile | cut -d= -f2 | tr -d '"')
+            RUST_VER=$(grep "^ARG RUST_VERSION=" Dockerfile | cut -d= -f2 | tr -d '"')
+            GO_VER=$(grep "^ARG GO_VERSION=" Dockerfile | cut -d= -f2 | tr -d '"')
+            RUBY_VER=$(grep "^ARG RUBY_VERSION=" Dockerfile | cut -d= -f2 | tr -d '"')
+            JAVA_VER=$(grep "^ARG JAVA_VERSION=" Dockerfile | cut -d= -f2 | tr -d '"')
+            R_VER=$(grep "^ARG R_VERSION=" Dockerfile | cut -d= -f2 | tr -d '"')
+
+            # Update tested_combinations status to passing and update tested arrays
+            jq \
+              --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+              --arg python "${PYTHON_VER:-}" \
+              --arg node "${NODE_VER:-}" \
+              --arg rust "${RUST_VER:-}" \
+              --arg go "${GO_VER:-}" \
+              --arg ruby "${RUBY_VER:-}" \
+              --arg java "${JAVA_VER:-}" \
+              --arg r "${R_VER:-}" \
+              '
+              .last_updated = $timestamp |
+              # Update all tested_combinations to passing with current timestamp
+              .tested_combinations = [
+                .tested_combinations[] |
+                .status = "passing" |
+                .tested_at = $timestamp |
+                # Update versions in tested combinations
+                if .variant == "python-dev" and $python != "" then .versions.python = $python
+                elif .variant == "node-dev" and $node != "" then .versions.node = $node
+                elif .variant == "rust-golang" and $rust != "" and $go != "" then .versions.rust = $rust | .versions.go = $go
+                elif .variant == "polyglot" then
+                  (if $python != "" then .versions.python = $python else . end) |
+                  (if $node != "" then .versions.node = $node else . end) |
+                  (if $rust != "" then .versions.rust = $rust else . end) |
+                  (if $go != "" then .versions.go = $go else . end)
+                else .
+                end
+              ] |
+              # Update tested arrays in language_versions
+              (if $python != "" and (.language_versions.python.tested | index($python) | not) then
+                .language_versions.python.tested += [$python]
+              else . end) |
+              (if $node != "" and (.language_versions.node.tested | index($node) | not) then
+                .language_versions.node.tested += [$node]
+              else . end) |
+              (if $rust != "" and (.language_versions.rust.tested | index($rust) | not) then
+                .language_versions.rust.tested += [$rust]
+              else . end) |
+              (if $go != "" and (.language_versions.go.tested | index($go) | not) then
+                .language_versions.go.tested += [$go]
+              else . end) |
+              (if $ruby != "" and (.language_versions.ruby.tested | index($ruby) | not) then
+                .language_versions.ruby.tested += [$ruby]
+              else . end) |
+              (if $java != "" and (.language_versions.java.tested | index($java) | not) then
+                .language_versions.java.tested += [$java]
+              else . end) |
+              (if $r != "" and (.language_versions.r.tested | index($r) | not) then
+                .language_versions.r.tested += [$r]
+              else . end)
+              ' version-compatibility-matrix.json > version-compatibility-matrix.json.tmp \
+              && mv version-compatibility-matrix.json.tmp version-compatibility-matrix.json
+
+            # Format JSON with dprint (jq expands compact arrays; dprint normalizes)
+            dprint fmt version-compatibility-matrix.json || true
+
+            # Skip commit/push when the only diff is the last_updated/tested_at
+            # timestamps. Without this guard, every post-merge cycle pushes a
+            # new commit to main even when nothing of substance changed.
+            NON_TIMESTAMP_DIFF=$(git diff --no-color version-compatibility-matrix.json \
+              | /usr/bin/grep -E '^[+-][^+-]' \
+              | /usr/bin/grep -vE '^[+-][[:space:]]*"(last_updated|tested_at)":' \
+              || true)
+
+            if [ -z "$NON_TIMESTAMP_DIFF" ]; then
+              echo "Only timestamp updates detected — skipping commit"
+              git checkout -- version-compatibility-matrix.json
+            else
+              git config user.name "github-actions[bot]"
+              git config user.email "github-actions[bot]@users.noreply.github.com"
+              git add version-compatibility-matrix.json
+              git commit -m "chore: Update compatibility matrix with passing test results"
+              git push origin HEAD:main
+              echo "Compatibility matrix updated with test results on main"
+            fi
+          else
+            echo "Warning: version-compatibility-matrix.json not found"
+          fi
 
       - name: Create and push version tag
         env:


### PR DESCRIPTION
## Summary

- Move the "Update compatibility matrix with test results" step from the \`auto-merge\` job (workflow_run: pushes a second commit to the patch branch *before* PR creation) to the \`post-merge\` job (after the PR has merged, writes against \`main\`).
- The validated SHA is now the SHA that ships.

## Root cause (incident 2026-05-17)

Auto-patch v4.19.1 merged to main even though the push-event CI on the auto-patch branch failed (Security Scan SARIF upload errors in \`Security Scan (cloud-ops)\` and \`Security Scan (minimal)\` — [run 25981896346](https://github.com/joshjhall/containers/actions/runs/25981896346)). Three things lined up:

1. The \`auto-merge\` job (triggered by \`workflow_run\` after the *first* commit's CI succeeded) pushed a **second commit** to the patch branch and *then* called \`gh pr merge --auto\`. The second commit triggers a fresh push-event CI run, but the workflow never waits on it.
2. The PR-event CI only runs the lightweight subset (\`Run Tests\`, \`Rust Tests\`, \`Lint AI Templates\`); Security Scan, Build Images, Integration Tests, and Debian compat are gated on \`event_name == 'push' || workflow_dispatch'\` in \`ci.yml\`.
3. The main branch ruleset currently has no \`required_status_checks\` — \`gh pr merge --auto\` merges as soon as the PR is mergeable.

So the failed push-event CI on the matrix-update commit had nothing to block on, and the merge proceeded.

## What this PR fixes

This PR fixes only the **self-induced** half: by writing the matrix update post-merge, the SHA that the original CI validated is exactly the SHA that gets squash-merged. No second commit, no race between two push-event CIs.

This does **not** on its own gate the auto-merge on failed CI in general — that requires either:
- Adding \`required_status_checks\` to the \`main\` ruleset (handled separately), and/or
- Having the auto-merge job wait on the original CI conclusion via \`wait-on-check-action\` before \`gh pr merge --auto\`.

## Behavior change

- **Before:** auto-patch branch ends up with 2 commits (\`chore: automated version updates…\` then \`chore: Update compatibility matrix…\`). Both get squashed into the merge commit.
- **After:** auto-patch branch is 1 commit. After PR merges, \`post-merge\` job pushes a separate \`chore: Update compatibility matrix…\` commit directly to \`main\`. The matrix is metadata-only (append-only test attestation), so direct push is appropriate.

The timestamp-only-diff guard is preserved so cycles where nothing material changed still no-op the commit.

## Test plan

- [x] \`actionlint\` clean (\`just lint-workflows\`)
- [ ] Verify on next auto-patch cycle that the matrix update lands on main as a follow-up commit and skips when only timestamps changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)