### PR TITLE
fix(ci): skip SARIF upload on ephemeral auto-patch branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -735,9 +735,20 @@ jobs:
           severity: "CRITICAL,HIGH"
           skip-setup-trivy: "true"
 
+      # Skip Code Scanning upload on ephemeral auto-patch branches. The
+      # auto-merge job deletes those branches as soon as the PR merges
+      # (typically before the push-event CI's Security Scan finishes),
+      # and `upload-sarif` then fails with `ref not found`. Code Scanning
+      # alerts on a deleted branch are unusable anyway — the trivy-results
+      # SARIF is still uploaded as a workflow artifact below.
+      # continue-on-error guards against any other transient ref race.
       - name: Upload Trivy results to GitHub Security
         uses: github/codeql-action/upload-sarif@v4
-        if: always() && hashFiles(format('trivy-results-{0}.sarif', matrix.variant)) != ''
+        if: |
+          always()
+          && hashFiles(format('trivy-results-{0}.sarif', matrix.variant)) != ''
+          && !startsWith(github.ref, 'refs/heads/auto-patch/')
+        continue-on-error: true
         with:
           sarif_file: "trivy-results-${{ matrix.variant }}.sarif"
           category: "container-${{ matrix.variant }}"


### PR DESCRIPTION
## Summary

- Gate the \`github/codeql-action/upload-sarif\` step in the Security Scan job on \`!startsWith(github.ref, 'refs/heads/auto-patch/')\`.
- Add \`continue-on-error: true\` as belt-and-suspenders against any other transient ref race.

## Root cause

The Security Scan job's "Upload Trivy results to GitHub Security" step failed on the auto-patch CI for v4.19.1 ([run 25981896346](https://github.com/joshjhall/containers/actions/runs/25981896346)) with:

\`\`\`
##[error]ref 'refs/heads/auto-patch/20260517-030533' not found in this repository
\`\`\`

Timeline reconstruction:
1. **05:01:19** — auto-merge job pushed the matrix-update commit → triggered CI run 25981896346
2. **05:01:30** — PR #480 created, \`gh pr merge --auto\` enabled
3. **05:06:55** — PR-event CI (5m25s, lightweight subset) succeeded → PR auto-merged → \`post-merge\` job deleted the auto-patch branch
4. **06:54** — push-event CI's Security Scan reached \`upload-sarif\` step ~1h47m after the branch was deleted

Code Scanning alerts on a deleted branch can't be navigated to, so the upload was always going to be unusable. The trivy-results SARIF is still written to a workflow artifact (\`Upload Trivy scan results\`, separate step) so the scan data is retained for offline review.

## Relationship to #483

PR #483 (move matrix update to post-merge) eliminates the specific second-push race that produced this incident. This PR is **defensive**: it ensures the bug can't reappear if a future workflow change re-introduces a window between auto-merge / branch deletion and a still-running push-event CI on an ephemeral branch.

## Test plan

- [x] \`actionlint\` clean (\`just lint-workflows\`)
- [ ] Verify on next auto-patch cycle that Security Scan completes without the \`ref not found\` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)