### PR TITLE
fix(tests): make changed_features.sh exit 0 on no-feature-match input

### DIFF
--- a/tests/changed_features.sh
+++ b/tests/changed_features.sh
@@ -199,6 +199,13 @@ if [ "$RUN_ALL" = true ]; then
 fi
 
 # Emit deduplicated, sorted feature list.
-if [ ${#SEEN[@]} -gt 0 ]; then
+#
+# Bash's `set -u` trips on `${#SEEN[@]}` for an empty associative array
+# (try `set -u; declare -A m; echo ${#m[@]}` — "unbound variable").
+# Detect emptiness via the `+` parameter-expansion operator, which
+# expands to the alt-value only when at least one element has been set
+# on the array. Hit when a PR touches only files that don't map to any
+# feature (e.g. .github/workflows/*, base-images/*, docs/*).
+if [ -n "${SEEN[*]+x}" ]; then
     command printf '%s\n' "${!SEEN[@]}" | command sort -u
 fi

--- a/tests/unit/changed_features.sh
+++ b/tests/unit/changed_features.sh
@@ -172,6 +172,22 @@ test_docs_only_change_emits_nothing() {
     fi
 }
 
+# Regression: prior to the SEEN-emptiness fix, the script exited 1 with
+# `SEEN: unbound variable` when no changed file mapped to a feature. The
+# previous tests caught only stdout shape (empty) — they used `|| true`
+# and never asserted the exit code, so the bug rode along silently and
+# broke PR-tier CI on docs/workflow-only PRs.
+test_no_feature_match_exits_zero() {
+    /usr/bin/printf 'docs/foo.md\n.github/workflows/ci.yml\nbase-images/debian/12/amd64/Dockerfile\n' |
+        "$SCRIPT" --files=- >/dev/null 2>&1
+    local rc=$?
+    if [ "$rc" -eq 0 ]; then
+        assert_true true "non-feature-only input → exit 0"
+    else
+        assert_true false "non-feature-only input should exit 0, got: $rc"
+    fi
+}
+
 test_mixed_with_dockerfile_short_circuits_to_all() {
     local out
     out=$(run_with "lib/features/python.sh" "Dockerfile" "docs/foo.md")
@@ -218,6 +234,7 @@ run_test test_helper_subdir_unknown_emits_all "unknown helper subdir → ALL"
 run_test test_integration_test_for_known_feature "integration test → matching feature"
 run_test test_integration_test_for_unknown_variant "variant integration test → no mapping"
 run_test test_docs_only_change_emits_nothing "docs-only changes → nothing"
+run_test test_no_feature_match_exits_zero "non-feature-only input → exit 0"
 run_test test_mixed_with_dockerfile_short_circuits_to_all "ALL short-circuits"
 run_test test_dedup_same_feature_twice "feature + its helper → deduplicated"
 run_test test_known_features_extractable "FEATURE_MAP extractable from test_feature.sh"


### PR DESCRIPTION
## Summary

- Use the \`\${SEEN[*]+x}\` parameter-expansion idiom instead of \`\${#SEEN[@]}\` to detect an empty associative array — safe under \`set -u\` on every bash version.
- Add a regression unit test that asserts **exit code 0** (not just empty stdout) so this bug can't ride along silently again.

## Root cause

\`tests/changed_features.sh\` exited 1 with \`SEEN: unbound variable\` on any input whose mapped features were all empty — e.g. a PR touching only \`.github/workflows/*\`, \`base-images/*\`, or \`docs/*\`. Bash 5.x trips \`set -u\` on \`\${#SEEN[@]}\` for an empty associative array declared via \`declare -A\`. Reproduces locally:

\`\`\`bash
set -u
declare -A m
echo "\${#m[@]}"
# bash: m: unbound variable
\`\`\`

This silently broke \`Detect changed features\` in \`test-pr.yml\`'s PR Tier matrix on every non-feature PR since #467, including the current cleanup PRs:
- #482 (fix(base): apt-get upgrade)
- #483 (fix(ci): move matrix update)
- #484 (fix(ci): skip SARIF on auto-patch)

It didn't hit PRs touching \`crates/*\` or known feature scripts because those set \`RUN_ALL=true\` and \`break\` out of the loop before reaching line 202.

## Why the existing unit test didn't catch it

\`test_docs_only_change_emits_nothing\` captured stdout via \`\$(...) … 2>/dev/null\`, only checked emptiness, and never inspected the exit code. The crash on stderr was silenced, the stdout was indeed empty, the assertion passed. New test \`test_no_feature_match_exits_zero\` plugs that gap.

## Test plan

- [x] \`bash tests/unit/changed_features.sh\` — 18/18 pass (was 17 before)
- [x] Local repro of the bug (without fix): \`echo docs/foo.md | bash tests/changed_features.sh --files=-\` exits 1 with \`SEEN: unbound variable\`
- [x] With fix: same input exits 0 with empty stdout
- [ ] CI \`Detect changed features\` job passes on this PR (this PR itself only touches \`tests/*\` so it's covered by an \`ALL\`-mapping path; the real validation is that the *other* fix PRs stop showing this failure after rebase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)