### PR TITLE
fix(ci): build evidence-run binaries as static musl

### DIFF
--- a/.github/workflows/evidence-run.yml
+++ b/.github/workflows/evidence-run.yml
@@ -72,16 +72,30 @@ jobs:
       - name: Checkout containers
         uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
+      - name: Install Rust toolchain (musl target)
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-musl
+
+      - name: Install musl linker
+        run: sudo apt-get install -y --no-install-recommends musl-tools
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+        with:
+          key: musl
 
-      - name: Build luggage and record-evidence
+      # Build statically against musl so the produced binaries run inside
+      # any base image (glibc 2.36 / 2.31 / alpine / RHEL) without a
+      # glibc-version match against the runner. luggage's TLS path uses
+      # rustls (pure Rust), so no native-tls/openssl configuration is
+      # needed for the static link.
+      - name: Build luggage and record-evidence (static musl)
         run: |
-          cargo build --release -p luggage -p record-evidence
-          ls -l target/release/luggage target/release/record-evidence
+          cargo build --release --target x86_64-unknown-linux-musl \
+            -p luggage -p record-evidence
+          ls -l target/x86_64-unknown-linux-musl/release/luggage \
+                target/x86_64-unknown-linux-musl/release/record-evidence
 
       - name: Resolve base image digest
         id: digest
@@ -127,7 +141,7 @@ jobs:
           # the verdict.
           set +e
           docker run --rm \
-            -v "$PWD/target/release/luggage:/usr/local/bin/luggage:ro" \
+            -v "$PWD/target/x86_64-unknown-linux-musl/release/luggage:/usr/local/bin/luggage:ro" \
             -v "$PWD/out:/out" \
             "$IMAGE" \
             luggage install "${INPUT_TOOL}@${INPUT_TOOL_VERSION}" --json-report /out/luggage-report.json
@@ -148,7 +162,7 @@ jobs:
           OS_VERSION: ${{ steps.tuple.outputs.os_version }}
           ARCH: ${{ steps.tuple.outputs.arch }}
         run: |
-          ./target/release/record-evidence \
+          ./target/x86_64-unknown-linux-musl/release/record-evidence \
             --luggage-report out/luggage-report.json \
             --image-ref "$IMAGE_REF" \
             --image-digest "$IMAGE_DIGEST" \


### PR DESCRIPTION
## Summary

Fixes the glibc mismatch that broke the first non-dry-run evidence-run
([run #26468683935](https://github.com/joshjhall/containers/actions/runs/26468683935)):

> `luggage: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found`

Runner ubuntu-24.04 ships glibc 2.39; debian-12 base image ships glibc
2.36; binary built on the former won't load on the latter.

Switch the build to `x86_64-unknown-linux-musl`. Binary becomes fully
static — confirmed locally on aarch64-musl (same dep graph): `ldd`
reports "not a dynamic executable". luggage's TLS path is rustls
(pure Rust), so no native-tls/openssl shenanigans are needed for the
static link.

Bonus: this is the right primitive for sub-issue D (#478) when the
matrix expands to alpine (musl), RHEL, and older debians — one binary
runs everywhere instead of matching runner glibc to target tuple per
matrix cell.

## Test plan

- [x] `actionlint .github/workflows/evidence-run.yml` — clean
- [x] Local build for `aarch64-unknown-linux-musl` succeeds in ~10s, `ldd` says "not a dynamic executable"
- [ ] After merge: re-trigger `evidence-run.yml` with `dry_run=false`; expect the install step to succeed and a PR to open in `joshjhall/containers-db`

Follow-up to #486 / closes the acceptance gap on #477.

🤖 Generated with [Claude Code](https://claude.com/claude-code)