### PR TITLE
fix(ci): mount containers-db catalog into evidence-run container

### DIFF
--- a/.github/workflows/evidence-run.yml
+++ b/.github/workflows/evidence-run.yml
@@ -130,6 +130,22 @@ jobs:
             echo "arch=${parts[2]}"
           } >> "$GITHUB_OUTPUT"
 
+      # Single containers-db clone serves two consumers:
+      #   1. luggage (below) reads `tools/<tool>/versions/<v>.json` to know
+      #      *how* to install the tool — catalog mounted read-only into the
+      #      docker container at /catalog.
+      #   2. bin/ingest-evidence.sh (later) writes the new row to the same
+      #      checkout and pushes a branch when dry_run=false.
+      # Cloning once keeps these two consumers seeing the same catalog SHA
+      # for the lifetime of the run.
+      - name: Clone containers-db catalog
+        run: |
+          git clone --depth=1 https://github.com/joshjhall/containers-db.git _db
+          test -f "_db/tools/${INPUT_TOOL}/versions/${INPUT_TOOL_VERSION}.json" || {
+            echo "containers-db missing tools/${INPUT_TOOL}/versions/${INPUT_TOOL_VERSION}.json" >&2
+            exit 1
+          }
+
       - name: Run luggage install inside the base image
         env:
           IMAGE: ${{ steps.digest.outputs.image_ref }}@${{ steps.digest.outputs.digest }}
@@ -142,7 +158,9 @@ jobs:
           set +e
           docker run --rm \
             -v "$PWD/target/x86_64-unknown-linux-musl/release/luggage:/usr/local/bin/luggage:ro" \
+            -v "$PWD/_db:/catalog:ro" \
             -v "$PWD/out:/out" \
+            -e CONTAINERS_DB=/catalog \
             "$IMAGE" \
             luggage install "${INPUT_TOOL}@${INPUT_TOOL_VERSION}" --json-report /out/luggage-report.json
           INSTALL_RC=$?


### PR DESCRIPTION
## Summary

Follow-up to #489. The musl build now produces a binary that loads
inside debian-12, but the second non-dry-run evidence-run still fails
because luggage can't find the catalog:

> `error: catalog error: catalog path `../containers-db` is not a directory; pass --catalog or set CONTAINERS_DB`

luggage needs `tools/<tool>/versions/<v>.json` at install time to
resolve the install_method. The workflow built luggage but never
provided a catalog inside the container.

Add a single `git clone --depth=1 containers-db _db` step early in the
job, then mount `_db` read-only at `/catalog` in the docker run with
`CONTAINERS_DB=/catalog` set. The same `_db` is reused by the later
ingest steps (the script detects `.git` and skips its own clone), so
both luggage and ingest see the same catalog SHA.

## Test plan

- [x] `actionlint .github/workflows/evidence-run.yml` — clean
- [ ] After merge: re-trigger `evidence-run.yml` with `dry_run=false`; expect install step to succeed and a PR to open in `joshjhall/containers-db`

Closes the second acceptance-gap iteration for #477.

🤖 Generated with [Claude Code](https://claude.com/claude-code)