### PR TITLE
fix(ci): run luggage as root inside hardened base image

### DIFF
--- a/.github/workflows/evidence-run.yml
+++ b/.github/workflows/evidence-run.yml
@@ -156,7 +156,13 @@ jobs:
           # point of an evidence run. The row's `result` field carries
           # the verdict.
           set +e
+          # --user 0: base image defaults to a non-root USER (security
+          # hardening), but luggage needs root to install rust system-wide
+          # via rustup-init (writes to /usr/local/cargo) and to write the
+          # report file to the runner-owned /out mount. Overriding USER
+          # here is the "this is an install test, not a service" exception.
           docker run --rm \
+            --user 0 \
             -v "$PWD/target/x86_64-unknown-linux-musl/release/luggage:/usr/local/bin/luggage:ro" \
             -v "$PWD/_db:/catalog:ro" \
             -v "$PWD/out:/out" \


### PR DESCRIPTION
## Summary

Follow-up to #490. Catalog mount works; install step now fails because
the base image's non-root default USER (hardening) can't write to the
runner-owned `/out` mount or to `/usr/local/cargo` for rustup-init:

> `error: io error at /out/luggage-report.json: Permission denied (os error 13)`

Override with `--user 0` on the docker run. The base image's hardening
target is "runtime services", not "install tests" — evidence runs are
explicitly the latter, so root-in-container is the right call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)