### PR TITLE
fix(luggage): fall back to root install user when resolved user is absent

### DIFF
--- a/crates/luggage/src/bin/luggage.rs
+++ b/crates/luggage/src/bin/luggage.rs
@@ -135,7 +135,8 @@ struct InstallArgs {
     #[arg(long, default_value = "/tmp")]
     tmp_root: PathBuf,
 
-    /// Override the install user (defaults to `$USERNAME`, then `vscode`).
+    /// Override the install user (defaults to `$USERNAME`, then `vscode`,
+    /// then `root` if the resolved user doesn't exist on the system).
     #[arg(long)]
     user: Option<String>,
 

--- a/crates/luggage/src/installer/methods/mod.rs
+++ b/crates/luggage/src/installer/methods/mod.rs
@@ -130,7 +130,10 @@ pub struct MethodContext<'a> {
     pub args: &'a [String],
     /// Already-substituted env exports from `Invoke.env`.
     pub env: &'a BTreeMap<String, String>,
-    /// User to run the install as (e.g. `vscode`).
+    /// User to run the install as, already resolved by
+    /// [`crate::installer::user::resolve_install_user`] (e.g. `vscode`, or
+    /// `root` when the resolved user doesn't exist on the system). A `root`
+    /// value tells the method to skip the cache-dir `chown`.
     pub user: &'a str,
     /// Cache root (`/cache` in production).
     pub cache_root: &'a Path,

--- a/crates/luggage/src/installer/methods/script_installer.rs
+++ b/crates/luggage/src/installer/methods/script_installer.rs
@@ -3,7 +3,9 @@
 //! Reproduces the side-effects of `lib/features/rust.sh` in Rust:
 //!
 //! 1. Ensure `cache_root/cargo` and `cache_root/rustup` exist, and chown
-//!    them to the install user so `su -c` writes don't hit EACCES.
+//!    them to the install user so `su -c` writes don't hit EACCES. The chown
+//!    is skipped when the install user is `root` — root already owns the
+//!    freshly-created dirs (see issue #492).
 //! 2. Mark the downloaded artifact executable.
 //! 3. `su - <user> -c "export CARGO_HOME=...; export RUSTUP_HOME=...;
 //!    <artifact> <args...>"`.
@@ -23,7 +25,7 @@ use shell_words::quote;
 
 use super::{CommandRunner, MethodContext};
 use crate::error::{LuggageError, Result};
-use crate::installer::user::{chown_command, su_command};
+use crate::installer::user::{ROOT_USER, chown_command, su_command};
 
 /// Binaries the rust install must surface in `bin_root` for parity with
 /// `lib/features/rust.sh`.
@@ -48,10 +50,21 @@ pub fn run(ctx: &MethodContext<'_>) -> Result<()> {
     //    subdirs it creates would otherwise be root-owned; the subsequent
     //    `su -c rustup-init` child would then hit EACCES on the first
     //    write into `$RUSTUP_HOME` (see issue #462).
+    //
+    //    When the install user *is* root there's nothing to transfer — root
+    //    already owns the freshly-created dirs — and `chown root:root` is at
+    //    best a no-op. Skipping it also keeps the install correct on base
+    //    images where the resolved user doesn't exist: `resolve_install_user`
+    //    falls back to `root` there, and an unconditional
+    //    `chown <user>:<user>` would otherwise fail outright (see issue #492).
     let cargo_home = ctx.cache_root.join("cargo");
     let rustup_home = ctx.cache_root.join("rustup");
+    let needs_chown = ctx.user != ROOT_USER;
     for dir in [&cargo_home, &rustup_home] {
         fs::create_dir_all(dir).map_err(|e| LuggageError::Io { path: dir.clone(), source: e })?;
+        if !needs_chown {
+            continue;
+        }
         let argv = chown_command(ctx.user, dir);
         let outcome = ctx.runner.run(&argv[0], &argv[1..])?;
         if !outcome.success() {
@@ -268,6 +281,42 @@ mod tests {
             assert_eq!(chown_args[0], "-R");
             assert_eq!(chown_args[1], "vscode:vscode");
         }
+    }
+
+    #[test]
+    fn run_skips_chown_when_user_is_root() {
+        // On a base image without the resolved dev user, the install user
+        // falls back to "root"; chown must be skipped (root already owns the
+        // freshly-created dirs) while su still runs as root. See issue #492.
+        let cache = tempdir().unwrap();
+        let bin = tempdir().unwrap();
+        let tmp = tempdir().unwrap();
+        let artifact = make_artifact(tmp.path());
+        let runner = RecordingRunner::new();
+        let env = BTreeMap::new();
+        let args: Vec<String> = vec![];
+
+        let ctx = MethodContext {
+            artifact: &artifact,
+            args: &args,
+            env: &env,
+            user: "root",
+            cache_root: cache.path(),
+            bin_root: bin.path(),
+            runner: &runner,
+        };
+        run(&ctx).unwrap();
+
+        let calls = runner.calls();
+        assert!(
+            !calls.iter().any(|(p, _)| p == "chown"),
+            "expected no chown calls when user is root, got {calls:?}",
+        );
+        // The cache dirs are still created, and the install still runs as root.
+        assert!(cache.path().join("cargo").is_dir());
+        assert!(cache.path().join("rustup").is_dir());
+        let su_call = calls.iter().find(|(p, _)| p == "su").expect("expected an su call");
+        assert_eq!(su_call.1[1], "root");
     }
 
     #[test]

--- a/crates/luggage/src/installer/mod.rs
+++ b/crates/luggage/src/installer/mod.rs
@@ -218,7 +218,7 @@ impl Installer {
         };
 
         let post_install_steps = resolved.post_install.as_ref().map_or(0, Vec::len);
-        let user = user::resolve_user(self.options.user_override.as_deref());
+        let user = user::resolve_install_user(self.options.user_override.as_deref());
 
         Ok(InstallPlan {
             tool: resolved.tool.clone(),

--- a/crates/luggage/src/installer/user.rs
+++ b/crates/luggage/src/installer/user.rs
@@ -7,6 +7,12 @@
 //!
 //! The username is read from `$USERNAME` (set by the Dockerfile) with a
 //! `vscode` fallback that matches the default user across the build matrix.
+//! When the resolved user doesn't actually exist on the system — e.g. a
+//! hardened base image whose `$USERNAME` is unset and that ships no `vscode`
+//! user (see issue #492) — [`resolve_install_user`] falls back to `root`, the
+//! uid the install already runs as. The caller treats a `root` install user
+//! as the signal to skip the cache-dir `chown` (root already owns the
+//! freshly-created paths).
 
 use std::collections::BTreeMap;
 use std::env;
@@ -18,6 +24,11 @@ use shell_words::quote;
 /// Default install user when `$USERNAME` is unset. Matches the Dockerfile
 /// default and the user `lib/features/rust.sh` falls back to.
 pub const DEFAULT_USERNAME: &str = "vscode";
+
+/// The root user — used as the last-resort install user when the resolved
+/// user doesn't exist, and as the sentinel the install method checks to skip
+/// the ownership `chown`.
+pub const ROOT_USER: &str = "root";
 
 /// Pick the install user from an explicit override or `$USERNAME`.
 ///
@@ -38,6 +49,44 @@ pub fn resolve_user(override_value: Option<&str>) -> String {
         .ok()
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| DEFAULT_USERNAME.to_owned())
+}
+
+/// Resolve the install user, falling back to [`ROOT_USER`] when the user
+/// [`resolve_user`] picks doesn't exist on the system.
+///
+/// Layered on top of [`resolve_user`]: that function answers "what name did
+/// the override / `$USERNAME` / default ask for"; this one answers "what user
+/// can we actually `chown`/`su` to". On a hardened base image where neither a
+/// `--user` override nor `$USERNAME` names a real user (issue #492), the bare
+/// name resolution returns `vscode`, which doesn't exist and would fail the
+/// `chown`/`su` mid-pipeline. Falling back to `root` — the uid the install
+/// already runs as — keeps the install correct without per-image plumbing.
+#[must_use]
+pub fn resolve_install_user(override_value: Option<&str>) -> String {
+    let user = resolve_user(override_value);
+    if user_exists(&user) { user } else { ROOT_USER.to_owned() }
+}
+
+/// Check whether `user` exists on the system by scanning `/etc/passwd`.
+///
+/// [`ROOT_USER`] short-circuits to `true` (uid 0 always exists). A failure to
+/// read `/etc/passwd` returns `false`, which steers callers to the safe
+/// `root` fallback rather than attempting a `chown`/`su` that would fail.
+#[must_use]
+pub fn user_exists(user: &str) -> bool {
+    if user == ROOT_USER {
+        return true;
+    }
+    std::fs::read_to_string("/etc/passwd").is_ok_and(|passwd| passwd_has_user(&passwd, user))
+}
+
+/// True iff `passwd` (the contents of an `/etc/passwd`-format file) has a line
+/// whose first colon-delimited field equals `user`.
+///
+/// Split out from [`user_exists`] so the line-matching logic is unit-testable
+/// without touching the host's real `/etc/passwd`.
+fn passwd_has_user(passwd: &str, user: &str) -> bool {
+    passwd.lines().any(|line| line.split(':').next() == Some(user))
 }
 
 /// Build a `su - <user> -c "<payload>"` argv.
@@ -127,5 +176,40 @@ mod tests {
     fn chown_command_builds_recursive_user_group_argv() {
         let argv = chown_command("vscode", Path::new("/cache/cargo"));
         assert_eq!(argv, vec!["chown", "-R", "vscode:vscode", "/cache/cargo"]);
+    }
+
+    const PASSWD_SAMPLE: &str = "root:x:0:0:root:/root:/bin/bash\n\
+                                 vscode:x:1000:1000::/home/vscode:/bin/bash\n";
+
+    #[test]
+    fn passwd_has_user_matches_exact_first_field() {
+        assert!(passwd_has_user(PASSWD_SAMPLE, "root"));
+        assert!(passwd_has_user(PASSWD_SAMPLE, "vscode"));
+    }
+
+    #[test]
+    fn passwd_has_user_rejects_missing_and_partial_names() {
+        assert!(!passwd_has_user(PASSWD_SAMPLE, "runner"));
+        // A prefix of a real user must not match the colon-delimited field.
+        assert!(!passwd_has_user(PASSWD_SAMPLE, "vsc"));
+        // A substring of a later field (uid/home) must not match either.
+        assert!(!passwd_has_user(PASSWD_SAMPLE, "1000"));
+    }
+
+    #[test]
+    fn user_exists_short_circuits_root() {
+        // root must report present even if /etc/passwd can't be read.
+        assert!(user_exists(ROOT_USER));
+    }
+
+    #[test]
+    fn resolve_install_user_falls_back_to_root_for_unknown_user() {
+        // This name cannot exist on any host, so the result is deterministic.
+        assert_eq!(resolve_install_user(Some("zzz-nonexistent-user-492")), ROOT_USER);
+    }
+
+    #[test]
+    fn resolve_install_user_keeps_root_override() {
+        assert_eq!(resolve_install_user(Some("root")), ROOT_USER);
     }
 }


### PR DESCRIPTION
## Summary

`luggage install` hardcoded `vscode` as the install-user fallback. On a base
image where `$USERNAME` is unset and no `vscode` user exists (e.g. the hardened
`base-debian-12`, whose USERNAME is `runner`), **both** the `chown` and the
subsequent `su - <user>` steps fail mid-pipeline:

```
chown /cache/cargo -> vscode exited with status Some(1):
chown: invalid user: 'vscode:vscode'   (error_class: install_method)
```

This was surfaced by the evidence-run prototype (#477) — `evidence-run.yml`
runs the container as `--user 0` with no luggage `--user` override and no
`USERNAME` env, so luggage falls back to `vscode`.

### Fix (issue option 1 — detect-then-fallback to root)

- Add `resolve_install_user()` in `installer/user.rs`, layering an
  `/etc/passwd` existence check (`user_exists()` + pure `passwd_has_user()`)
  over the existing `resolve_user()`. When the resolved user doesn't exist,
  fall back to `root` — the uid the install already runs as.
- The script installer treats a `root` install user as the signal to **skip
  the cache-dir `chown`** (root already owns the freshly-created dirs, and
  `su - root -c` runs without a real dev user). `CARGO_HOME`/`RUSTUP_HOME` are
  still exported into the `su` payload, so cargo state lands in `/cache`, not
  `/root/.cargo`.

Using `ctx.user == "root"` as the skip signal needs **no new `MethodContext`
field** and leaves the `chown` wire format unchanged, so all existing tests
stay green. `resolve_user()` is untouched (its pure name-resolution contract
is preserved).

## Test plan

- 6 new unit tests, including `run_skips_chown_when_user_is_root` which locks
  the chosen fallback semantics (acceptance criterion #2), plus
  `passwd_has_user` exact/partial-match coverage and `resolve_install_user`
  root-fallback behavior.
- Full workspace suite green after a clean rebuild (19 test suites, 0 failures);
  `cargo clippy -p luggage --all-targets -- -D warnings` and `cargo fmt` clean.
- End-to-end against `base-debian-12` (acceptance #1/#3) is validated by a
  rerun of the evidence-run workflow — the install should now emit a
  `result: pass` row instead of `result: fail, error_class: install_method`.

## Notes

- `evidence-run.yml` needs no change — it never carried the temporary
  `-e USERNAME=runner` workaround; the luggage-side fix is the durable answer.
- Pre-review scanner flagged `missing-test-file` for `script_installer.rs` —
  false positive; that file's tests live in an inline `#[cfg(test)] mod tests`
  per Rust convention.

Closes #492