### PR TITLE
feat(ci): matrix + PR/push triggers for evidence-run workflow

### DIFF
--- a/.github/workflows/evidence-run.yml
+++ b/.github/workflows/evidence-run.yml
@@ -1,29 +1,35 @@
 name: Evidence Run
 
-# Prototype evidence-run workflow for sub-issue C of #473 (transport
-# choice + end-to-end prototype). Single tuple, manual trigger only.
-# Sub-issue D (#478) extends this with the full matrix and tier
-# scheduling — keep the surface area here small so D can replace freely.
+# Evidence-run workflow (sub-issue D of #473 — matrix + tier integration).
+# Builds `luggage` + `record-evidence` from this repo, runs a tool install
+# against a published, signed base image at its digest, records a
+# TestEntry-shaped row, and hands it to `bin/ingest-evidence.sh` for
+# delivery into `joshjhall/containers-db`.
 #
-# Flow per dispatch:
-#   1. Build `luggage` and `record-evidence` from this repo.
-#   2. Pull the pilot base image and capture its `sha256:` digest.
+# Triggers (all path-scoped to evidence-relevant sources):
+#   - pull_request → main : run the matrix in DRY-RUN (validate the row
+#     merges cleanly). Fork-safe — needs no secrets.
+#   - push → main         : run the matrix and open a real PR against
+#     containers-db (requires the `CONTAINERS_DB_PAT` secret).
+#   - workflow_dispatch   : ad-hoc single run; the `dry_run` input chooses.
+# No cron: per #473, while the catalog is small "just enumerate" beats
+# sampling, so the matrix is exhaustive and event-driven.
+#
+# A `setup` job resolves the matrix (a single input-derived leg for
+# dispatch, the enumerated pilot legs for PR/push) and the effective
+# dry-run flag, so the `evidence` job body is identical across events.
+# Per-leg coordinates are read into `env:` rather than interpolated into
+# `run:` scripts — the same guardrail the dispatch prototype used.
+#
+# Flow per matrix leg:
+#   1. Build `luggage` and `record-evidence` from this repo (static musl).
+#   2. Pull the base image and capture its `sha256:` digest.
 #   3. Run `luggage install <tool>@<version> --json-report` inside the
 #      image (binary mounted from the runner per the
 #      luggage-release-deferred convention).
 #   4. Run `record-evidence` to assemble the TestEntry-shaped row.
-#   5. Hand the row to `bin/ingest-evidence.sh`, which dedup-merges into
-#      `joshjhall/containers-db` and (when `dry_run=false`) opens a PR
-#      against that repo.
-#
-# The default is `dry_run=true`. Switching to false requires the
-# `CONTAINERS_DB_PAT` secret to be configured — see
-# `docs/operations/evidence-runs.md` for setup and rotation.
-#
-# All `inputs.*` values are read into `env:` rather than interpolated
-# directly into `run:` scripts. workflow_dispatch inputs come from
-# trusted maintainers, but the env indirection keeps the same guardrail
-# the matrix-and-cron version (#478) will need anyway.
+#   5. Hand the row to `bin/ingest-evidence.sh` — a dry-run validate, or a
+#      real cross-repo push + PR when dry-run is false.
 
 on:
   workflow_dispatch:
@@ -52,22 +58,97 @@ on:
         required: true
         default: true
         type: boolean
+  pull_request:
+    branches: [main]
+    paths:
+      - "crates/luggage/**"
+      - "crates/record-evidence/**"
+      - "crates/containers-common/**"
+      - "base-images/**"
+      - "bin/ingest-evidence.sh"
+      - ".github/workflows/evidence-run.yml"
+  push:
+    branches: [main]
+    paths:
+      - "crates/luggage/**"
+      - "crates/record-evidence/**"
+      - "crates/containers-common/**"
+      - "base-images/**"
+      - "bin/ingest-evidence.sh"
+      - ".github/workflows/evidence-run.yml"
 
 permissions:
   contents: read
 
+# Serialize runs on the same ref so two pushes to main don't race to open
+# duplicate containers-db PRs. Don't cancel an in-flight run — an
+# interrupted ingest could leave a half-pushed branch behind.
+concurrency:
+  group: evidence-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
-  INPUT_TOOL: ${{ inputs.tool }}
-  INPUT_TOOL_VERSION: ${{ inputs.tool_version }}
-  INPUT_TUPLE: ${{ inputs.tuple }}
-  INPUT_IMAGE_TAG: ${{ inputs.image_tag }}
 
 jobs:
+  # Resolve the matrix and the effective dry-run flag once, so the
+  # `evidence` job body is event-agnostic:
+  #   - workflow_dispatch: a single leg built from the inputs; dry-run
+  #     follows the `dry_run` input.
+  #   - pull_request: the enumerated pilot legs in dry-run (validate only).
+  #   - push → main: the enumerated pilot legs with a real ingest.
+  setup:
+    name: Resolve matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.gen.outputs.matrix }}
+      dry_run: ${{ steps.gen.outputs.dry_run }}
+    steps:
+      - name: Generate matrix and dry-run flag
+        id: gen
+        env:
+          EVENT: ${{ github.event_name }}
+          INPUT_TOOL: ${{ inputs.tool }}
+          INPUT_TOOL_VERSION: ${{ inputs.tool_version }}
+          INPUT_TUPLE: ${{ inputs.tuple }}
+          INPUT_IMAGE_TAG: ${{ inputs.image_tag }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            MATRIX=$(jq -cn \
+              --arg tool "$INPUT_TOOL" \
+              --arg version "$INPUT_TOOL_VERSION" \
+              --arg tuple "$INPUT_TUPLE" \
+              --arg image_tag "$INPUT_IMAGE_TAG" \
+              '{include: [{tool: $tool, version: $version, tuple: $tuple, image_tag: $image_tag}]}')
+            DRY="$INPUT_DRY_RUN"
+          else
+            # Pilot legs. Extend here (add tuples/tools) as base images
+            # publish — the evidence job body needs no changes.
+            MATRIX='{"include":[{"tool":"rust","version":"1.95.0","tuple":"debian-12-amd64","image_tag":"latest"}]}'
+            if [ "$EVENT" = "pull_request" ]; then
+              DRY="true"
+            else
+              DRY="false"
+            fi
+          fi
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          echo "dry_run=$DRY" >> "$GITHUB_OUTPUT"
+
   evidence:
-    name: Evidence ${{ inputs.tool }}@${{ inputs.tool_version }} on ${{ inputs.tuple }}
+    name: Evidence ${{ matrix.tool }}@${{ matrix.version }} on ${{ matrix.tuple }}
+    needs: setup
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
+    env:
+      INPUT_TOOL: ${{ matrix.tool }}
+      INPUT_TOOL_VERSION: ${{ matrix.version }}
+      INPUT_TUPLE: ${{ matrix.tuple }}
+      INPUT_IMAGE_TAG: ${{ matrix.image_tag }}
     steps:
       - name: Checkout containers
         uses: actions/checkout@v4
@@ -208,7 +289,7 @@ jobs:
         uses: extractions/setup-just@v3
 
       - name: Ingest evidence (dry-run)
-        if: ${{ inputs.dry_run }}
+        if: ${{ needs.setup.outputs.dry_run == 'true' }}
         env:
           GIT_AUTHOR_NAME: github-actions[bot]
           GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
@@ -222,7 +303,7 @@ jobs:
             --dry-run
 
       - name: Ingest evidence (PR open)
-        if: ${{ ! inputs.dry_run }}
+        if: ${{ needs.setup.outputs.dry_run != 'true' }}
         env:
           GH_TOKEN: ${{ secrets.CONTAINERS_DB_PAT }}
           GIT_AUTHOR_NAME: github-actions[bot]

--- a/docs/operations/ci-tiers.md
+++ b/docs/operations/ci-tiers.md
@@ -2,8 +2,10 @@
 
 Container builds and integration tests are split across four cadence tiers,
 trading depth of coverage for feedback speed. A PR sees only the features it
-touched; the full distro × arch × feature matrix runs weekly. This page
-describes the design, what's implemented today, and what's planned.
+touched; the full distro × arch × feature matrix runs weekly. Evidence runs sit
+alongside these as an event-driven tier that records per-tool install results
+against signed base images. This page describes the design, what's implemented
+today, and what's planned.
 
 ## Overview
 
@@ -14,15 +16,18 @@ describes the design, what's implemented today, and what's planned.
 | Weekly    | Cron Sundays 03:00 UTC               | <2 h             | All features × all distros × all arches     | Planned (#408-B)      |
 | Monthly   | Cron 1st of month 04:00 UTC          | <4 h             | Long-tail: image size, abandonment scan     | Planned (#408-C)      |
 | Quarterly | Cron 1st of Q 09:00 UTC (existing)   | Best-effort      | Cross-version dependency drift              | Planned (#408-D)      |
+| Evidence  | `pull_request` + `push` → main       | <30 min          | Pilot: rust × debian-12-amd64 (extensible)  | Implemented (#478)    |
 
 Promotion criteria are unidirectional — passing a faster tier is a prereq
 for letting code reach the next slower tier, but a failure at a slower tier
-does not block ongoing work (the regression opens an issue instead).
+does not block ongoing work (the regression opens an issue instead). Evidence
+runs are off to the side of this chain: they don't gate merges, they record
+what a published base image actually does when a tool is installed onto it.
 
-Evidence runs (per-tool installs against signed base images, results
-landing in `joshjhall/containers-db`) are dispatch-only today; see
+The evidence tier records per-tool installs against signed base images, with
+results landing in `joshjhall/containers-db`. It is event-driven (no cron) and
+path-scoped — see the [Evidence runs](#evidence-runs) section below and
 [evidence-runs.md](evidence-runs.md) for the ingestion contract.
-Tier integration is [#478](https://github.com/joshjhall/containers/issues/478).
 
 ## PR tier
 
@@ -201,6 +206,67 @@ Uses [`bin/check-versions.sh --json`](../../bin/check-versions.sh) to
 enumerate the pinned versions; combinations are sampled rather than
 exhaustive (full Cartesian product is infeasible for >50 tools).
 
+## Evidence runs
+
+**Status:** Implemented in
+[`.github/workflows/evidence-run.yml`](../../.github/workflows/evidence-run.yml).
+
+Unlike the cadence tiers above, the evidence tier is not about catching
+regressions in *this* repo — it produces a durable record of what a published
+base image does when a real tool is installed onto it. Each run builds
+[`luggage`](../../crates/luggage/) and
+[`record-evidence`](../../crates/record-evidence/) from this repo, pulls a
+signed base image at its `sha256:` digest, runs `luggage install <tool>@<version>`
+inside it, and assembles a `TestEntry`-shaped row. The row is delivered to
+`joshjhall/containers-db` via [`bin/ingest-evidence.sh`](../../bin/ingest-evidence.sh).
+
+### Cadence
+
+Event-driven, not cron. Per [#473](https://github.com/joshjhall/containers/issues/473),
+while the tool catalog is small "just enumerate" beats sampling, so the matrix is
+exhaustive rather than scheduled. Three triggers, all **path-scoped** to evidence
+sources (`crates/luggage/**`, `crates/record-evidence/**`,
+`crates/containers-common/**`, `base-images/**`, `bin/ingest-evidence.sh`, and the
+workflow itself) so unrelated PRs don't pay the build-and-install cost:
+
+| Trigger             | Ingest behavior                                       |
+| ------------------- | ----------------------------------------------------- |
+| `pull_request` → main | Dry-run: validate the row merges cleanly against the catalog schema. Fork-safe — no secrets. |
+| `push` → main       | Real ingest: open a PR against `joshjhall/containers-db` (requires the `CONTAINERS_DB_PAT` secret). |
+| `workflow_dispatch` | Single ad-hoc leg from inputs; the `dry_run` input chooses validate vs. real ingest. |
+
+A `setup` job resolves the matrix (a single input-derived leg for dispatch, the
+enumerated pilot legs for PR/push) and the effective dry-run flag, keeping the
+`evidence` job body identical across events. A `concurrency` group serializes
+runs on the same ref so two main pushes can't race to open duplicate PRs.
+
+### What it produces
+
+One `TestEntry` row per `(tool, version, tuple)` leg, dedup-merged into
+`tools/<tool>/versions/<version>.json` in containers-db by
+`(os, os_version, arch, image_digest)`. The pilot leg is
+`rust@1.95.0 × debian-12-amd64`; add tuples or tools to the matrix in the
+`setup` job as their base images publish.
+
+### What it consumes
+
+- **Signed base images** from [`base-images/`](../../base-images/) (cosign +
+  SBOM), pulled by digest so the evidence is reproducible.
+- **The containers-db catalog**, cloned once and mounted read-only into the
+  install container so luggage knows *how* to install the tool.
+- **`luggage` + `record-evidence`**, built from this repo and mounted into the
+  base image — the luggage release pipeline is deferred until v5 stabilizes, so
+  the binary is mounted rather than installed from a package.
+
+### Failure behavior
+
+A failed `luggage install` is not a workflow failure — it is the evidence. The
+install step runs under `set +e`, and luggage writes its `--json-report` on
+every exit path (success, skip, dry-run, and failure). `record-evidence` maps a
+populated `error_class` to `result: fail`, so a broken install still produces a
+row recording *why* it broke. See [evidence-runs.md](evidence-runs.md) for the
+wire format, transport, auth model, merge policy, and failure modes.
+
 ## Cache strategy summary
 
 | Scope                            | Producer                  | Consumers                                              |
@@ -269,6 +335,7 @@ This is correct behavior for docs-only PRs. The summary job emits
 
 - [`.github/workflows/test-pr.yml`](../../.github/workflows/test-pr.yml) — PR tier
 - [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) — merge tier
+- [`.github/workflows/evidence-run.yml`](../../.github/workflows/evidence-run.yml) — evidence runs (#478)
 - `.github/workflows/test-weekly.yml` — planned (#408-B)
 - `.github/workflows/test-monthly.yml` — planned (#408-C)
 - `.github/workflows/quarterly-review.yml` — extends for #408-D


### PR DESCRIPTION
## Summary

Promotes the dispatch-only evidence-run prototype (sub-issue C) into the matrix + tier-integrated workflow that **sub-issue D of #473** calls for.

- **Triggers**: adds path-scoped `pull_request` + `push` → main (keeps `workflow_dispatch`). Scoped to `crates/luggage/**`, `crates/record-evidence/**`, `crates/containers-common/**`, `base-images/**`, `bin/ingest-evidence.sh`, and the workflow itself, so unrelated PRs don't pay the build+install cost.
- **Event-agnostic body**: a `setup` job resolves the matrix and the effective dry-run flag once. `pull_request` → dry-run validate (fork-safe, no secrets); `push` → main → real ingest (opens a containers-db PR via `CONTAINERS_DB_PAT`); `workflow_dispatch` → manual `dry_run` toggle.
- **Concurrency**: a `concurrency` group serializes runs on the same ref so two main pushes can't race to open duplicate containers-db PRs.
- **Docs**: `docs/operations/ci-tiers.md` gets an overview-table row, a full `## Evidence runs` section (cadence/triggers, produces, consumes, failure behavior), and an entry in the workflow-files list.

## Scope notes (drift from the issue checklist)

The issue checklist predates sub-issues B/C; several items were already delivered:

- `base-images/README.md` "How evidence runs consume these images" pointer already references `evidence-runs.md` — **no change needed**.
- The `result: fail` + `error_class` failure-row behavior is already implemented in luggage (`--json-report` on all exit paths) and the workflow (`set +e`) — **preserved, not re-added**.
- The build/digest/install/record steps are unchanged in substance (they encode fixes from #489–#493).

The "real row in containers-db" criterion is satisfied by the mechanism: the first `push` → main after merge runs the real ingest (requires `CONTAINERS_DB_PAT`).

## Known follow-up

`bin/ingest-evidence.sh` commits unconditionally, so a no-op re-run against an unchanged image digest fails at `git commit`. Tracked separately in #494 (idempotency hardening) — out of scope here.

## Test plan

- `just lint-workflows` (actionlint + shellcheck) → clean.
- Pre-commit hooks passed: actionlint, dprint-yaml, rumdl (markdown), conform, gitleaks.
- ci-tiers.md overview table verified uniform (5 columns); `#evidence-runs` cross-link matches the new heading.
- On-merge: this PR touches `.github/workflows/evidence-run.yml`, so the path filter fires and the workflow runs the matrix in **dry-run** against `debian-12-amd64` — expected green.

Closes #478