### PR TITLE
fix(ci): make evidence ingestion idempotent on no-op re-runs

### DIFF
--- a/bin/ingest-evidence.sh
+++ b/bin/ingest-evidence.sh
@@ -13,6 +13,14 @@
 # commit → push + `gh pr create`. The script never pushes when --dry-run
 # is set; that mode is for local development and CI smoke tests.
 #
+# Idempotent on re-runs: a row that already exists and differs only in
+# volatile fields (tested_at, ci_run, duration_seconds) is a clean no-op —
+# the merge leaves the file untouched and the script exits 0 before
+# committing, pushing, or opening a (duplicate) PR. Only a meaningful change
+# (new digest, flipped result, changed error_class/version_output, new
+# version) produces a commit + PR. See docs/operations/evidence-runs.md
+# (Merge policy) for the rationale.
+#
 # Per CLAUDE.md, all bare external commands use `command` to bypass any
 # user-shell aliases.
 
@@ -192,8 +200,13 @@ BRANCH_NAME="evidence/$TOOL/$VERSION/$TUPLE_SLUG/$BRANCH_SUFFIX"
 # --- Dedup-merge row into the tested[] array -------------------------------
 
 # Policy: rows with the same (os, os_version, arch, image_digest) are
-# replaced by the new row; everything else is preserved. Rationale lives
-# in docs/operations/evidence-runs.md (Merge policy).
+# replaced by the new row; everything else is preserved. But if an existing
+# row matches that dedup key AND is identical on every non-volatile field,
+# the new row carries no fresh signal (same content-addressed image, same
+# result) — only a newer timestamp — so we leave the file untouched and let
+# the no-op guard below short-circuit. Volatile fields are tested_at, ci_run,
+# and duration_seconds. Rationale lives in docs/operations/evidence-runs.md
+# (Merge policy).
 TMP_FILE="$(command mktemp)"
 trap 'rm -f "$TMP_FILE"' EXIT
 
@@ -203,19 +216,38 @@ jq \
     --arg ov "$NEW_OS_VERSION" \
     --arg arch "$NEW_ARCH" \
     --arg digest "$NEW_DIGEST" \
-    '.tested = (
-        ((.tested // []) | map(select(
-            (.os // "") != $os
-            or (.os_version // "") != $ov
-            or (.arch // "") != $arch
-            or (.image_digest // "") != $digest
-        ))) + [$new]
-    )' \
+    '
+    def dedup_match:
+        (.os // "") == $os
+        and (.os_version // "") == $ov
+        and (.arch // "") == $arch
+        and (.image_digest // "") == $digest;
+    def strip_volatile: del(.tested_at, .ci_run, .duration_seconds);
+    ($new | strip_volatile) as $new_core
+    | (.tested // []) as $rows
+    | if ($rows | map(select(dedup_match)) | any(strip_volatile == $new_core))
+      then .
+      else .tested = (($rows | map(select(dedup_match | not))) + [$new])
+      end
+    ' \
     "$VERSIONS_FILE" >"$TMP_FILE"
 
 # Trailing newline keeps `git diff` and POSIX text-tool output clean.
 command cp "$TMP_FILE" "$VERSIONS_FILE"
 command echo "" >>"$VERSIONS_FILE"
+
+# --- No-op short-circuit ---------------------------------------------------
+
+# If the merge produced no change against HEAD (re-running an already-recorded
+# row, modulo volatile fields), there is nothing to ingest. Exit cleanly here
+# — before validate / branch / commit / push / PR — so re-runs are a clean
+# no-op in both dry-run and real-ingest modes. The merge above is byte-stable
+# for identical inputs (jq preserves key order; the file was last written by
+# this same pipeline), so this diff check is reliable.
+if git -C "$DB_PATH" diff --quiet -- "tools/$TOOL/versions/$VERSION.json"; then
+    command echo "$SCRIPT_NAME: row already present for $TOOL@$VERSION on $TUPLE_SLUG; nothing to ingest" >&2
+    exit 0
+fi
 
 # --- Validate via the existing contributor flow ----------------------------
 
@@ -244,6 +276,14 @@ image_digest: ${NEW_DIGEST:-<absent>}
 
 See docs/operations/evidence-runs.md in joshjhall/containers for the
 ingestion contract (sub-issue C of joshjhall/containers#473)."
+
+# Belt-and-suspenders: never let an empty commit abort the run. The no-op
+# guard above is the primary defense; this catches any path that stages
+# nothing (e.g. a future caller that skips the merge).
+if git -C "$DB_PATH" diff --cached --quiet; then
+    command echo "$SCRIPT_NAME: nothing staged for $TOOL@$VERSION; nothing to ingest" >&2
+    exit 0
+fi
 
 git -C "$DB_PATH" commit -m "$COMMIT_SUBJECT" -m "$COMMIT_BODY" >&2
 

--- a/docs/operations/evidence-runs.md
+++ b/docs/operations/evidence-runs.md
@@ -156,18 +156,34 @@ the second 401 (the auth header doesn't change between retries).
 ## Merge policy
 
 Default: **append**. The transport never deletes existing rows in
-`tested[]`.
+`tested[]`. The ingest is idempotent end-to-end: re-running it with
+unchanged inputs produces no commit, no branch, and no PR (see below).
 
 Dedup key: `(os, os_version, arch, image_digest)`. When the new row
-matches an existing row on all four, the existing row is **replaced**
-by the new row. Rationale:
+matches an existing row on all four, behavior depends on whether
+anything *meaningful* changed:
+
+- **Meaningful change** (different `result`, `error_class`,
+  `version_output`, …) → the existing row is **replaced** by the new
+  row. The fresh answer supersedes the stale one.
+- **Volatile-only change** (only `tested_at`, `ci_run`, and/or
+  `duration_seconds` differ) → **no-op**. The existing row is left
+  untouched and the ingest exits 0 without committing, pushing, or
+  opening a PR. Re-running the identical image on the identical tuple
+  reproduces the same result deterministically, so a fresher timestamp
+  alone carries no new evidence — and would otherwise churn a
+  review-required PR on every `push → main`.
+
+Rationale:
 
 - Different `image_digest` = different base image build = independent
-  evidence point; keep both for history.
-- Same `image_digest` + same tuple = the row is "have we tested this
-  exact image on this exact tuple recently?". The fresh answer
-  supersedes the stale answer; we don't carry duplicates of the same
-  reproducible run.
+  evidence point; keep both for history. Freshness from patched base
+  images therefore rides on the **digest** — a rebuilt image is
+  content-addressed to a new digest, yielding a new appended row — not
+  on re-timestamping a byte-identical image.
+- Same `image_digest` + same tuple + same meaningful fields = "have we
+  already recorded this exact reproducible run?". We don't carry
+  duplicates of it.
 
 A row missing both `image_ref` and `image_digest` is allowed by the
 schema (paired-absent), but in practice the producer always sets both
@@ -202,10 +218,13 @@ is not stable across multiple producers anyway.
    set the PAT's expiration ≤90 days and audit `Settings → Secrets`
    monthly.
 
-1. **Duplicate row.**
-   Handled by the dedup key in [Merge policy](#merge-policy). Operators
-   can land the same row twice (re-running a flaky workflow) without
-   bloating the file.
+1. **Duplicate / re-run row.**
+   Handled by the dedup key in [Merge policy](#merge-policy). Re-running
+   a workflow against an unchanged image digest is a clean no-op: the
+   ingest detects nothing meaningful changed, logs `nothing to ingest`,
+   and exits 0 without committing, pushing, or opening a duplicate PR.
+   Operators can re-run a flaky workflow freely without bloating the
+   file or spawning redundant PRs.
 
 1. **Network flake on push or PR open.**
    The script retries `git push` and `gh pr create` up to 3 times with

--- a/tests/unit/ingest-evidence.sh
+++ b/tests/unit/ingest-evidence.sh
@@ -116,21 +116,24 @@ test_commit_lands_on_new_branch() {
 }
 
 test_dedup_replaces_same_tuple_same_digest() {
-    # Seed an existing row with the same (os, os_version, arch, digest)
-    # as the fixture but a stale tested_at, then ingest. The new row
-    # must replace the old one — count stays at 1, tested_at advances.
+    # Seed an existing row with the same (os, os_version, arch, digest) as
+    # the fixture but a *meaningful* difference (a failing result), then
+    # ingest the passing fixture row. Because a non-volatile field differs,
+    # the new row must replace the old one — count stays at 1 and the result
+    # flips to pass. (A difference in volatile fields alone is a no-op; that
+    # path is covered by test_noop_on_volatile_only_reingest.)
     RESULT_DB="$(command mktemp -d)"
     make_fake_db "$RESULT_DB"
     RESULT_FILE="$RESULT_DB/tools/rust/versions/1.95.0.json"
     local seed
-    seed=$(jq '. + {"tested_at": "2024-01-01T00:00:00Z", "duration_seconds": 99.9}' \
+    seed=$(jq '. + {"result": "fail", "error_class": "verify", "tested_at": "2024-01-01T00:00:00Z"}' \
         "$SAMPLE_ROW")
     local tmp
     tmp=$(command mktemp)
     jq --argjson row "$seed" '.tested = [$row]' "$RESULT_FILE" >"$tmp"
     command mv "$tmp" "$RESULT_FILE"
     git -C "$RESULT_DB" -c user.email=test@example.com -c user.name=test \
-        commit -q -am "seed stale row"
+        commit -q -am "seed failing row"
 
     "$INGEST" \
         --row "$SAMPLE_ROW" \
@@ -144,10 +147,10 @@ test_dedup_replaces_same_tuple_same_digest() {
     count=$(jq '.tested | length' "$RESULT_FILE")
     assert_equals "1" "$count" \
         "dedup on same (os, os_version, arch, image_digest) replaces, not appends"
-    local fresh_at
-    fresh_at=$(jq -r '.tested[0].tested_at' "$RESULT_FILE")
-    assert_not_equals "2024-01-01T00:00:00Z" "$fresh_at" \
-        "stale row replaced — fresh tested_at present"
+    local result
+    result=$(jq -r '.tested[0].result' "$RESULT_FILE")
+    assert_equals "pass" "$result" \
+        "meaningful change (result fail->pass) replaces the stale row"
     cleanup_db
 }
 
@@ -179,6 +182,73 @@ test_dedup_appends_different_digest() {
     count=$(jq '.tested | length' "$RESULT_FILE")
     assert_equals "2" "$count" \
         "different image_digest preserves both rows as history"
+    cleanup_db
+}
+
+test_noop_on_identical_reingest() {
+    # Re-ingesting a byte-identical row is a clean no-op: the script exits 0,
+    # creates no new commit, and prints no branch name on stdout. This is the
+    # literal "nothing to commit" regression from #494.
+    RESULT_DB="$(command mktemp -d)"
+    make_fake_db "$RESULT_DB"
+    RESULT_FILE="$RESULT_DB/tools/rust/versions/1.95.0.json"
+
+    # First ingest records the row and commits it in the script's own format.
+    GITHUB_RUN_ID=1 "$INGEST" \
+        --row "$SAMPLE_ROW" --db-path "$RESULT_DB" \
+        --tool rust --version 1.95.0 --dry-run --no-validate >/dev/null 2>&1
+    local head1
+    head1=$(git -C "$RESULT_DB" rev-parse HEAD)
+
+    # Second ingest of the identical row must change nothing.
+    local out rc=0
+    out=$(GITHUB_RUN_ID=2 "$INGEST" \
+        --row "$SAMPLE_ROW" --db-path "$RESULT_DB" \
+        --tool rust --version 1.95.0 --dry-run --no-validate 2>/dev/null) || rc=$?
+    assert_equals "0" "$rc" "identical re-ingest exits 0"
+    assert_equals "" "$out" "identical re-ingest prints no branch name on stdout"
+    local head2
+    head2=$(git -C "$RESULT_DB" rev-parse HEAD)
+    assert_equals "$head1" "$head2" "identical re-ingest creates no new commit"
+    cleanup_db
+}
+
+test_noop_on_volatile_only_reingest() {
+    # A row that matches the dedup key and differs only in volatile fields
+    # (tested_at, ci_run, duration_seconds) carries no fresh signal, so the
+    # re-ingest is a no-op and the recorded tested_at is left untouched.
+    RESULT_DB="$(command mktemp -d)"
+    make_fake_db "$RESULT_DB"
+    RESULT_FILE="$RESULT_DB/tools/rust/versions/1.95.0.json"
+
+    # First ingest records the fixture row.
+    GITHUB_RUN_ID=1 "$INGEST" \
+        --row "$SAMPLE_ROW" --db-path "$RESULT_DB" \
+        --tool rust --version 1.95.0 --dry-run --no-validate >/dev/null 2>&1
+    local head1 original_at
+    head1=$(git -C "$RESULT_DB" rev-parse HEAD)
+    original_at=$(jq -r '.tested[0].tested_at' "$RESULT_FILE")
+
+    # Second ingest: same tuple+digest+result, only volatile fields differ.
+    local volatile_row
+    volatile_row=$(command mktemp)
+    jq '. + {"tested_at": "2030-12-31T23:59:59Z", "duration_seconds": 0.1, "ci_run": "https://example.com/runs/99"}' \
+        "$SAMPLE_ROW" >"$volatile_row"
+    local rc=0
+    GITHUB_RUN_ID=2 "$INGEST" \
+        --row "$volatile_row" --db-path "$RESULT_DB" \
+        --tool rust --version 1.95.0 --dry-run --no-validate >/dev/null 2>&1 || rc=$?
+    assert_equals "0" "$rc" "volatile-only re-ingest exits 0"
+
+    local count fresh_at head2
+    count=$(jq '.tested | length' "$RESULT_FILE")
+    assert_equals "1" "$count" "volatile-only re-ingest keeps a single row"
+    fresh_at=$(jq -r '.tested[0].tested_at' "$RESULT_FILE")
+    assert_equals "$original_at" "$fresh_at" \
+        "volatile-only re-ingest leaves the recorded tested_at untouched"
+    head2=$(git -C "$RESULT_DB" rev-parse HEAD)
+    assert_equals "$head1" "$head2" "volatile-only re-ingest creates no new commit"
+    command rm -f "$volatile_row"
     cleanup_db
 }
 
@@ -254,6 +324,8 @@ run_test test_branch_name_includes_run_id_suffix "branch name uses GITHUB_RUN_ID
 run_test test_commit_lands_on_new_branch "commit lands on the new branch with conventional subject"
 run_test test_dedup_replaces_same_tuple_same_digest "dedup replaces same (tuple, digest) row"
 run_test test_dedup_appends_different_digest "different image_digest accumulates as history"
+run_test test_noop_on_identical_reingest "identical re-ingest is a clean no-op"
+run_test test_noop_on_volatile_only_reingest "volatile-only re-ingest is a clean no-op"
 run_test test_stdin_row_via_dash "--row - reads JSON from stdin"
 run_test test_rejects_missing_required_flag "missing --db-path is exit 2"
 run_test test_rejects_unknown_argument "unknown flag is exit 2"


### PR DESCRIPTION
## Summary

- Make `bin/ingest-evidence.sh` **semantically idempotent**: a re-run that differs only in volatile fields (`tested_at`, `ci_run`, `duration_seconds`) is a clean no-op — no commit, no branch, no duplicate PR. Fixes the `nothing to commit` failure and the per-push PR churn introduced when #478 wired the real ingest to `push → main`.
- **Volatile-aware merge** — the `jq` program leaves the existing row untouched when an existing row matches the dedup key `(os, os_version, arch, image_digest)` and is identical on every non-volatile field.
- **No-op short-circuit** — after the merge, `git diff --quiet` exits 0 before validate/branch/commit/push/PR, in both dry-run and real-ingest mode.
- **Empty-commit guard** — `git diff --cached --quiet` before `git commit` as belt-and-suspenders.
- Meaningful changes (new digest, flipped result, changed `error_class`/`version_output`, new version) still replace + open a PR as today.

## Decisions worth a reviewer's eye

- This **reverses the documented "fresh answer supersedes stale" policy** for same-digest re-runs. Freshness from patched base images is unaffected: a rebuilt image is content-addressed to a **new digest → a new appended row**, so freshness rides on the digest, not on re-timestamping a byte-identical image. `docs/operations/evidence-runs.md` (Merge policy + Duplicate-row failure mode) updated to match.
- `image_ref` is treated as **meaningful**, not volatile (a same-digest row fetched via a different tag would still PR — rare, conservative).

## Audit (acceptance criterion 6)

- `crates/record-evidence/` — pure deterministic transform; only `tested_at` varies, now absorbed by the merge. No change needed.
- Other evidence-run steps (`cargo build`, `luggage`, `record-evidence`, `just`) never commit/push. `.github/workflows/evidence-run.yml` needs no change — a no-op now exits 0 so the ingest step stays green.

## Test plan

- `tests/unit/ingest-evidence.sh`: **12/12 pass** — reworked `test_dedup_replaces_same_tuple_same_digest` to exercise a *meaningful* change (its old volatile-only seed is now a no-op), plus new `test_noop_on_identical_reingest` and `test_noop_on_volatile_only_reingest`.
- Full shell unit suite: **3007 passed / 0 failed**.
- `shellcheck` + `rumdl` clean; all pre-commit hooks + `conform` passed.

Closes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)