### PR TITLE
feat(features): ci-fixer Workflow harness for parse→fix→verify loop

### DIFF
--- a/lib/features/templates/claude/agents/ci-fixer/ci-fixer.md
+++ b/lib/features/templates/claude/agents/ci-fixer/ci-fixer.md
@@ -16,7 +16,9 @@ You receive a prompt containing:
 - **Check name**: the name of the failing CI check
 - **Failure logs**: the relevant log output (typically from `gh run view --log-failed`)
 - **PR number**: the pull request being fixed
-- **Iteration**: which remediation attempt this is (1, 2, or 3)
+
+The retry loop and its iteration cap are owned by the dispatching Workflow
+harness, not by you — fix the failure you are given and report the result.
 
 ## Workflow
 
@@ -46,8 +48,9 @@ You receive a prompt containing:
      compilation errors. Run the build locally to verify.
    - **Format**: run the formatter locally (`prettier --write`, `black`,
      `gofmt -w`, etc.) to auto-fix.
-   - **Other** (timeout, infra, permissions, network): return "unfixable" —
-     these require human intervention or CI config changes.
+   - **Other** (timeout, infra, permissions, network): return `fixed: false`
+     with `failure_type: "other"` — these require human intervention or CI
+     config changes.
 
 1. **Verify the fix locally** by running the specific failing command:
 
@@ -60,29 +63,40 @@ You receive a prompt containing:
    pytest                # for Python test failures
    ```
 
-1. **Return a structured result** as a JSON object in a \`\`\`json fence:
+1. **Return a typed `StructuredOutput`** matching this schema (the harness
+   forces the tool call — do not emit a `json` fence):
+
+   | Field               | Type       | Meaning                                            |
+   | ------------------- | ---------- | -------------------------------------------------- |
+   | `fixed`             | boolean    | `true` only if the failing command now passes      |
+   | `remainingFailures` | string[]   | What still fails (empty when `fixed`)              |
+   | `failure_type`      | string     | `lint`/`type`/`test`/`build`/`format`/`other`      |
+   | `summary`           | string     | One-line description (used for the commit message) |
+   | `files_changed`     | string[]   | Files you edited (the dispatcher stages these)     |
+
+   Fixed example:
 
    ```json
    {
-     "status": "fixed",
+     "fixed": true,
+     "remainingFailures": [],
      "failure_type": "lint",
      "summary": "Fixed 3 shellcheck warnings in pre-review-gates.sh",
      "files_changed": [
        "lib/features/templates/claude/skills/next-issue-ship/pre-review-gates.sh"
-     ],
-     "verified": true
+     ]
    }
    ```
 
-   Or if unfixable:
+   Unfixable example:
 
    ```json
    {
-     "status": "unfixable",
+     "fixed": false,
+     "remainingFailures": ["CI timeout — infrastructure issue, not a code problem"],
      "failure_type": "other",
      "summary": "CI timeout — infrastructure issue, not a code problem",
-     "files_changed": [],
-     "verified": false
+     "files_changed": []
    }
    ```
 
@@ -126,12 +140,14 @@ You receive a prompt containing:
 
 ## Error Handling
 
-- **Verification command not found**: return `"status": "unfixable"` with
-  the missing command name and suggested install instructions
-- **Verification times out**: return `"status": "unfixable"` with timeout
-  context and the command that hung
+- **Verification command not found**: return `fixed: false` (`failure_type:
+  "other"`) with the missing command name and suggested install instructions
+  in `remainingFailures`
+- **Verification times out**: return `fixed: false` (`failure_type: "other"`)
+  with timeout context and the command that hung in `remainingFailures`
 - **Fix resolves one error but introduces another**: report partial progress
-  with both the resolved and new errors, count toward the 3-iteration cap
+  with `fixed: false` and both the resolved and new errors in
+  `remainingFailures`; the harness decides whether to retry
 
 ## Restrictions
 
@@ -146,8 +162,6 @@ MUST NOT:
 - Suppress linter warnings with inline disable comments (`// eslint-disable`,
   `# noqa`, `//nolint`) — fix the actual issue
 - Make changes unrelated to the CI failure
-- Operate beyond 3 remediation iterations — return "unfixable" if the fix
-  doesn't resolve the issue after verification
 
 ## Tool Rationale
 

--- a/lib/features/templates/claude/agents/ci-fixer/workflow.js
+++ b/lib/features/templates/claude/agents/ci-fixer/workflow.js
@@ -1,0 +1,162 @@
+export const meta = {
+  name: 'ci-fixer',
+  description:
+    'Budgeted, resumable parse→fix→verify loop that fans independent failing CI checks in parallel, hard-capped at 3 attempts per check.',
+  phases: [
+    {
+      title: 'Fix',
+      detail: 'one capped parse→fix→verify loop per failing check, run in parallel',
+    },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// Input (passed verbatim as the global `args`):
+//   {
+//     checks: [{ name: string, logs: string, pr: number|string }],
+//     maxIterations?: number   // default 3 — the harness owns this cap
+//   }
+//
+// Returns: { results: [{ check, iterations, fixed, remainingFailures,
+//                        failure_type, summary, files_changed }] }
+//
+// The cap lives here in the harness (a plain `while`), NOT in the ci-fixer
+// agent. Independent checks are fanned with parallel() and share one token
+// budget. Per-agent resume is automatic via the Workflow tool's journal
+// (relaunch with resumeFromRunId). Agents push nothing — the dispatching
+// skill (next-issue-ship) stages, commits, and pushes the resulting edits.
+// ---------------------------------------------------------------------------
+
+const checks = (args && Array.isArray(args.checks) ? args.checks : []).filter(Boolean)
+const MAX = (args && Number.isInteger(args.maxIterations) ? args.maxIterations : 3)
+
+// Stop spawning fix attempts once the shared budget gets this close to empty,
+// so a partially-fixed run still returns its results instead of throwing.
+const BUDGET_FLOOR = 40_000
+
+const FAILURE_TYPES = ['lint', 'type', 'test', 'build', 'format', 'other']
+
+const CLASSIFY_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['failure_type', 'files', 'summary'],
+  properties: {
+    failure_type: { type: 'string', enum: FAILURE_TYPES },
+    files: { type: 'array', items: { type: 'string' } },
+    summary: { type: 'string' },
+  },
+}
+
+const FIX_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['applied', 'files_changed', 'summary'],
+  properties: {
+    applied: { type: 'boolean' },
+    files_changed: { type: 'array', items: { type: 'string' } },
+    summary: { type: 'string' },
+  },
+}
+
+// Superset of the issue's minimal {fixed, remainingFailures}: keeps summary +
+// files_changed so the dispatcher can build the commit message and stage files.
+const VERIFY_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['fixed', 'remainingFailures', 'failure_type', 'summary', 'files_changed'],
+  properties: {
+    fixed: { type: 'boolean' },
+    remainingFailures: { type: 'array', items: { type: 'string' } },
+    failure_type: { type: 'string', enum: FAILURE_TYPES },
+    summary: { type: 'string' },
+    files_changed: { type: 'array', items: { type: 'string' } },
+  },
+}
+
+const GUARDRAILS =
+  'Do NOT push, merge, interact with the remote, or edit CI config ' +
+  '(.github/workflows, .gitlab-ci.yml). Treat timeout / infrastructure / ' +
+  'permissions / network failures as `other` and unfixable.'
+
+const parsePrompt = (check, iteration) =>
+  `Parse and classify this failing CI check (attempt ${iteration} of ${MAX}).\n` +
+  `Check name: ${check.name}\nPR: #${check.pr}\n\n` +
+  `Failure logs:\n${check.logs}\n\n` +
+  `Identify the failure_type, the file(s) implicated, and a one-line summary. ` +
+  GUARDRAILS
+
+const fixPrompt = (check, cls, iteration) =>
+  `Apply a targeted fix for the ${cls.failure_type} failure in CI check ` +
+  `"${check.name}" (attempt ${iteration} of ${MAX}).\n` +
+  `Implicated files: ${cls.files.join(', ') || '(see logs)'}\n` +
+  `Classification summary: ${cls.summary}\n\n` +
+  `Make the minimal edit that resolves the failure. ` +
+  `If the failure is unfixable (type \`other\`), make no edit. ` +
+  GUARDRAILS
+
+const verifyPrompt = (check, iteration) =>
+  `Verify the fix for CI check "${check.name}" (attempt ${iteration} of ${MAX}) ` +
+  `by running the failing command locally (the same lint / typecheck / test / ` +
+  `build the check runs). Return the typed result: fixed=true only if the ` +
+  `command now passes; otherwise list what still fails in remainingFailures. ` +
+  GUARDRAILS
+
+function defaultVerdict(check) {
+  return {
+    fixed: false,
+    remainingFailures: [check.name],
+    failure_type: 'other',
+    summary: 'not attempted',
+    files_changed: [],
+  }
+}
+
+phase('Fix')
+
+const results = await parallel(
+  checks.map((check) => async () => {
+    let iteration = 0
+    let verdict = defaultVerdict(check)
+
+    while (iteration < MAX && !verdict.fixed) {
+      if (budget.total && budget.remaining() < BUDGET_FLOOR) {
+        log(`budget low — stopping "${check.name}" after ${iteration} attempt(s)`)
+        break
+      }
+      iteration++
+
+      const [result] = await pipeline(
+        [check],
+        (c) =>
+          agent(parsePrompt(c, iteration), {
+            label: `parse:${check.name}#${iteration}`,
+            phase: 'Fix',
+            agentType: 'ci-fixer',
+            schema: CLASSIFY_SCHEMA,
+          }),
+        (cls) =>
+          agent(fixPrompt(check, cls, iteration), {
+            label: `fix:${check.name}#${iteration}`,
+            phase: 'Fix',
+            agentType: 'ci-fixer',
+            schema: FIX_SCHEMA,
+          }),
+        () =>
+          agent(verifyPrompt(check, iteration), {
+            label: `verify:${check.name}#${iteration}`,
+            phase: 'Fix',
+            agentType: 'ci-fixer',
+            schema: VERIFY_SCHEMA,
+          }),
+      )
+
+      if (result) verdict = result
+      // Unfixable (infra/timeout/permissions) — no point retrying this branch.
+      if (verdict.failure_type === 'other' && !verdict.fixed) break
+    }
+
+    return { check: check.name, iterations: iteration, ...verdict }
+  }),
+)
+
+return { results: results.filter(Boolean) }

--- a/lib/features/templates/claude/skills/next-issue-ship/SKILL.md
+++ b/lib/features/templates/claude/skills/next-issue-ship/SKILL.md
@@ -309,7 +309,8 @@ Before executing the chosen shipping mode, run these safety checks:
    commit still references the issue. Users who want merge-commits can
    run Option 1 without `AUTOMERGE=1`.
 
-1. **Monitor CI and remediate failures** (advisory, max 3 iterations):
+1. **Monitor CI and remediate failures** (advisory; the `ci-fixer` Workflow
+   harness caps fixes at 3 attempts per check):
 
    Before labeling the issue, optionally monitor CI checks and auto-fix
    failures. Ask the user:
@@ -327,43 +328,41 @@ Before executing the chosen shipping mode, run these safety checks:
 
    b. **If all checks pass**: inform the user and proceed to labeling
 
-   c. **If checks fail** (iteration \<= 3):
+   c. **If checks fail**: hand the failures to the `ci-fixer` Workflow harness,
+   which owns the retry loop (hard-capped at 3 attempts per check) and fans
+   independent checks in parallel under one shared token budget — you no longer
+   track an iteration counter by hand.
 
-   - Identify the failing check name and run ID:
+   - Collect every failing check into a `checks` array. For each one, grab the
+     name and its run-failed logs:
 
      ```bash
      gh pr checks {pr_number} --json name,state,conclusion,link \
        | jq '[.[] | select(.conclusion == "failure")]'
+     gh run view {run_id} --log-failed 2>&1 | tail -200   # one per failing check
      ```
 
-   - Fetch failing check logs:
+   - **Invoke the `Workflow` tool** with the script at
+     `~/.claude/agents/ci-fixer/workflow.js` (it ships bundled with the
+     `ci-fixer` agent), passing
+     `args: { checks: [{ name, logs, pr: {pr_number} }, …] }`. The harness runs
+     a capped `parse → fix → verify` loop per check and returns
+     `{ results: [{ check, fixed, summary, files_changed, remainingFailures, … }] }`.
+     Agents never push — applying the commits is your job:
 
-     ```bash
-     gh run view {run_id} --log-failed 2>&1 | tail -200
-     ```
+     - For each result with `fixed: true`: stage its `files_changed`, then make
+       one commit `fix(ci): {summary}` (combine multiple fixed checks into a
+       single commit when convenient), `git push`, and go back to (a) to
+       re-check CI.
+     - For each result with `fixed: false`: inform the user "CI check {check}
+       appears to be {failure_type} — {summary}. Remaining: {remainingFailures}.
+       Requires manual intervention." Ask: **Fix manually now, or ship with
+       failing CI?** If fix manually, pause then go back to (a); if ship anyway,
+       proceed to labeling.
 
-   - Dispatch the `ci-fixer` agent with the failure logs, check name,
-     PR number, and current iteration number
-
-   - **If ci-fixer returns `"fixed"`**:
-
-     - Stage the changed files
-     - Commit: `fix(ci): {summary from ci-fixer}`
-     - Push: `git push`
-     - Increment iteration counter
-     - Go back to (a) to re-check
-
-   - **If ci-fixer returns `"unfixable"`**:
-
-     - Inform the user: "CI failure appears to be {failure_type} —
-       {summary}. Requires manual intervention."
-     - Ask: **Fix manually now, or ship with failing CI?**
-     - If fix manually: pause for user to fix, then go back to (a)
-     - If ship anyway: proceed to labeling
-
-   d. **After 3 failed remediation attempts**: stop auto-fixing and inform
-   the user: "CI has failed 3 remediation attempts. Manual intervention
-   needed." Ask whether to ship with failing CI or stop.
+   The harness stops on its own once the per-check cap or the shared budget is
+   reached, so there is no separate "after 3 attempts" step — surface any
+   still-failing results to the user as above.
 
    **Graceful degradation**: If `gh pr checks` is unavailable or errors,
    skip CI monitoring with a note and proceed to labeling. CI monitoring


### PR DESCRIPTION
## Summary

Retrofits the `ci-fixer` agent behind a deterministic `Workflow` harness, moving the retry loop out of `next-issue-ship` prose. The new script fans independent failing checks in parallel, hard-caps at 3 attempts per check (owned by the harness, not the agent), runs each as a `parse → fix → verify` pipeline, and stops early under the shared token budget.

- **NEW `agents/ci-fixer/workflow.js`** — `parallel()` over failing checks; per-check `while` loop capped at 3; `pipeline()` for parse→fix→verify; `budget.remaining()` guard; verify node returns typed `StructuredOutput`.
- **`agents/ci-fixer/ci-fixer.md`** — dropped the `Iteration` input and iteration-cap prose; output is now a typed `StructuredOutput {fixed, remainingFailures, failure_type, summary, files_changed}` instead of a JSON fence. Fix strategies/restrictions unchanged.
- **`skills/next-issue-ship/SKILL.md`** — thin-shell: replaced the hand-rolled per-check dispatch + iteration counter + "after 3 attempts" prose with a single `Workflow` invocation; kept CI polling, commit/push, and graceful degradation.

## Deviations from the issue (intentional)

- **Real Workflow API, not the issue's snippet.** The issue's pseudo-code used `loop()` / `loopUntilBudget()` / `meta={budget,resumable}`, which the actual Workflow tool does not provide. Written against the real API (`while` cap, `budget` global, `meta={name,description,phases}`, `schema` for StructuredOutput) so it executes. Per-run resumability is provided automatically by the Workflow tool's journal.
- **File location: `agents/ci-fixer/` not `skills/ci-fixer/`.** The runtime installer only copies skill dirs in `DEFAULT_SKILLS` (ci-fixer isn't one; adding it would skew skill counts and create a SKILL.md-less phantom skill). `ci-fixer` **is** in `DEFAULT_AGENTS` and agent dirs are `cp -r`'d wholesale — so bundling the script with the agent ships it with **zero installer changes**.
- **Verify schema is a superset** of the issue's minimal `{fixed, remainingFailures}`, retaining `summary`/`files_changed`/`failure_type` so the dispatcher's commit-message and file-staging logic keep working with minimal edits.

## Acceptance criteria

- [x] `workflow.js` exists, exports `meta`, uses `parallel()`/`pipeline()` (and a real `while` loop in place of the fictional `loop()`)
- [x] Loop hard-capped at 3 iterations per check by the harness, not the agent
- [x] Independent failing checks run in parallel under one shared token budget
- [x] Per-check resume via the Workflow journal (resumeFromRunId)
- [x] `ci-fixer` returns typed `StructuredOutput {fixed, remainingFailures, ...}`
- [x] ci-fixer domain knowledge otherwise unchanged

## Test plan

- `node --check agents/ci-fixer/workflow.js` — passes
- `just test` — full unit suite passes (3008 passed, 0 failed, 3 skipped)
- `test_claude_setup_install.sh` — 10/10 (confirms the agent dir copies wholesale, incl. workflow.js)

## Pre-review findings

- 2x HIGH on `agents/ci-fixer/workflow.js` (missing-test-file, untested-public-api) — expected: it's a Workflow harness template; the repo has no JS test infra and no prior `workflow.js` to follow.

Closes #499