### PR TITLE
fix(luggage): add rust@1.96.0 to vendored catalog

### DIFF
--- a/crates/luggage/testdata/catalog/tools/rust/index.json
+++ b/crates/luggage/testdata/catalog/tools/rust/index.json
@@ -22,6 +22,7 @@
   "available": [
     { "version": "1.84.0" },
     { "version": "1.84.1" },
-    { "version": "1.95.0" }
+    { "version": "1.95.0" },
+    { "version": "1.96.0" }
   ]
 }

--- a/crates/luggage/testdata/catalog/tools/rust/versions/1.96.0.json
+++ b/crates/luggage/testdata/catalog/tools/rust/versions/1.96.0.json
@@ -1,0 +1,75 @@
+{
+  "schemaVersion": 1,
+  "tool": "rust",
+  "version": "1.96.0",
+  "released": "2026-05-28",
+  "channel": "stable",
+  "support_matrix": [
+    { "os": "debian", "os_version": "13", "arch": "amd64", "status": "supported" },
+    { "os": "debian", "os_version": "13", "arch": "arm64", "status": "supported" },
+    { "os": "ubuntu", "os_version": "24.04", "arch": "amd64", "status": "supported" },
+    { "os": "alpine", "os_version": "3.21", "arch": "amd64", "status": "supported" },
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "status": "unsupported",
+      "reason": "no upstream rustup target for this glibc-only build path",
+      "tracking_url": "https://example.test/rust-windows"
+    }
+  ],
+  "tested": [],
+  "install_methods": [
+    {
+      "name": "rustup-init",
+      "platform": {
+        "os": ["debian", "ubuntu", "rhel"],
+        "arch": ["amd64", "arm64"]
+      },
+      "verification": {
+        "tier": 3,
+        "algorithm": "sha256",
+        "checksum_url_template": "https://static.rust-lang.org/rustup/dist/{rustup_target}/rustup-init.sha256"
+      },
+      "source_url_template": "https://static.rust-lang.org/rustup/dist/{rustup_target}/rustup-init",
+      "invoke": {
+        "args": ["-y", "--default-toolchain", "1.96.0", "--profile", "default"]
+      },
+      "post_install": [
+        { "kind": "component_add", "component": "rust-src" },
+        { "kind": "component_add", "component": "rust-analyzer" },
+        { "kind": "component_add", "component": "clippy" },
+        { "kind": "component_add", "component": "rustfmt" }
+      ],
+      "dependencies": [
+        { "tool": "ca_certificates" },
+        { "tool": "gcc" },
+        { "tool": "libc_dev" }
+      ]
+    },
+    {
+      "name": "rustup-init-musl",
+      "platform": {
+        "os": "alpine",
+        "arch": ["amd64", "arm64"]
+      },
+      "verification": {
+        "tier": 3,
+        "algorithm": "sha256",
+        "checksum_url_template": "https://static.rust-lang.org/rustup/dist/{rustup_target}/rustup-init.sha256"
+      },
+      "source_url_template": "https://static.rust-lang.org/rustup/dist/{rustup_target}/rustup-init",
+      "invoke": {
+        "args": ["-y", "--default-toolchain", "1.96.0", "--profile", "default"]
+      },
+      "dependencies": [
+        { "tool": "ca_certificates" },
+        { "tool": "gcc" },
+        { "tool": "musl_dev" }
+      ]
+    }
+  ],
+  "metadata": {
+    "added_at": "2026-05-31T00:00:00Z",
+    "schema_version": 1
+  }
+}


### PR DESCRIPTION
## Summary

Unblocks the nightly auto-patch image build, which failed on `auto-patch/20260531-030656`.

The auto-patch bumped `RUST_VERSION` 1.95.0 → 1.96.0, but the image build installs the Rust toolchain via `luggage install rust@1.96.0` against the **vendored catalog snapshot** (`crates/luggage/testdata/catalog`, `COPY`'d to `/opt/containers-db` at `Dockerfile:152`). That snapshot topped out at 1.95.0, so the build failed:

```
error: no version of `rust` matches spec `1.96.0`
✗ luggage install rust@1.96.0 failed (Dockerfile:208, rust-golang image)
```

(All tests + Debian-compat jobs passed; only the Merge-Tier `rust-golang` build leg failed, the rest were fail-fast cancelled.)

## Changes

- **`crates/luggage/testdata/catalog/tools/rust/versions/1.96.0.json`** — new entry mirroring 1.95.0 (rustup-init + rustup-init-musl methods, identical support matrix and post-install components, `--default-toolchain 1.96.0`).
- **`crates/luggage/testdata/catalog/tools/rust/index.json`** — list `1.96.0` in `available`.

Purely additive — `default_version` stays `1.95.0`, so the `cli.rs` default-resolution golden tests are unaffected.

## Verification

- `cargo test -p luggage` → all pass (incl. the `cli.rs` default-version golden tests)
- `luggage install rust@1.96.0 --catalog crates/luggage/testdata/catalog --dry-run` → resolves a complete install plan (previously errored)

## Related / follow-up

- **containers-db#19** adds the same entry to the real sibling catalog (kept in lockstep).
- **Root cause:** `check-versions.sh` tracks Rust from upstream GitHub releases and has no awareness of the luggage catalog, so the pin can outrun the snapshot. Worth a tracking issue to make `check-versions` catalog-aware (or have it add the catalog entry when it bumps a luggage-installed tool).
- The failing `auto-patch/20260531-030656` build won't self-heal; once this lands on `main` the auto-patch branch needs to be re-driven (or superseded by next Sunday's run, which will regenerate against the fixed catalog).