### PR TITLE
feat(luggage): catalog-aware version bump via `catalog add-version` (#506 Phase 1)

### DIFF
--- a/.github/workflows/auto-patch.yml
+++ b/.github/workflows/auto-patch.yml
@@ -80,6 +80,14 @@ jobs:
             echo "has_updates=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # update-versions.sh calls `luggage catalog add-version` for
+      # luggage-installed tools (e.g. Rust) to keep the vendored catalog in
+      # lockstep with the Dockerfile pin (issue #506). Build the binary first
+      # so the updater can find it at target/release/luggage.
+      - name: Build luggage (for catalog updates)
+        if: steps.check.outputs.has_updates == 'true'
+        run: cargo build --release -p luggage --bin luggage
+
       - name: Create auto-patch branch and apply updates
         if: steps.check.outputs.has_updates == 'true'
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1646,6 +1646,7 @@ dependencies = [
  "shell-words",
  "tempfile",
  "thiserror 2.0.18",
+ "time",
  "tracing",
  "tracing-subscriber",
  "ureq",

--- a/bin/lib/update-versions/updaters.sh
+++ b/bin/lib/update-versions/updaters.sh
@@ -21,6 +21,43 @@ sed_inplace() {
     done
 }
 
+# Add a bumped luggage-installed tool's new version to the vendored catalog
+# snapshot (crates/luggage/testdata/catalog), which the image build COPYs to
+# /opt/containers-db and resolves `luggage install <tool>@<version>` against.
+# Without this, a Dockerfile pin can outrun the catalog and the build fails
+# with "no version of <tool> matches spec <version>" (see issue #506).
+#
+# The `luggage catalog add-version` subcommand is additive and idempotent, so a
+# re-run for an already-present version is a no-op. A missing luggage binary is
+# a hard error rather than a silent skip: skipping would let the pin and the
+# catalog drift, breaking the build the change is meant to keep green.
+# Usage: update_luggage_catalog <tool> <version>
+update_luggage_catalog() {
+    local tool="$1"
+    local version="$2"
+    local catalog="$PROJECT_ROOT/crates/luggage/testdata/catalog"
+
+    local luggage_bin="${LUGGAGE_BIN:-}"
+    if [ -z "$luggage_bin" ]; then
+        if [ -x "$PROJECT_ROOT/target/release/luggage" ]; then
+            luggage_bin="$PROJECT_ROOT/target/release/luggage"
+        elif [ -x "$PROJECT_ROOT/target/debug/luggage" ]; then
+            luggage_bin="$PROJECT_ROOT/target/debug/luggage"
+        else
+            luggage_bin="$(command -v luggage 2>/dev/null || true)"
+        fi
+    fi
+
+    if [ -z "$luggage_bin" ]; then
+        echo -e "${RED}    ERROR: luggage binary not found; cannot update vendored catalog for ${tool}@${version}${NC}" >&2
+        echo -e "${YELLOW}    Build it first (cargo build --release -p luggage) or set LUGGAGE_BIN.${NC}" >&2
+        return 1
+    fi
+
+    echo -e "${BLUE}    Updating vendored luggage catalog: ${tool}@${version}${NC}"
+    "$luggage_bin" catalog add-version "${tool}@${version}" --catalog "$catalog"
+}
+
 # Function to update a version in a file
 update_version() {
     local tool="$1"
@@ -72,6 +109,10 @@ update_version() {
                     sed_inplace "s/^ARG RUST_VERSION=.*/ARG RUST_VERSION=$latest/" "$PROJECT_ROOT/Dockerfile"
                     # Also update the fallback default in rust.sh
                     sed_inplace "s/RUST_VERSION=\"\${RUST_VERSION:-[^}]*}\"/RUST_VERSION=\"\${RUST_VERSION:-$latest}\"/" "$PROJECT_ROOT/lib/features/rust.sh"
+                    # Rust installs via luggage — keep the vendored catalog in
+                    # lockstep with the pin (issue #506). Future luggage-managed
+                    # tools add the same one-liner to their case.
+                    update_luggage_catalog "rust" "$latest"
                     ;;
                 Ruby)
                     sed_inplace "s/^ARG RUBY_VERSION=.*/ARG RUBY_VERSION=$latest/" "$PROJECT_ROOT/Dockerfile"

--- a/crates/luggage/Cargo.toml
+++ b/crates/luggage/Cargo.toml
@@ -20,6 +20,7 @@ sha2 = { workspace = true }
 shell-words = "1"
 tempfile = { workspace = true }
 thiserror = { workspace = true }
+time = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 ureq = { version = "2", default-features = false, features = ["tls"] }

--- a/crates/luggage/src/bin/luggage.rs
+++ b/crates/luggage/src/bin/luggage.rs
@@ -22,9 +22,12 @@ use std::process::ExitCode;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use containers_common::tooldb::ActivityScore;
 use luggage::{
-    Catalog, CatalogSource, InstallReport, Installer, InstallerOptions, LuggageError, Platform,
-    PolicyPreset, ResolutionPolicy, ResolutionWarning, ResolvedInstall, VersionSpec,
+    AddOutcome, Catalog, CatalogSource, InstallReport, Installer, InstallerOptions, LuggageError,
+    Platform, PolicyPreset, ResolutionPolicy, ResolutionWarning, ResolvedInstall, VersionSpec,
+    add_version,
 };
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
 
 /// Luggage — catalog loader and version/platform resolver.
 #[derive(Parser, Debug)]
@@ -44,6 +47,36 @@ enum Commands {
     Resolve(ResolveArgs),
     /// Install a tool — download, verify, run installer, validate.
     Install(InstallArgs),
+    /// Catalog maintenance (write-side helpers for the vendored catalog).
+    Catalog {
+        #[command(subcommand)]
+        command: CatalogCommand,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum CatalogCommand {
+    /// Add a tool version by cloning the latest existing version entry.
+    ///
+    /// Used by the version-bump pipeline to keep the vendored catalog in
+    /// lockstep with a Dockerfile pin. Additive and idempotent: a version
+    /// already present is a no-op, and `default_version` is never changed.
+    AddVersion(CatalogAddVersionArgs),
+}
+
+/// `luggage catalog add-version <tool>@<version>` arguments.
+#[derive(Args, Debug)]
+struct CatalogAddVersionArgs {
+    /// Catalog tool id with a required `@<version>` suffix (e.g. `rust@1.96.0`).
+    tool: String,
+
+    /// Path to the catalog root (or `CONTAINERS_DB` env var).
+    #[arg(long, env = "CONTAINERS_DB", default_value = "../containers-db")]
+    catalog: PathBuf,
+
+    /// Upstream release date `YYYY-MM-DD` (defaults to today, UTC).
+    #[arg(long)]
+    released: Option<String>,
 }
 
 #[derive(Args, Debug)]
@@ -201,7 +234,45 @@ fn main() -> ExitCode {
                 ExitCode::from(u8::try_from(e.exit_code()).unwrap_or(1))
             }
         },
+        Commands::Catalog { command } => {
+            let CatalogCommand::AddVersion(args) = command;
+            match cmd_catalog_add_version(&args) {
+                Ok(()) => ExitCode::SUCCESS,
+                Err(e) => {
+                    report_error(&e);
+                    ExitCode::from(u8::try_from(e.exit_code()).unwrap_or(1))
+                }
+            }
+        }
     }
+}
+
+/// `luggage catalog add-version <tool>@<version>` — clone the latest existing
+/// version entry into a new one and list it in `available[]`.
+fn cmd_catalog_add_version(args: &CatalogAddVersionArgs) -> Result<(), LuggageError> {
+    let (tool, inline_version) = split_tool_version(&args.tool);
+    let version = inline_version.ok_or_else(|| {
+        LuggageError::Catalog("specify the version as `tool@version` (e.g. `rust@1.96.0`)".into())
+    })?;
+
+    let now = OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .map_err(|e| LuggageError::Catalog(format!("could not format current time: {e}")))?;
+
+    match add_version(&args.catalog, tool, version, args.released.as_deref(), &now)? {
+        AddOutcome::AlreadyPresent => {
+            println!(
+                "{tool}@{version} already present in {}; nothing to do",
+                args.catalog.display()
+            );
+        }
+        AddOutcome::Added { template_version, version_path, index_path } => {
+            println!("added {tool}@{version} (templated from {tool}@{template_version})");
+            println!("  wrote   {}", version_path.display());
+            println!("  updated {}", index_path.display());
+        }
+    }
+    Ok(())
 }
 
 fn cmd_resolve(args: &ResolveArgs) -> Result<(), LuggageError> {

--- a/crates/luggage/src/catalog_gen.rs
+++ b/crates/luggage/src/catalog_gen.rs
@@ -1,0 +1,367 @@
+//! Generate new `versions/<v>.json` entries in a vendored luggage catalog
+//! by cloning a tool's most recent existing version file.
+//!
+//! This is the write-side counterpart to [`crate::catalog`]'s read path. It
+//! exists so the version-bump pipeline can keep the vendored catalog snapshot
+//! (`crates/luggage/testdata/catalog`, COPY'd into the image at build time) in
+//! lockstep with a Dockerfile pin: when the auto-patch bumps a luggage-managed
+//! tool, it calls `luggage catalog add-version <tool>@<version>` so the build's
+//! `luggage install` can resolve the new pin instead of failing with
+//! "no version of `<tool>` matches spec `<version>`".
+//!
+//! Approach mirrors the containers-db scanner (`scanner/src/generate.rs`):
+//! deep-clone the latest existing version file, swap the top-level
+//! `version` / `released` / `metadata` fields, then walk the rest of the JSON
+//! and replace any remaining whole-string occurrence of the old version (this
+//! catches `install_methods[].invoke.args[N]`, where rust hard-codes the
+//! toolchain version in the rustup invocation). The change is deliberately
+//! **additive**: `default_version` and `activity` in `index.json` are left
+//! untouched so existing default-resolution behaviour (and its golden tests)
+//! is unaffected.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use containers_common::version::{Version, VersionStyle};
+use serde_json::{Value, json};
+
+use crate::error::{LuggageError, Result};
+
+/// Outcome of [`add_version`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum AddOutcome {
+    /// The version was already in the catalog (version file exists or the id
+    /// is already listed in `available[]`); nothing was written. Idempotent
+    /// re-runs land here.
+    AlreadyPresent,
+    /// A new version file was written and `index.json` updated.
+    Added {
+        /// Version whose file was used as the render template.
+        template_version: String,
+        /// Path of the version file written.
+        version_path: PathBuf,
+        /// Path of the index that was updated.
+        index_path: PathBuf,
+    },
+}
+
+/// Add `version` for `tool` to the catalog rooted at `catalog`, cloning the
+/// latest existing version entry as a template.
+///
+/// `released` is the upstream release date (`YYYY-MM-DD`); when `None` it
+/// defaults to the date portion of `now_rfc3339`. `now_rfc3339` stamps
+/// `metadata.{added_at,updated_at}` — passed in (rather than read from the
+/// clock) so the generation is deterministic and unit-testable.
+///
+/// # Errors
+///
+/// Returns [`LuggageError::Catalog`] when the tool directory has no existing
+/// version file to template from, and [`LuggageError::Io`] /
+/// [`LuggageError::Parse`] on filesystem or JSON failures.
+pub fn add_version(
+    catalog: &Path,
+    tool: &str,
+    version: &str,
+    released: Option<&str>,
+    now_rfc3339: &str,
+) -> Result<AddOutcome> {
+    let tool_dir = catalog.join("tools").join(tool);
+    let versions_dir = tool_dir.join("versions");
+    let index_path = tool_dir.join("index.json");
+    let version_path = versions_dir.join(format!("{version}.json"));
+
+    let mut index = read_json(&index_path)?;
+
+    // Idempotent: a re-run for a version we already carry is a no-op. Guard on
+    // both the on-disk file and the index listing so a partial prior run still
+    // converges.
+    if version_path.exists() || index_listed(&index, version) {
+        return Ok(AddOutcome::AlreadyPresent);
+    }
+
+    let template_version = latest_existing_version(&versions_dir)?.ok_or_else(|| {
+        LuggageError::Catalog(format!(
+            "tool `{tool}` has no existing version file under {} to use as a template",
+            versions_dir.display()
+        ))
+    })?;
+    let template = read_json(&versions_dir.join(format!("{template_version}.json")))?;
+
+    let released = released.unwrap_or_else(|| date_part(now_rfc3339));
+    let new_version =
+        render_new_version(&template, &template_version, version, released, now_rfc3339);
+
+    write_json(&version_path, &new_version)?;
+    add_version_to_index(&mut index, version);
+    write_json(&index_path, &index)?;
+
+    Ok(AddOutcome::Added { template_version, version_path, index_path })
+}
+
+/// Build a new version-file [`Value`] from `template` (the latest existing
+/// version file for the same tool) and the version being added.
+#[must_use]
+pub fn render_new_version(
+    template: &Value,
+    old_version: &str,
+    new_version: &str,
+    released: &str,
+    now_rfc3339: &str,
+) -> Value {
+    let mut out = template.clone();
+
+    if let Some(obj) = out.as_object_mut() {
+        obj.insert("version".into(), Value::String(new_version.to_owned()));
+        obj.insert("released".into(), Value::String(released.to_owned()));
+        let metadata = obj.entry("metadata").or_insert_with(|| json!({}));
+        if let Some(m) = metadata.as_object_mut() {
+            m.insert("added_at".into(), Value::String(now_rfc3339.to_owned()));
+            m.insert("updated_at".into(), Value::String(now_rfc3339.to_owned()));
+            m.entry("schema_version").or_insert_with(|| json!(1));
+        }
+    }
+
+    // Catch literal version strings buried elsewhere (e.g. the rustup
+    // `--default-toolchain <v>` arg). Whole-string match only, so version-shaped
+    // substrings inside URL templates or prose are left alone.
+    rewrite_string_matches(&mut out, old_version, new_version);
+    out
+}
+
+/// Append `{ "version": new_version }` to the index `available[]` array when
+/// absent. Leaves `default_version` and `activity` untouched (additive only).
+pub fn add_version_to_index(index: &mut Value, new_version: &str) {
+    let Some(obj) = index.as_object_mut() else {
+        return;
+    };
+    let available = obj.entry("available").or_insert_with(|| json!([])).as_array_mut();
+    let Some(available) = available else {
+        return;
+    };
+    if !available.iter().any(|e| e.get("version").and_then(Value::as_str) == Some(new_version)) {
+        available.push(json!({ "version": new_version }));
+    }
+}
+
+/// Highest semver among the `<v>.json` basenames in `versions_dir`, returned
+/// as the original basename string. Non-semver filenames are skipped.
+///
+/// # Errors
+///
+/// Returns [`LuggageError::Io`] if the directory cannot be read.
+pub fn latest_existing_version(versions_dir: &Path) -> Result<Option<String>> {
+    let entries = fs::read_dir(versions_dir)
+        .map_err(|source| LuggageError::Io { path: versions_dir.to_path_buf(), source })?;
+
+    let mut best: Option<(Version, String)> = None;
+    for entry in entries {
+        let entry = entry
+            .map_err(|source| LuggageError::Io { path: versions_dir.to_path_buf(), source })?;
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        let Some(stem) = name.strip_suffix(".json") else { continue };
+        let Ok(parsed) = Version::parse(stem, VersionStyle::Semver) else { continue };
+        if best.as_ref().is_none_or(|(b, _)| parsed > *b) {
+            best = Some((parsed, stem.to_owned()));
+        }
+    }
+    Ok(best.map(|(_, s)| s))
+}
+
+/// True when `version` already appears in the index `available[]` array.
+fn index_listed(index: &Value, version: &str) -> bool {
+    index.get("available").and_then(Value::as_array).is_some_and(|arr| {
+        arr.iter().any(|e| e.get("version").and_then(Value::as_str) == Some(version))
+    })
+}
+
+/// Date portion (`YYYY-MM-DD`) of an RFC3339 timestamp, or the whole string if
+/// there is no `T` separator.
+fn date_part(rfc3339: &str) -> &str {
+    rfc3339.split_once('T').map_or(rfc3339, |(d, _)| d)
+}
+
+/// Walk every string in `value`, replacing whole-string matches of `from`
+/// with `to`. Substring matches are ignored on purpose.
+fn rewrite_string_matches(value: &mut Value, from: &str, to: &str) {
+    match value {
+        Value::String(s) if s == from => to.clone_into(s),
+        Value::Array(arr) => {
+            for v in arr.iter_mut() {
+                rewrite_string_matches(v, from, to);
+            }
+        }
+        Value::Object(map) => {
+            for v in map.values_mut() {
+                rewrite_string_matches(v, from, to);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn read_json(path: &Path) -> Result<Value> {
+    let bytes =
+        fs::read(path).map_err(|source| LuggageError::Io { path: path.to_path_buf(), source })?;
+    serde_json::from_slice(&bytes)
+        .map_err(|source| LuggageError::Parse { path: path.to_path_buf(), source })
+}
+
+/// Write `value` as pretty JSON with a trailing newline. Formatting is
+/// normalized downstream by the auto-patch dprint step; here we only need
+/// valid, stable JSON.
+fn write_json(path: &Path, value: &Value) -> Result<()> {
+    let mut out = serde_json::to_string_pretty(value)
+        .map_err(|source| LuggageError::Parse { path: path.to_path_buf(), source })?;
+    out.push('\n');
+    fs::write(path, out).map_err(|source| LuggageError::Io { path: path.to_path_buf(), source })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn template() -> Value {
+        json!({
+            "schemaVersion": 1,
+            "tool": "rust",
+            "version": "1.95.0",
+            "released": "2026-04-16",
+            "channel": "stable",
+            "install_methods": [
+                {
+                    "name": "rustup-init",
+                    "invoke": {
+                        "args": ["-y", "--default-toolchain", "1.95.0", "--profile", "default"]
+                    }
+                }
+            ],
+            "metadata": {
+                "added_at": "2026-04-29T00:00:00Z",
+                "schema_version": 1
+            }
+        })
+    }
+
+    #[test]
+    fn render_swaps_version_released_metadata_and_invoke_args() {
+        let out = render_new_version(
+            &template(),
+            "1.95.0",
+            "1.96.0",
+            "2026-05-28",
+            "2026-05-31T00:00:00Z",
+        );
+        assert_eq!(out["version"], "1.96.0");
+        assert_eq!(out["released"], "2026-05-28");
+        assert_eq!(
+            out["install_methods"][0]["invoke"]["args"][2], "1.96.0",
+            "the rustup --default-toolchain literal must be rewritten"
+        );
+        assert_eq!(out["metadata"]["added_at"], "2026-05-31T00:00:00Z");
+        assert_eq!(out["metadata"]["updated_at"], "2026-05-31T00:00:00Z");
+        assert_eq!(out["metadata"]["schema_version"], 1);
+    }
+
+    #[test]
+    fn render_preserves_static_fields() {
+        let out = render_new_version(
+            &template(),
+            "1.95.0",
+            "1.96.0",
+            "2026-05-28",
+            "2026-05-31T00:00:00Z",
+        );
+        assert_eq!(out["schemaVersion"], 1);
+        assert_eq!(out["tool"], "rust");
+        assert_eq!(out["channel"], "stable");
+        assert_eq!(out["install_methods"][0]["name"], "rustup-init");
+    }
+
+    #[test]
+    fn rewrite_only_replaces_whole_strings() {
+        let mut v = json!({
+            "exact": "1.95.0",
+            "substr": "rust 1.95.0 build",
+            "nested": ["1.95.0", "keep"]
+        });
+        rewrite_string_matches(&mut v, "1.95.0", "1.96.0");
+        assert_eq!(v["exact"], "1.96.0");
+        assert_eq!(v["substr"], "rust 1.95.0 build", "substrings must not be rewritten");
+        assert_eq!(v["nested"][0], "1.96.0");
+        assert_eq!(v["nested"][1], "keep");
+    }
+
+    #[test]
+    fn add_to_index_appends_and_dedups_without_touching_default() {
+        let mut index = json!({
+            "default_version": "1.95.0",
+            "available": [{ "version": "1.84.0" }, { "version": "1.95.0" }]
+        });
+        add_version_to_index(&mut index, "1.96.0");
+        add_version_to_index(&mut index, "1.96.0"); // dedup
+        let versions: Vec<&str> = index["available"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v["version"].as_str().unwrap())
+            .collect();
+        assert_eq!(versions, vec!["1.84.0", "1.95.0", "1.96.0"]);
+        assert_eq!(index["default_version"], "1.95.0", "default_version must be left alone");
+    }
+
+    #[test]
+    fn date_part_extracts_calendar_date() {
+        assert_eq!(date_part("2026-05-31T12:34:56Z"), "2026-05-31");
+        assert_eq!(date_part("2026-05-31"), "2026-05-31");
+    }
+
+    #[test]
+    fn add_version_writes_file_updates_index_and_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let versions = tmp.path().join("tools/rust/versions");
+        fs::create_dir_all(&versions).unwrap();
+        write_json(&versions.join("1.95.0.json"), &template()).unwrap();
+        write_json(
+            &tmp.path().join("tools/rust/index.json"),
+            &json!({ "default_version": "1.95.0", "available": [{ "version": "1.95.0" }] }),
+        )
+        .unwrap();
+
+        let outcome =
+            add_version(tmp.path(), "rust", "1.96.0", Some("2026-05-28"), "2026-05-31T00:00:00Z")
+                .unwrap();
+        assert!(matches!(outcome, AddOutcome::Added { .. }));
+
+        let written = read_json(&versions.join("1.96.0.json")).unwrap();
+        assert_eq!(written["version"], "1.96.0");
+        assert_eq!(written["released"], "2026-05-28");
+        assert_eq!(written["install_methods"][0]["invoke"]["args"][2], "1.96.0");
+
+        let index = read_json(&tmp.path().join("tools/rust/index.json")).unwrap();
+        let listed =
+            index["available"].as_array().unwrap().iter().any(|v| v["version"] == "1.96.0");
+        assert!(listed, "new version must be listed in available[]");
+        assert_eq!(index["default_version"], "1.95.0");
+
+        // Second call is a no-op.
+        let again =
+            add_version(tmp.path(), "rust", "1.96.0", Some("2026-05-28"), "2026-05-31T00:00:00Z")
+                .unwrap();
+        assert_eq!(again, AddOutcome::AlreadyPresent);
+    }
+
+    #[test]
+    fn latest_existing_version_picks_highest_semver() {
+        let tmp = tempfile::tempdir().unwrap();
+        for v in ["1.84.0", "1.84.1", "1.95.0", "not-a-version"] {
+            let name = if v == "not-a-version" {
+                "not-a-version.txt".to_owned()
+            } else {
+                format!("{v}.json")
+            };
+            fs::write(tmp.path().join(name), "{}").unwrap();
+        }
+        assert_eq!(latest_existing_version(tmp.path()).unwrap().as_deref(), Some("1.95.0"));
+    }
+}

--- a/crates/luggage/src/lib.rs
+++ b/crates/luggage/src/lib.rs
@@ -26,6 +26,7 @@
 //! ```
 
 pub mod catalog;
+pub mod catalog_gen;
 pub mod error;
 pub mod installer;
 pub mod platform;
@@ -33,6 +34,7 @@ pub mod policy;
 pub mod resolver;
 
 pub use catalog::{Catalog, CatalogSource};
+pub use catalog_gen::{AddOutcome, add_version};
 pub use error::{ErrorClass, LuggageError, Result};
 pub use installer::{InstallPlan, InstallReport, Installer, InstallerOptions};
 pub use platform::Platform;

--- a/crates/luggage/tests/cli.rs
+++ b/crates/luggage/tests/cli.rs
@@ -261,3 +261,82 @@ fn install_resolve_time_errors_do_not_write_json_report() {
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(stderr.contains("not found"), "stderr should mention 'not found': {stderr}");
 }
+
+/// Recursively copy a directory tree (test helper — keeps the suite hermetic
+/// without shelling out to `cp`).
+fn copy_tree(src: &std::path::Path, dst: &std::path::Path) {
+    std::fs::create_dir_all(dst).expect("create dst dir");
+    for entry in std::fs::read_dir(src).expect("read src dir") {
+        let entry = entry.expect("dir entry");
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if entry.file_type().expect("file type").is_dir() {
+            copy_tree(&from, &to);
+        } else {
+            std::fs::copy(&from, &to).expect("copy file");
+        }
+    }
+}
+
+/// `catalog add-version` clones the latest version entry into a new one,
+/// lists it in `available[]`, leaves `default_version` alone, and resolves
+/// afterward — then a second run is an idempotent no-op. Operates on a temp
+/// copy so the in-tree fixture is never mutated.
+#[test]
+fn catalog_add_version_generates_resolvable_entry_and_is_idempotent() {
+    let workdir = tempdir().expect("tempdir");
+    let catalog = workdir.path().join("catalog");
+    copy_tree(&catalog_dir(), &catalog);
+
+    let add = Command::new(binary())
+        .args(["catalog", "add-version", "rust@1.99.0", "--released", "2026-08-01"])
+        .arg("--catalog")
+        .arg(&catalog)
+        .output()
+        .expect("spawn luggage");
+    assert_exit(&add, 0);
+
+    // The generated version file resolves and carries the rewritten toolchain.
+    let resolve = Command::new(binary())
+        .args([
+            "resolve",
+            "rust",
+            "--version",
+            "1.99.0",
+            "--os",
+            "debian",
+            "--os-version",
+            "13",
+            "--arch",
+            "amd64",
+            "--json",
+        ])
+        .arg("--catalog")
+        .arg(&catalog)
+        .output()
+        .expect("spawn luggage");
+    assert_exit(&resolve, 0);
+    let value: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&resolve.stdout)).expect("parse JSON");
+    assert_eq!(value["version"], "1.99.0");
+
+    // default_version is untouched.
+    let index: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(catalog.join("tools/rust/index.json")).expect("read index"),
+    )
+    .expect("parse index");
+    assert_eq!(index["default_version"], "1.95.0");
+
+    // Second run is a no-op.
+    let again = Command::new(binary())
+        .args(["catalog", "add-version", "rust@1.99.0"])
+        .arg("--catalog")
+        .arg(&catalog)
+        .output()
+        .expect("spawn luggage");
+    assert_exit(&again, 0);
+    assert!(
+        String::from_utf8_lossy(&again.stdout).contains("already present"),
+        "second run should report the version is already present",
+    );
+}


### PR DESCRIPTION
## Summary

Makes the version-bump / auto-patch pipeline keep the **vendored luggage catalog** in lockstep with a Dockerfile pin, so a bump can never again outrun the catalog and break the image build.

The image build installs luggage-managed tools via `luggage install <tool>@<version>` against the vendored catalog snapshot (`crates/luggage/testdata/catalog`, COPY'd to `/opt/containers-db`). When the pin outran that snapshot the build failed with `no version of <tool> matches spec <version>` — as happened on the 2026-05-31 auto-patch (Rust 1.95.0 → 1.96.0), fixed reactively in #505 / containers-db#19.

## Changes

- **NEW `crates/luggage/src/catalog_gen.rs`** + `luggage catalog add-version <tool>@<ver> --catalog <path>` — clones the latest existing version file as a template, rewrites version strings (incl. the rustup `--default-toolchain` arg), appends to index `available[]`. **Additive + idempotent**: never touches `default_version`, no-ops if the version already exists. Ports the containers-db scanner's `render_version` logic.
- **`bin/lib/update-versions/updaters.sh`** — new `update_luggage_catalog()` helper; the `Rust)` bump case calls it after rewriting the pin. A missing luggage binary is a hard error (not a silent skip — skipping would let the pin and catalog drift).
- **`.github/workflows/auto-patch.yml`** — builds `luggage` before `update-versions.sh`; the existing `git add -A` stages the generated catalog files into the auto-patch commit.

## Scope

This is **Phase 1 of #506** — the vendored-catalog auto-update (the part that directly fixes the recurring build break). **Evidence-CI triggering** (the other acceptance criterion) is the deliberate fast-follow: it has a cross-repo ordering dependency (the sibling `containers-db` must already hold the bumped version before `evidence-run.yml` can run). **#506 stays open** for that — hence `Part of #506`, not `Closes`.

## Test plan

- `cargo test -p luggage` — all pass (incl. new `catalog_gen` unit tests + a CLI integration test, and the existing `cli.rs` default-version golden tests still resolve `1.95.0`)
- `cargo clippy -p luggage -- -D warnings` clean; `cargo fmt --check` clean
- `just lint-workflows` (actionlint) + `shellcheck` on updaters.sh — clean
- `just test` — full unit suite 3008 pass, 0 fail
- Manual: `luggage catalog add-version rust@1.99.0` on a temp catalog → file generated, `default_version` untouched, `luggage install rust@1.99.0 --dry-run` resolves, re-run no-ops

## No catalog data in this PR

The subcommand generates version files at runtime (CI / tests); no catalog JSON is committed here. `rust@1.96.0` itself is added by #505; the subcommand idempotently no-ops on it.

Part of #506