### PR TITLE
feat(ci): dispatch luggage evidence runs for bumped tools (#506 Phase 2)

### DIFF
--- a/.github/workflows/auto-patch.yml
+++ b/.github/workflows/auto-patch.yml
@@ -509,6 +509,18 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+      # When this patch bumped a luggage-managed tool (e.g. Rust), trigger the
+      # evidence run for the new tool@version. Best-effort and non-blocking:
+      # dispatch-evidence.sh defers cleanly if the sibling containers-db catalog
+      # doesn't yet publish the version (evidence-run requires it). See #506.
+      - name: Dispatch luggage evidence runs for bumped tools
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.AUTO_PATCH_TOKEN }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: ./bin/dispatch-evidence.sh --base "$BASE_SHA" --head "$HEAD_SHA"
+
       - name: Update compatibility matrix with test results
         run: |
           echo "Updating compatibility matrix with passing test results..."

--- a/bin/dispatch-evidence.sh
+++ b/bin/dispatch-evidence.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Dispatch luggage evidence-run.yml for luggage-managed tools whose Dockerfile
+# pin changed in a merged range (#506 Phase 2).
+#
+# Invoked by the auto-patch post-merge job after a version bump lands on main.
+# For each luggage-managed tool whose `ARG <TOOL>_VERSION=` changed between
+# --base and --head, it dispatches the evidence workflow for that tool@version.
+#
+# Cross-repo ordering: evidence-run.yml clones the sibling containers-db and
+# hard-fails if `tools/<slug>/versions/<version>.json` is missing there. So this
+# script first checks the sibling catalog; if the version isn't published yet it
+# logs a clean deferral (the hourly containers-db scanner adds it independently)
+# and moves on. Best-effort by design — never blocks the release.
+#
+# Usage:
+#   bin/dispatch-evidence.sh --base <sha> --head <sha> [--dry-run]
+#
+# Env overrides:
+#   EVIDENCE_TUPLE       base-image tuple slug   (default: debian-12-amd64)
+#   EVIDENCE_IMAGE_TAG   base-image tag          (default: latest)
+#   EVIDENCE_REPO        workflow repo           (default: joshjhall/containers)
+#   CONTAINERS_DB_REPO   sibling catalog repo    (default: joshjhall/containers-db)
+#   DISPATCH_PROJECT_ROOT  repo root override    (default: this script's ../)
+set -euo pipefail
+
+# Luggage-managed tools as `catalog_slug:DOCKERFILE_ARG`. Add a row when a
+# feature script (lib/features/<tool>.sh) starts delegating installation to
+# `luggage install <tool>@<version>`. Today: Rust only.
+LUGGAGE_TOOLS=(
+    "rust:RUST_VERSION"
+)
+
+EVIDENCE_REPO="${EVIDENCE_REPO:-joshjhall/containers}"
+CONTAINERS_DB_REPO="${CONTAINERS_DB_REPO:-joshjhall/containers-db}"
+EVIDENCE_TUPLE="${EVIDENCE_TUPLE:-debian-12-amd64}"
+EVIDENCE_IMAGE_TAG="${EVIDENCE_IMAGE_TAG:-latest}"
+WORKFLOW="evidence-run.yml"
+# GitHub CLI, overridable for tests (a fake `gh` injected by absolute path).
+GH="${GH:-gh}"
+
+PROJECT_ROOT="${DISPATCH_PROJECT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+BASE=""
+HEAD=""
+DRY_RUN=false
+
+usage() {
+    command sed -n '2,27p' "${BASH_SOURCE[0]}"
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --base)
+            BASE="$2"
+            shift 2
+            ;;
+        --head)
+            HEAD="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [ -z "$BASE" ] || [ -z "$HEAD" ]; then
+    echo "error: --base and --head are required" >&2
+    exit 2
+fi
+
+# Current value of a Dockerfile ARG on the checked-out tree.
+arg_value() {
+    local arg="$1"
+    command grep -E "^ARG ${arg}=" "$PROJECT_ROOT/Dockerfile" |
+        command head -1 | command cut -d= -f2 | command tr -d '"'
+}
+
+# Did the `ARG <arg>=` line change between BASE and HEAD?
+arg_changed() {
+    local arg="$1"
+    command git -C "$PROJECT_ROOT" diff "${BASE}..${HEAD}" -- Dockerfile |
+        command grep -qE "^[+-]ARG ${arg}="
+}
+
+# Does the sibling catalog publish tools/<slug>/versions/<version>.json?
+sibling_has_version() {
+    local slug="$1" version="$2"
+    "$GH" api "repos/${CONTAINERS_DB_REPO}/contents/tools/${slug}/versions/${version}.json" \
+        >/dev/null 2>&1
+}
+
+dispatch_evidence() {
+    local slug="$1" version="$2"
+    "$GH" workflow run "$WORKFLOW" --repo "$EVIDENCE_REPO" \
+        -f tool="$slug" \
+        -f tool_version="$version" \
+        -f tuple="$EVIDENCE_TUPLE" \
+        -f image_tag="$EVIDENCE_IMAGE_TAG" \
+        -f dry_run=false
+}
+
+dispatched=0
+for entry in "${LUGGAGE_TOOLS[@]}"; do
+    slug="${entry%%:*}"
+    arg="${entry##*:}"
+
+    if ! arg_changed "$arg"; then
+        echo "no change: ${slug} (${arg}) — skipping"
+        continue
+    fi
+
+    version="$(arg_value "$arg")"
+    if [ -z "$version" ]; then
+        echo "warning: ${arg} changed but no value found in Dockerfile; skipping ${slug}" >&2
+        continue
+    fi
+
+    if sibling_has_version "$slug" "$version"; then
+        if [ "$DRY_RUN" = true ]; then
+            echo "PLAN dispatch ${slug} ${version} (tuple=${EVIDENCE_TUPLE} tag=${EVIDENCE_IMAGE_TAG})"
+        else
+            echo "dispatching evidence run for ${slug}@${version}"
+            dispatch_evidence "$slug" "$version"
+        fi
+        dispatched=$((dispatched + 1))
+    else
+        echo "PLAN defer ${slug} ${version}"
+        echo "evidence deferred: containers-db lacks ${slug}@${version} (sibling scanner will add it)"
+    fi
+done
+
+echo "evidence dispatch complete (${dispatched} dispatched)"

--- a/docs/operations/automated-releases.md
+++ b/docs/operations/automated-releases.md
@@ -42,6 +42,26 @@ The push to `auto-patch/*` triggers the full CI pipeline:
 - Preserves the branch for manual review
 - Includes links to the failed workflow and branch
 
+### 4. Luggage Catalog + Evidence (luggage-managed tools)
+
+Some tools (currently Rust) are installed at build time by `luggage` against
+the **vendored catalog** snapshot (`crates/luggage/testdata/catalog`). Two hooks
+keep that catalog in step with version bumps:
+
+- **Catalog update (branch creation):** when the patch bumps a luggage-managed
+  tool, `update-versions.sh` calls `luggage catalog add-version <tool>@<version>`
+  so the new version is resolvable in the same commit. Without this the image
+  build fails with `no version of <tool> matches spec <version>`.
+- **Evidence dispatch (post-merge):** after the patch merges, the post-merge job
+  runs `bin/dispatch-evidence.sh`, which triggers the `evidence-run.yml` workflow
+  for each bumped luggage tool's new version.
+
+`evidence-run.yml` reads the **sibling `containers-db`** catalog and requires the
+version to be published there. If it isn't yet (the hourly containers-db scanner
+adds new versions independently), the dispatcher logs `evidence deferred …` and
+exits cleanly — it never blocks the release. Evidence is then recorded on a later
+run once the sibling catalog catches up.
+
 ## Pushover Notifications
 
 The system sends notifications via Pushover for:

--- a/tests/unit/dispatch-evidence.sh
+++ b/tests/unit/dispatch-evidence.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Unit tests for bin/dispatch-evidence.sh — the auto-patch post-merge step that
+# triggers luggage evidence runs for bumped, luggage-managed tools (#506 Phase 2).
+#
+# These tests drive the script against a throwaway git repo (DISPATCH_PROJECT_ROOT)
+# and a fake `gh` injected via the script's `GH` override (an absolute path —
+# PATH-shadowing is unreliable here because the shell re-initializes PATH from
+# the profile on each bash startup). No network or real dispatch happens. The
+# fake `gh`'s behavior is controlled by SIBLING_PRESENT:
+#   SIBLING_PRESENT=1  -> `gh api .../contents/...` exits 0 (version present)
+#   SIBLING_PRESENT=0  -> `gh api` exits 1 (404 — version absent)
+# `gh workflow run` always exits 0 (the script's own stdout reports the dispatch).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../framework.sh"
+
+init_test_framework
+
+test_suite "dispatch-evidence.sh tests"
+
+DISPATCH_SCRIPT="$PROJECT_ROOT/bin/dispatch-evidence.sh"
+
+# Build a throwaway repo with a Dockerfile, then change one ARG in a second
+# commit. Echoes "<base_sha> <head_sha>". The repo lives at a deterministic
+# path ($TEST_TEMP_DIR/repo) so callers don't depend on a variable surviving
+# the process-substitution subshell this runs in.
+# Args: <arg_to_change> <new_value>   (empty new_value => no second commit)
+make_repo() {
+    local change_arg="$1" new_value="$2"
+    local REPO_DIR="$TEST_TEMP_DIR/repo"
+    command mkdir -p "$REPO_DIR"
+    command git -C "$REPO_DIR" init -q
+    command git -C "$REPO_DIR" config user.email t@t.test
+    command git -C "$REPO_DIR" config user.name test
+
+    command cat >"$REPO_DIR/Dockerfile" <<'DOCKER'
+ARG RUST_VERSION=1.95.0
+ARG PYTHON_VERSION=3.13.0
+DOCKER
+    command git -C "$REPO_DIR" add Dockerfile
+    command git -C "$REPO_DIR" commit -qm base
+    local base
+    base="$(command git -C "$REPO_DIR" rev-parse HEAD)"
+
+    if [ -n "$new_value" ]; then
+        command sed -i.bak "s/^ARG ${change_arg}=.*/ARG ${change_arg}=${new_value}/" "$REPO_DIR/Dockerfile"
+        command rm -f "$REPO_DIR/Dockerfile.bak"
+        command git -C "$REPO_DIR" commit -qam "bump ${change_arg}"
+    fi
+    local head
+    head="$(command git -C "$REPO_DIR" rev-parse HEAD)"
+    echo "$base $head"
+}
+
+# Write a fake `gh` to an absolute path; the script calls it via its `GH`
+# override. The fake reads SIBLING_PRESENT from its environment.
+install_gh_stub() {
+    GH_STUB="$TEST_TEMP_DIR/gh"
+    command cat >"$GH_STUB" <<'STUB'
+#!/usr/bin/env bash
+if [ "$1" = "api" ]; then
+    [ "${SIBLING_PRESENT:-0}" = "1" ] && exit 0 || exit 1
+fi
+exit 0   # `workflow run` and anything else succeed; the script logs the dispatch
+STUB
+    command chmod +x "$GH_STUB"
+}
+
+# Run the dispatcher against the throwaway repo with the fake gh injected by
+# absolute path (GH=) and SIBLING_PRESENT forwarded as external-command env
+# assignments, both of which reliably reach the script.
+# Usage: run_dispatch <present:0|1> <base> <head> [extra args...]
+run_dispatch() {
+    local present="$1" base="$2" head="$3"
+    shift 3
+    DISPATCH_PROJECT_ROOT="$TEST_TEMP_DIR/repo" \
+        GH="$GH_STUB" \
+        SIBLING_PRESENT="$present" \
+        "$DISPATCH_SCRIPT" --base "$base" --head "$head" "$@" 2>&1
+}
+
+test_dispatches_when_sibling_present() {
+    install_gh_stub
+    read -r base head < <(make_repo RUST_VERSION 1.96.0)
+    local out
+    out="$(run_dispatch 1 "$base" "$head" --dry-run)"
+    assert_contains "$out" "PLAN dispatch rust 1.96.0" "bumped rust with present sibling should plan a dispatch"
+    assert_contains "$out" "tuple=debian-12-amd64" "plan should carry the pilot tuple"
+}
+
+test_defers_when_sibling_absent() {
+    install_gh_stub
+    read -r base head < <(make_repo RUST_VERSION 1.96.0)
+    local out
+    out="$(run_dispatch 0 "$base" "$head" --dry-run)"
+    assert_contains "$out" "PLAN defer rust 1.96.0" "absent sibling should defer"
+    assert_not_contains "$out" "PLAN dispatch" "must not dispatch when sibling lacks the version"
+}
+
+test_ignores_non_luggage_tool_change() {
+    install_gh_stub
+    read -r base head < <(make_repo PYTHON_VERSION 3.13.1)
+    local out
+    out="$(run_dispatch 1 "$base" "$head" --dry-run)"
+    assert_contains "$out" "no change: rust" "a non-luggage ARG bump should not trigger rust evidence"
+    assert_not_contains "$out" "PLAN dispatch" "no luggage tool changed => no dispatch"
+}
+
+test_no_change_no_dispatch() {
+    install_gh_stub
+    read -r base head < <(make_repo RUST_VERSION "") # no second commit
+    local out
+    out="$(run_dispatch 1 "$base" "$head" --dry-run)"
+    assert_contains "$out" "no change: rust" "identical base/head => nothing changed"
+    assert_not_contains "$out" "PLAN dispatch" "no diff => no dispatch"
+}
+
+test_real_run_reaches_dispatch() {
+    install_gh_stub
+    read -r base head < <(make_repo RUST_VERSION 1.96.0)
+    # Non-dry-run with a present sibling: the script reaches dispatch_evidence,
+    # the stub's `gh workflow run` succeeds, and the script reports the dispatch.
+    local out
+    out="$(run_dispatch 1 "$base" "$head")"
+    assert_contains "$out" "dispatching evidence run for rust@1.96.0" "non-dry-run with present sibling dispatches"
+    assert_contains "$out" "1 dispatched" "summary should count the dispatch"
+}
+
+run_test test_dispatches_when_sibling_present "dispatches when sibling catalog has the version"
+run_test test_defers_when_sibling_absent "defers when sibling catalog lacks the version"
+run_test test_ignores_non_luggage_tool_change "ignores non-luggage ARG bumps"
+run_test test_no_change_no_dispatch "no Dockerfile change => no dispatch"
+run_test test_real_run_reaches_dispatch "non-dry-run reaches dispatch for the bumped version"
+
+generate_report


### PR DESCRIPTION
## Summary

Completes **#506**. Phase 1 (#507, merged) made the auto-patch keep the **vendored** luggage catalog in lockstep with a Dockerfile pin. Phase 2 triggers the luggage **evidence** run for the bumped tool@version after the patch merges, so the result is recorded in the sibling `containers-db` `tested[]` arrays.

## Changes

- **NEW `bin/dispatch-evidence.sh`** — table-driven (catalog slug → Dockerfile ARG; today `rust:RUST_VERSION`). For each luggage-managed tool whose pin changed between the merged range's base/head, it checks the sibling catalog and dispatches `evidence-run.yml` for the new version. `gh` is injected via a `GH` override for testability.
- **`.github/workflows/auto-patch.yml`** — a **non-blocking** post-merge step runs the dispatcher with the merged PR's `base.sha`/`merge_commit_sha` (passed via env vars, not inline `${{ }}`, per injection-safety guidance).
- **NEW `tests/unit/dispatch-evidence.sh`** — 5 tests: dispatch-when-present, defer-when-absent, ignore non-luggage bumps, no-change, and non-dry-run reaches dispatch (throwaway git repo + injected fake `gh`).
- **`docs/operations/automated-releases.md`** — documents the catalog-update + evidence-dispatch hooks.

## Cross-repo ordering

`evidence-run.yml` clones the sibling `containers-db` and **hard-fails** if it doesn't already publish `tools/<slug>/versions/<v>.json`. So the dispatcher checks the sibling first: **present → dispatch; absent → log a clean deferral** and continue (the hourly containers-db scanner adds the version independently; the weekly auto-patch almost always runs well after that). The step is `continue-on-error`, so evidence never blocks the release tag.

## Acceptance criteria (#506, across both phases)

- [x] Bumping a luggage tool auto-adds the vendored catalog version file + `available[]` in the same commit — **Phase 1 (#507)**
- [x] The auto-patch image build resolves `luggage install <tool>@<new>` — **Phase 1 (#507)**
- [x] Evidence CI runs for the newly-bumped tool@version (not hardcoded) — **this PR**
- [x] `default_version` unchanged; `cli.rs` golden tests green — **Phase 1**
- [x] Generalizes to any future luggage tool (table-driven), Rust first

## Test plan

- `bash tests/unit/dispatch-evidence.sh` — 5/5 pass
- `shellcheck` (script + test) + `actionlint` (auto-patch.yml) + `rumdl` (doc) — clean
- `just test` — full unit suite passes (3012)
- Full E2E (a real dispatch) will be exercised by re-running the auto-patch end-to-end.

## Note

Implementation detail worth knowing for future shell tests: PATH-shadowing of `gh` is unreliable in this environment (the shell re-initializes PATH from the profile on each bash startup), so the script takes a `GH` override and the test injects the fake by absolute path.

Closes #506