### PR TITLE
fix(ci): guard auto-merge job against already-merged auto-patch branch

### DIFF
--- a/.github/workflows/auto-patch.yml
+++ b/.github/workflows/auto-patch.yml
@@ -341,6 +341,20 @@ jobs:
         run: |
           echo "branch=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
+          # A single auto-patch branch produces two CI/CD Pipeline runs that
+          # match this workflow_run trigger: the initial push and the PR
+          # synchronize. The first cycle creates the PR, auto-merge lands it,
+          # and post-merge deletes the branch — all before the second cycle's
+          # workflow_run fires. By then the branch is gone, so fetching it
+          # would fail with exit 128 and fire a false "PR Creation Failed"
+          # page. Detect the already-merged branch and short-circuit cleanly.
+          if ! git ls-remote --exit-code --heads origin "$BRANCH_NAME" >/dev/null 2>&1; then
+            echo "Branch $BRANCH_NAME no longer exists — already merged. Skipping."
+            echo "branch_exists=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "branch_exists=true" >> "$GITHUB_OUTPUT"
+
           # Extract version changes from the branch
           git fetch origin "$BRANCH_NAME"
           git checkout "$BRANCH_NAME"
@@ -373,6 +387,7 @@ jobs:
 
       - name: Create pull request
         id: create_pr
+        if: steps.branch_info.outputs.branch_exists == 'true'
         env:
           GH_TOKEN: ${{ secrets.AUTO_PATCH_TOKEN }}
           BRANCH_NAME: ${{ steps.branch_info.outputs.branch }}
@@ -405,7 +420,7 @@ jobs:
           fi
 
       - name: Add hold label for GPG key changes
-        if: steps.branch_info.outputs.gpg_keys_changed == 'true'
+        if: steps.branch_info.outputs.branch_exists == 'true' && steps.branch_info.outputs.gpg_keys_changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.AUTO_PATCH_TOKEN }}
         run: |
@@ -427,7 +442,7 @@ jobs:
           echo "GPG key changes detected — PR held for manual review"
 
       - name: Enable auto-merge (no GPG key changes)
-        if: steps.branch_info.outputs.gpg_keys_changed != 'true'
+        if: steps.branch_info.outputs.branch_exists == 'true' && steps.branch_info.outputs.gpg_keys_changed != 'true'
         env:
           GH_TOKEN: ${{ secrets.AUTO_PATCH_TOKEN }}
           PR_URL: ${{ steps.create_pr.outputs.pr_url }}


### PR DESCRIPTION
## Problem

The Sunday 2026-06-07 auto-patch run looked like it failed and fired a **priority-1 \"PR Creation Failed\" Pushover alert** — but the release itself **succeeded** (\`v4.19.5\` was tagged and published). The alert was a false alarm from a duplicate, redundant run.

## Root cause

The \`auto-merge\` job triggers on \`workflow_run\` for any \`CI/CD Pipeline\` run on an \`auto-patch/**\` branch. A single auto-patch branch generates **two** matching CI runs:

1. The **push** CI (branch first pushed) → triggered auto-merge → created PR, enabled auto-merge ✅
2. The **pull_request** CI (PR opened) → triggered auto-merge **a second time**

By the time the second trigger ran, the PR had already merged and the \`post-merge\` job had **deleted the branch**. The "Get patch branch info" step then ran \`git fetch\` on the missing ref:

\`\`\`
fatal: couldn't find remote ref auto-patch/20260607-030755
##[error]Process completed with exit code 128.
\`\`\`

That tripped \`if: failure()\` and paged, even though nothing was actually wrong.

The sibling \`ci-failure\` job already guards against this with a branch-existence check; the \`auto-merge\` job did not.

## Fix

- **Get patch branch info** now checks \`git ls-remote --exit-code --heads\` first. If the branch is already merged/deleted, it sets \`branch_exists=false\` and exits 0 — no failure, no page.
- **Create pull request**, **Add hold label**, and **Enable auto-merge** are gated on \`branch_exists == 'true'\` so they skip cleanly instead of running against a deleted branch / empty PR URL.
- Genuine failures (branch exists, PR creation actually fails) still page as before.

Mirrors the existing branch-existence guard in the \`ci-failure\` job.

## Testing

actionlint passes. Workflow-only change — takes effect on the next auto-patch cycle; cannot be exercised without a real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)